### PR TITLE
feat: Improve bothersome eslint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,16 +44,6 @@
         ],
         "enforceBuildableLibDependency": true
       }
-    ],
-    "@typescript-eslint/ban-types": [
-      "error",
-      {
-        "types": {
-          "null": false
-        },
-        "extendDefaults": true
-      }
-    ],
-    "capitalized-comments": "off"
+    ]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,6 +44,16 @@
         ],
         "enforceBuildableLibDependency": true
       }
-    ]
+    ],
+    "@typescript-eslint/ban-types": [
+      "error",
+      {
+        "types": {
+          "null": false
+        },
+        "extendDefaults": true
+      }
+    ],
+    "capitalized-comments": "off"
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           # GitHub checks PRs out based on the merge commit; we want the branch HEAD.
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+      - run: git fetch origin main:main
       - uses: nrwl/nx-set-shas@v4
       - uses: actions/cache@v4
         with:

--- a/packages/eslint-config/.eslintrc.json
+++ b/packages/eslint-config/.eslintrc.json
@@ -13,5 +13,17 @@
         "@nx/dependency-checks": "off"
       }
     }
-  ]
+  ],
+  "rules": {
+    "@typescript-eslint/ban-types": [
+      "error",
+      {
+        "types": {
+          "null": false
+        },
+        "extendDefaults": true
+      }
+    ],
+    "capitalized-comments": "off"
+  }
 }

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -9,6 +9,8 @@ Shared [ESLint](https://eslint.org/) configuration.
 
 ## Install
 
+Use the following command to install this package as a dependency in another package.
+
 ```bash
 npm install -D @clipboard-health/eslint-config eslint-config-prettier prettier
 ```
@@ -36,7 +38,3 @@ module.exports = {
   root: true,
 };
 ```
-
-## Local development commands
-
-See [`package.json`](./package.json) `scripts` for a list of commands.


### PR DESCRIPTION
Summary
===
<!--
- For PR best practices, see https://www.notion.so/Best-Practices-797056a67747474ebe5b551d26958f61?p=efedc19c33da45f787033113a0be3b8e&pm=s
- For expectations after PR approval and merge, see the CONTRIBUTING.md file
-->

Changes
---
- Remove `null` from banned types rule as it's used extensively in Prisma, and break when running `eslint --fix .`
- Remove `capitalized-comments` as it's annoying and commenting out code + saving breaks uncommenting it

Videos/screenshots
---
