### PR TITLE
feat: json-api query helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           # GitHub checks PRs out based on the merge commit; we want the branch HEAD.
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+      - run: git fetch origin main:main
       - uses: nrwl/nx-set-shas@v4
       - uses: actions/cache@v4
         with:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 npx lint-staged
 
 if command -v gitleaks >/dev/null; then

--- a/cspell.json
+++ b/cspell.json
@@ -2,13 +2,16 @@
   "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
   "version": "0.2",
   "ignorePaths": [
-    "coverage",
-    "dist",
-    "node_modules",
     ".github/CODEOWNERS",
     ".vscode",
+    "coverage",
     "default.json",
-    "tmp"
+    "dist",
+    "node_modules",
+    "tmp",
+    "packages/json-api/examples/toJsonApiQuery.ts",
+    "packages/json-api/README.md",
+    "packages/json-api/src/lib/toSearchParams.spec.ts"
   ],
   "words": [
     "amannn",
@@ -17,6 +20,7 @@
     "CODEOWNERS",
     "devkit",
     "embedme",
+    "fieldsets",
     "gitleaks",
     "lcov",
     "maxage",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2001,6 +2001,10 @@
       "resolved": "packages/eslint-config",
       "link": true
     },
+    "node_modules/@clipboard-health/json-api": {
+      "resolved": "packages/json-api",
+      "link": true
+    },
     "node_modules/@clipboard-health/nx-plugin": {
       "resolved": "packages/nx-plugin",
       "link": true
@@ -15178,6 +15182,14 @@
         "eslint-plugin-simple-import-sort": ">=10",
         "eslint-plugin-sonarjs": "^0.23",
         "eslint-plugin-unicorn": ">=48"
+      }
+    },
+    "packages/json-api": {
+      "name": "@clipboard-health/json-api",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.6.3"
       }
     },
     "packages/nx-plugin": {

--- a/packages/json-api/.eslintrc.json
+++ b/packages/json-api/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "parserOptions": {
+    "project": "tsconfig.lint.json",
+    "tsconfigRootDir": "packages/json-api"
+  }
+}

--- a/packages/json-api/README.md
+++ b/packages/json-api/README.md
@@ -1,6 +1,6 @@
 # @clipboard-health/json-api
 
-TODO
+Utilities for adhering to the [JSON:API](https://jsonapi.org/) specification.
 
 ## Table of Contents
 

--- a/packages/json-api/README.md
+++ b/packages/json-api/README.md
@@ -1,0 +1,70 @@
+# @clipboard-health/json-api
+
+TODO
+
+## Table of Contents
+
+- [Install](#install)
+- [Usage](#usage)
+- [Local development commands](#local-development-commands)
+
+## Install
+
+```bash
+npm install @clipboard-health/json-api
+```
+
+## Usage
+
+### Query helpers
+
+From the client, call `toSearchParams` to convert from `JsonApiQuery` to `URLSearchParams`:
+
+<!-- prettier-ignore -->
+```ts
+// ./examples/toSearchParams.ts
+
+import { toSearchParams } from "@clipboard-health/json-api";
+
+import { type JsonApiQuery } from "../src/lib/types";
+
+const query: JsonApiQuery = {
+  fields: { dog: ["age", "name"] },
+  filter: { age: ["2", "5"] },
+  include: ["vet"],
+  page: { size: "10" },
+  sort: ["-age"],
+};
+
+console.log(toSearchParams(query).toString());
+// Note: actual result is URL-encoded, but unencoded below for readability
+// => fields[dog]=age,name&filter[age]=2,5&include=vet&page[size]=10&sort=-age
+
+```
+
+From the server, call `toJsonApiQuery` to convert from `URLSearchParams` to `JsonApiQuery`:
+
+<!-- prettier-ignore -->
+```ts
+// ./examples/toJsonApiQuery.ts
+
+import { toJsonApiQuery } from "@clipboard-health/json-api";
+
+const searchParams = new URLSearchParams(
+  "fields%5Bdog%5D=age%2Cname&filter%5Bage%5D=2%2C5&include=vet&page%5Bsize%5D=10&sort=-age",
+);
+
+console.log(toJsonApiQuery(searchParams));
+// => {
+//   fields: { dog: ["age", "name"] },
+//   filter: { age: ["2", "5"] },
+//   include: ["vet"],
+//   page: { size: "10" },
+//   sort: ["-age"],
+// }
+
+```
+
+## Local development commands
+
+See [`package.json`](./package.json) `scripts` for a list of commands.

--- a/packages/json-api/examples/toJsonApiQuery.ts
+++ b/packages/json-api/examples/toJsonApiQuery.ts
@@ -1,0 +1,14 @@
+import { toJsonApiQuery } from "@clipboard-health/json-api";
+
+const searchParams = new URLSearchParams(
+  "fields%5Bdog%5D=age%2Cname&filter%5Bage%5D=2%2C5&include=vet&page%5Bsize%5D=10&sort=-age",
+);
+
+console.log(toJsonApiQuery(searchParams));
+// => {
+//   fields: { dog: ["age", "name"] },
+//   filter: { age: ["2", "5"] },
+//   include: ["vet"],
+//   page: { size: "10" },
+//   sort: ["-age"],
+// }

--- a/packages/json-api/examples/toSearchParams.ts
+++ b/packages/json-api/examples/toSearchParams.ts
@@ -1,0 +1,15 @@
+import { toSearchParams } from "@clipboard-health/json-api";
+
+import { type JsonApiQuery } from "../src/lib/types";
+
+const query: JsonApiQuery = {
+  fields: { dog: ["age", "name"] },
+  filter: { age: ["2", "5"] },
+  include: ["vet"],
+  page: { size: "10" },
+  sort: ["-age"],
+};
+
+console.log(toSearchParams(query).toString());
+// Note: actual result is URL-encoded, but unencoded below for readability
+// => fields[dog]=age,name&filter[age]=2,5&include=vet&page[size]=10&sort=-age

--- a/packages/json-api/jest.config.ts
+++ b/packages/json-api/jest.config.ts
@@ -1,0 +1,19 @@
+export default {
+  coverageDirectory: "../../coverage/packages/json-api",
+  coveragePathIgnorePatterns: [],
+  coverageThreshold: {
+    global: {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+  },
+  displayName: "json-api",
+  moduleFileExtensions: ["ts", "js"],
+  preset: "../../jest.preset.js",
+  testEnvironment: "node",
+  transform: {
+    "^.+\\.[tj]s$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.spec.json" }],
+  },
+};

--- a/packages/json-api/package.json
+++ b/packages/json-api/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@clipboard-health/json-api",
+  "description": "",
+  "version": "0.0.0",
+  "bugs": "https://github.com/clipboardhealth/core-utils/issues",
+  "dependencies": {
+    "tslib": "2.6.3"
+  },
+  "keywords": [],
+  "license": "MIT",
+  "main": "./src/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/clipboardhealth/core-utils.git",
+    "directory": "packages/json-api"
+  },
+  "scripts": {
+    "embed": "embedme README.md"
+  },
+  "type": "commonjs",
+  "typings": "./src/index.d.ts"
+}

--- a/packages/json-api/project.json
+++ b/packages/json-api/project.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "json-api",
+  "projectType": "library",
+  "sourceRoot": "packages/json-api/src",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "options": {
+        "assets": ["packages/json-api/*.md"],
+        "main": "packages/json-api/src/index.js",
+        "outputPath": "dist/packages/json-api",
+        "tsConfig": "packages/json-api/tsconfig.lib.json"
+      },
+      "outputs": ["{options.outputPath}"]
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "options": {
+        "lintFilePatterns": ["packages/json-api/**/*.[jt]s"],
+        "maxWarnings": 0
+      },
+      "outputs": ["{options.outputFile}"]
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "options": {
+        "jestConfig": "packages/json-api/jest.config.ts"
+      }
+    }
+  }
+}

--- a/packages/json-api/src/index.ts
+++ b/packages/json-api/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./lib/toJsonApiQuery";
+export * from "./lib/toSearchParams";
+export * from "./lib/types";

--- a/packages/json-api/src/lib/toJsonApiQuery.spec.ts
+++ b/packages/json-api/src/lib/toJsonApiQuery.spec.ts
@@ -1,0 +1,99 @@
+import { toJsonApiQuery } from "./toJsonApiQuery";
+
+const BASE_URL = "https://google.com";
+
+describe("toJsonApiQuery", () => {
+  it("returns empty object if no matches", () => {
+    expect(toJsonApiQuery(new URL(`${BASE_URL}?hi=there`).searchParams)).toEqual({});
+  });
+
+  it("parses fields", () => {
+    expect(toJsonApiQuery(new URL(`${BASE_URL}?fields[dog]=age`).searchParams)).toEqual({
+      fields: { dog: ["age"] },
+    });
+  });
+
+  it("parses fields with multiple values", () => {
+    expect(toJsonApiQuery(new URL(`${BASE_URL}?fields[dog]=age,name`).searchParams)).toEqual({
+      fields: { dog: ["age", "name"] },
+    });
+  });
+
+  it("parses filter", () => {
+    expect(toJsonApiQuery(new URL(`${BASE_URL}?filter[name]=alice`).searchParams)).toEqual({
+      filter: { name: ["alice"] },
+    });
+  });
+
+  it("parses multiple filters", () => {
+    expect(
+      toJsonApiQuery(new URL(`${BASE_URL}?filter[name]=alice&filter[age]=2`).searchParams),
+    ).toEqual({
+      filter: { age: ["2"], name: ["alice"] },
+    });
+  });
+
+  it("parses filters with multiple values", () => {
+    expect(toJsonApiQuery(new URL(`${BASE_URL}?filter[name]=alice,bob`).searchParams)).toEqual({
+      filter: { name: ["alice", "bob"] },
+    });
+  });
+
+  it("parses filter type ge", () => {
+    expect(toJsonApiQuery(new URL(`${BASE_URL}?filter[age][ge]=2`).searchParams)).toEqual({
+      filter: { age: { ge: "2" } },
+    });
+  });
+
+  it("parses include", () => {
+    expect(toJsonApiQuery(new URL(`${BASE_URL}?include=owner`).searchParams)).toEqual({
+      include: ["owner"],
+    });
+  });
+
+  it("parses include with multiple values", () => {
+    expect(toJsonApiQuery(new URL(`${BASE_URL}?include=owner,vet`).searchParams)).toEqual({
+      include: ["owner", "vet"],
+    });
+  });
+
+  it("parses page", () => {
+    expect(
+      toJsonApiQuery(new URL(`${BASE_URL}?page[size]=10&page[cursor]=a2c12`).searchParams),
+    ).toEqual({
+      page: {
+        cursor: "a2c12",
+        size: "10",
+      },
+    });
+  });
+
+  it("parses sort", () => {
+    expect(toJsonApiQuery(new URL(`${BASE_URL}?sort=age`).searchParams)).toEqual({
+      sort: ["age"],
+    });
+  });
+
+  it("parses sort with multiple values", () => {
+    expect(toJsonApiQuery(new URL(`${BASE_URL}?sort=age,-name`).searchParams)).toEqual({
+      sort: ["age", "-name"],
+    });
+  });
+
+  it("parses combinations", () => {
+    expect(
+      toJsonApiQuery(
+        new URL(`${BASE_URL}?filter[age]=2&include=vet&sort=age&fields[dog]=age&page[size]=10`)
+          .searchParams,
+      ),
+    ).toEqual({
+      fields: { dog: ["age"] },
+      filter: { age: ["2"] },
+      include: ["vet"],
+      page: {
+        size: "10",
+      },
+      sort: ["age"],
+    });
+  });
+});

--- a/packages/json-api/src/lib/toJsonApiQuery.spec.ts
+++ b/packages/json-api/src/lib/toJsonApiQuery.spec.ts
@@ -39,9 +39,9 @@ describe("toJsonApiQuery", () => {
     });
   });
 
-  it("parses filter type ge", () => {
-    expect(toJsonApiQuery(new URL(`${BASE_URL}?filter[age][ge]=2`).searchParams)).toEqual({
-      filter: { age: { ge: "2" } },
+  it("parses filter type gte", () => {
+    expect(toJsonApiQuery(new URL(`${BASE_URL}?filter[age][gte]=2`).searchParams)).toEqual({
+      filter: { age: { gte: "2" } },
     });
   });
 

--- a/packages/json-api/src/lib/toJsonApiQuery.ts
+++ b/packages/json-api/src/lib/toJsonApiQuery.ts
@@ -10,7 +10,7 @@ const REGEX = {
 } as const;
 
 /**
- * Call this function from clients to converts from {@link URLSearchParams} to {@link JsonApiQuery}.
+ * Call this function from clients to convert from {@link URLSearchParams} to {@link JsonApiQuery}.
  *
  * @see [Example](https://github.com/ClipboardHealth/core-utils/blob/main/packages/json-api/examples/toJsonApiQuery.ts)
  */

--- a/packages/json-api/src/lib/toJsonApiQuery.ts
+++ b/packages/json-api/src/lib/toJsonApiQuery.ts
@@ -21,7 +21,7 @@ export function toJsonApiQuery(searchParams: URLSearchParams): JsonApiQuery {
       return accumulator;
     }
 
-    const [type, regex] = match;
+    const [type, regex] = match as [keyof typeof REGEX, RegExp];
     const groups = regex.exec(key)?.slice(1);
     if (type === "fields" && groups?.[0]) {
       return {
@@ -34,14 +34,14 @@ export function toJsonApiQuery(searchParams: URLSearchParams): JsonApiQuery {
     }
 
     if ((type === "filter" || type === "filterType") && groups?.length) {
-      const [field, subfield] = groups;
+      const [field, fieldType] = groups;
       if (field) {
         return {
           ...accumulator,
           filter: {
             ...accumulator.filter,
-            [field]: subfield
-              ? { ...accumulator.filter?.[field], [subfield]: value }
+            [field]: fieldType
+              ? { ...accumulator.filter?.[field], [fieldType]: value }
               : value.split(","),
           },
         };

--- a/packages/json-api/src/lib/toJsonApiQuery.ts
+++ b/packages/json-api/src/lib/toJsonApiQuery.ts
@@ -15,7 +15,6 @@ const REGEX = {
  * @see [Example](https://github.com/ClipboardHealth/core-utils/blob/main/packages/json-api/examples/toJsonApiQuery.ts)
  */
 export function toJsonApiQuery(searchParams: URLSearchParams): JsonApiQuery {
-  // eslint-disable-next-line sonarjs/cognitive-complexity
   return [...searchParams].reduce<JsonApiQuery>((accumulator, [key, value]) => {
     const match = Object.entries(REGEX).find(([, regex]) => regex.test(key));
     if (!match) {
@@ -42,11 +41,7 @@ export function toJsonApiQuery(searchParams: URLSearchParams): JsonApiQuery {
           filter: {
             ...accumulator.filter,
             [field]: subfield
-              ? {
-                  // eslint-disable-next-line unicorn/no-useless-fallback-in-spread
-                  ...(accumulator.filter?.[field] ?? {}),
-                  [subfield]: value,
-                }
+              ? { ...accumulator.filter?.[field], [subfield]: value }
               : value.split(","),
           },
         };

--- a/packages/json-api/src/lib/toJsonApiQuery.ts
+++ b/packages/json-api/src/lib/toJsonApiQuery.ts
@@ -1,0 +1,70 @@
+import { type JsonApiQuery } from "./types";
+
+const REGEX = {
+  fields: /^fields\[(.*?)]$/i,
+  filter: /^filter\[([^\]]*?)]$/i,
+  filterType: /^filter\[(.*?)]\[(.*?)]$/i,
+  include: /^include$/i,
+  page: /^page\[(.*?)]$/i,
+  sort: /^sort$/i,
+} as const;
+
+/**
+ * Call this function from clients to converts from {@link URLSearchParams} to {@link JsonApiQuery}.
+ *
+ * @see [Example](https://github.com/ClipboardHealth/core-utils/blob/main/packages/json-api/examples/toJsonApiQuery.ts)
+ */
+export function toJsonApiQuery(searchParams: URLSearchParams): JsonApiQuery {
+  // eslint-disable-next-line sonarjs/cognitive-complexity
+  return [...searchParams].reduce<JsonApiQuery>((accumulator, [key, value]) => {
+    const match = Object.entries(REGEX).find(([, regex]) => regex.test(key));
+    if (!match) {
+      return accumulator;
+    }
+
+    const [type, regex] = match;
+    const groups = regex.exec(key)?.slice(1);
+    if (type === "fields" && groups?.[0]) {
+      return {
+        ...accumulator,
+        fields: {
+          ...accumulator.fields,
+          [groups[0]]: value.split(","),
+        },
+      };
+    }
+
+    if ((type === "filter" || type === "filterType") && groups?.length) {
+      const [field, subfield] = groups;
+      if (field) {
+        return {
+          ...accumulator,
+          filter: {
+            ...accumulator.filter,
+            [field]: subfield
+              ? {
+                  // eslint-disable-next-line unicorn/no-useless-fallback-in-spread
+                  ...(accumulator.filter?.[field] ?? {}),
+                  [subfield]: value,
+                }
+              : value.split(","),
+          },
+        };
+      }
+    }
+
+    if (type === "include" || type === "sort") {
+      return { ...accumulator, [type]: value.split(",") };
+    }
+
+    if (type === "page" && groups?.[0]) {
+      return {
+        ...accumulator,
+        page: { ...accumulator.page, [groups[0]]: value },
+      };
+    }
+
+    /* istanbul ignore next */
+    return accumulator;
+  }, {});
+}

--- a/packages/json-api/src/lib/toSearchParams.spec.ts
+++ b/packages/json-api/src/lib/toSearchParams.spec.ts
@@ -1,0 +1,107 @@
+import { toSearchParams } from "./toSearchParams";
+
+describe("toSearchParams", () => {
+  it("returns empty URLSearchParams for empty query", () => {
+    const actual = toSearchParams({});
+
+    expect(actual.toString()).toBe("");
+  });
+
+  it("converts fields", () => {
+    const actual = toSearchParams({ fields: { dog: ["age"] } });
+
+    expect(actual.get("fields[dog]")).toBe("age");
+    expect(actual.toString()).toBe("fields%5Bdog%5D=age");
+  });
+
+  it("converts fields with multiple values", () => {
+    const actual = toSearchParams({ fields: { dog: ["age", "name"] } });
+
+    expect(actual.get("fields[dog]")).toBe("age,name");
+    expect(actual.toString()).toBe("fields%5Bdog%5D=age%2Cname");
+  });
+
+  it("converts simple filter", () => {
+    const actual = toSearchParams({ filter: { name: ["alice"] } });
+
+    expect(actual.get("filter[name]")).toBe("alice");
+    expect(actual.toString()).toBe("filter%5Bname%5D=alice");
+  });
+
+  it("converts multiple filters", () => {
+    const actual = toSearchParams({ filter: { name: ["alice"], age: ["2"] } });
+
+    expect(actual.get("filter[name]")).toBe("alice");
+    expect(actual.get("filter[age]")).toBe("2");
+    expect(actual.toString()).toBe("filter%5Bname%5D=alice&filter%5Bage%5D=2");
+  });
+
+  it("converts filters with multiple values", () => {
+    const actual = toSearchParams({ filter: { name: ["alice", "bob"] } });
+
+    expect(actual.get("filter[name]")).toBe("alice,bob");
+    expect(actual.toString()).toBe("filter%5Bname%5D=alice%2Cbob");
+  });
+
+  it("converts complex filter", () => {
+    const actual = toSearchParams({ filter: { age: { ge: "2" } } });
+
+    expect(actual.get("filter[age][ge]")).toBe("2");
+    expect(actual.toString()).toBe("filter%5Bage%5D%5Bge%5D=2");
+  });
+
+  it("converts include", () => {
+    const actual = toSearchParams({ include: ["owner"] });
+
+    expect(actual.get("include")).toBe("owner");
+    expect(actual.toString()).toBe("include=owner");
+  });
+
+  it("converts include with multiple values", () => {
+    const actual = toSearchParams({ include: ["owner", "vet"] });
+
+    expect(actual.get("include")).toBe("owner,vet");
+    expect(actual.toString()).toBe("include=owner%2Cvet");
+  });
+
+  it("converts page", () => {
+    const actual = toSearchParams({ page: { size: "10", cursor: "a2c12" } });
+
+    expect(actual.get("page[size]")).toBe("10");
+    expect(actual.get("page[cursor]")).toBe("a2c12");
+    expect(actual.toString()).toBe("page%5Bsize%5D=10&page%5Bcursor%5D=a2c12");
+  });
+
+  it("converts sort", () => {
+    const actual = toSearchParams({ sort: ["age"] });
+
+    expect(actual.get("sort")).toBe("age");
+    expect(actual.toString()).toBe("sort=age");
+  });
+
+  it("converts sort with multiple values", () => {
+    const actual = toSearchParams({ sort: ["age", "-name"] });
+
+    expect(actual.get("sort")).toBe("age,-name");
+    expect(actual.toString()).toBe("sort=age%2C-name");
+  });
+
+  it("converts combinations", () => {
+    const actual = toSearchParams({
+      fields: { dog: ["age"] },
+      filter: { age: ["2"] },
+      include: ["vet"],
+      page: { size: "10" },
+      sort: ["age"],
+    });
+
+    expect(actual.get("fields[dog]")).toBe("age");
+    expect(actual.get("filter[age]")).toBe("2");
+    expect(actual.get("include")).toBe("vet");
+    expect(actual.get("page[size]")).toBe("10");
+    expect(actual.get("sort")).toBe("age");
+    expect(actual.toString()).toBe(
+      "fields%5Bdog%5D=age&filter%5Bage%5D=2&include=vet&page%5Bsize%5D=10&sort=age",
+    );
+  });
+});

--- a/packages/json-api/src/lib/toSearchParams.spec.ts
+++ b/packages/json-api/src/lib/toSearchParams.spec.ts
@@ -44,10 +44,10 @@ describe("toSearchParams", () => {
   });
 
   it("converts complex filter", () => {
-    const actual = toSearchParams({ filter: { age: { ge: "2" } } });
+    const actual = toSearchParams({ filter: { age: { gte: "2" } } });
 
-    expect(actual.get("filter[age][ge]")).toBe("2");
-    expect(actual.toString()).toBe("filter%5Bage%5D%5Bge%5D=2");
+    expect(actual.get("filter[age][gte]")).toBe("2");
+    expect(actual.toString()).toBe("filter%5Bage%5D%5Bgte%5D=2");
   });
 
   it("converts include", () => {

--- a/packages/json-api/src/lib/toSearchParams.ts
+++ b/packages/json-api/src/lib/toSearchParams.ts
@@ -11,9 +11,9 @@ export function toSearchParams(query: JsonApiQuery): URLSearchParams {
   const searchParams = new URLSearchParams();
 
   if (query.fields) {
-    for (const [type, fields] of Object.entries(query.fields)) {
+    Object.entries(query.fields).forEach(([type, fields]) => {
       searchParams.append(`fields[${type}]`, fields.join(","));
-    }
+    });
   }
 
   handleFilter(query, searchParams);
@@ -23,9 +23,9 @@ export function toSearchParams(query: JsonApiQuery): URLSearchParams {
   }
 
   if (query.page) {
-    for (const [key, value] of Object.entries(query.page)) {
+    Object.entries(query.page).forEach(([key, value]) => {
       searchParams.append(`page[${key}]`, value);
-    }
+    });
   }
 
   if (query.sort) {
@@ -37,14 +37,14 @@ export function toSearchParams(query: JsonApiQuery): URLSearchParams {
 
 function handleFilter(query: JsonApiQuery, searchParams: URLSearchParams) {
   if (query.filter) {
-    for (const [key, value] of Object.entries(query.filter)) {
+    Object.entries(query.filter).forEach(([key, value]) => {
       if (Array.isArray(value)) {
         searchParams.append(`filter[${key}]`, value.join(","));
       } else if (typeof value === "object") {
-        for (const [subKey, subValue] of Object.entries(value)) {
+        Object.entries(value).forEach(([subKey, subValue]) => {
           searchParams.append(`filter[${key}][${subKey}]`, String(subValue));
-        }
+        });
       }
-    }
+    });
   }
 }

--- a/packages/json-api/src/lib/toSearchParams.ts
+++ b/packages/json-api/src/lib/toSearchParams.ts
@@ -37,12 +37,12 @@ export function toSearchParams(query: JsonApiQuery): URLSearchParams {
 
 function handleFilter(query: JsonApiQuery, searchParams: URLSearchParams) {
   if (query.filter) {
-    Object.entries(query.filter).forEach(([key, value]) => {
-      if (Array.isArray(value)) {
-        searchParams.append(`filter[${key}]`, value.join(","));
-      } else if (typeof value === "object") {
-        Object.entries(value).forEach(([subKey, subValue]) => {
-          searchParams.append(`filter[${key}][${subKey}]`, String(subValue));
+    Object.entries(query.filter).forEach(([field, values]) => {
+      if (Array.isArray(values)) {
+        searchParams.append(`filter[${field}]`, values.join(","));
+      } else if (typeof values === "object") {
+        Object.entries(values).forEach(([fieldType, value]) => {
+          searchParams.append(`filter[${field}][${fieldType}]`, value);
         });
       }
     });

--- a/packages/json-api/src/lib/toSearchParams.ts
+++ b/packages/json-api/src/lib/toSearchParams.ts
@@ -3,7 +3,7 @@ import { URLSearchParams } from "node:url";
 import { type JsonApiQuery } from "./types";
 
 /**
- * Call this function from clients to converts from {@link JsonApiQuery} to {@link URLSearchParams}.
+ * Call this function from clients to convert from {@link JsonApiQuery} to {@link URLSearchParams}.
  *
  * @see [Example](https://github.com/ClipboardHealth/core-utils/blob/main/packages/json-api/examples/toSearchParams.ts)
  */

--- a/packages/json-api/src/lib/toSearchParams.ts
+++ b/packages/json-api/src/lib/toSearchParams.ts
@@ -1,0 +1,50 @@
+import { URLSearchParams } from "node:url";
+
+import { type JsonApiQuery } from "./types";
+
+/**
+ * Call this function from clients to converts from {@link JsonApiQuery} to {@link URLSearchParams}.
+ *
+ * @see [Example](https://github.com/ClipboardHealth/core-utils/blob/main/packages/json-api/examples/toSearchParams.ts)
+ */
+export function toSearchParams(query: JsonApiQuery): URLSearchParams {
+  const searchParams = new URLSearchParams();
+
+  if (query.fields) {
+    for (const [type, fields] of Object.entries(query.fields)) {
+      searchParams.append(`fields[${type}]`, fields.join(","));
+    }
+  }
+
+  handleFilter(query, searchParams);
+
+  if (query.include) {
+    searchParams.append("include", query.include.join(","));
+  }
+
+  if (query.page) {
+    for (const [key, value] of Object.entries(query.page)) {
+      searchParams.append(`page[${key}]`, value);
+    }
+  }
+
+  if (query.sort) {
+    searchParams.append("sort", query.sort.join(","));
+  }
+
+  return searchParams;
+}
+
+function handleFilter(query: JsonApiQuery, searchParams: URLSearchParams) {
+  if (query.filter) {
+    for (const [key, value] of Object.entries(query.filter)) {
+      if (Array.isArray(value)) {
+        searchParams.append(`filter[${key}]`, value.join(","));
+      } else if (typeof value === "object") {
+        for (const [subKey, subValue] of Object.entries(value)) {
+          searchParams.append(`filter[${key}][${subKey}]`, String(subValue));
+        }
+      }
+    }
+  }
+}

--- a/packages/json-api/src/lib/toSearchParams.ts
+++ b/packages/json-api/src/lib/toSearchParams.ts
@@ -16,7 +16,17 @@ export function toSearchParams(query: JsonApiQuery): URLSearchParams {
     });
   }
 
-  handleFilter(query, searchParams);
+  if (query.filter) {
+    Object.entries(query.filter).forEach(([field, values]) => {
+      if (Array.isArray(values)) {
+        searchParams.append(`filter[${field}]`, values.join(","));
+      } else if (typeof values === "object") {
+        Object.entries(values).forEach(([fieldType, value]) => {
+          searchParams.append(`filter[${field}][${fieldType}]`, value);
+        });
+      }
+    });
+  }
 
   if (query.include) {
     searchParams.append("include", query.include.join(","));
@@ -33,18 +43,4 @@ export function toSearchParams(query: JsonApiQuery): URLSearchParams {
   }
 
   return searchParams;
-}
-
-function handleFilter(query: JsonApiQuery, searchParams: URLSearchParams) {
-  if (query.filter) {
-    Object.entries(query.filter).forEach(([field, values]) => {
-      if (Array.isArray(values)) {
-        searchParams.append(`filter[${field}]`, values.join(","));
-      } else if (typeof values === "object") {
-        Object.entries(values).forEach(([fieldType, value]) => {
-          searchParams.append(`filter[${field}][${fieldType}]`, value);
-        });
-      }
-    });
-  }
 }

--- a/packages/json-api/src/lib/types.ts
+++ b/packages/json-api/src/lib/types.ts
@@ -1,0 +1,51 @@
+/**
+ * Filter operators to build complex filter queries.
+ * - gt: Greater than
+ * - ge: Greater than or equal to
+ * - lt: Less than
+ * - le: Less than or equal to
+ * - not: Not equal to
+ */
+type Operator = ["gt", "ge", "lt", "le", "not"][number];
+
+/**
+ * A JSON:API URL query string.
+ */
+export interface JsonApiQuery {
+  /**
+   * Fields to include in the response.
+   *
+   * @see {@link https://jsonapi.org/format/#fetching-sparse-fieldsets Sparse fieldsets}
+   */
+  fields?: Record<string, string[]>;
+
+  /**
+   * Filters to apply to the query.
+   *
+   * @see {@link https://jsonapi.org/recommendations/#filtering Filtering}
+   * @see {@link https://discuss.jsonapi.org/t/share-propose-a-filtering-strategy/257 Filtering strategy}
+   */
+  filter?: Record<string, string[] | { [K in Operator]?: string }>;
+
+  /**
+   * Relationships to include in the response.
+   *
+   * @see {@link https://jsonapi.org/format/#fetching-includes Fetching includes}
+   */
+  include?: string[];
+
+  /**
+   * Pagination data.
+   *
+   * @see {@link https://jsonapi.org/format/#fetching-pagination Pagination}
+   * @see {@link https://jsonapi.org/examples/#pagination Pagination examples}
+   */
+  page?: Record<string, string>;
+
+  /**
+   * Sorting data. Include the "-" prefix for descending order.
+   *
+   * @see {@link https://jsonapi.org/format/#fetching-sorting Sorting}
+   */
+  sort?: string[];
+}

--- a/packages/json-api/src/lib/types.ts
+++ b/packages/json-api/src/lib/types.ts
@@ -1,12 +1,12 @@
 /**
  * Filter operators to build complex filter queries.
  * - gt: Greater than
- * - ge: Greater than or equal to
+ * - gte: Greater than or equal to
  * - lt: Less than
- * - le: Less than or equal to
+ * - lte: Less than or equal to
  * - not: Not equal to
  */
-type FieldType = "gt" | "ge" | "lt" | "le" | "not";
+type FieldType = "gt" | "gte" | "lt" | "lte" | "not";
 
 /**
  * A JSON:API URL query string.

--- a/packages/json-api/src/lib/types.ts
+++ b/packages/json-api/src/lib/types.ts
@@ -25,11 +25,7 @@ export interface JsonApiQuery {
    * @see {@link https://jsonapi.org/recommendations/#filtering Filtering}
    * @see {@link https://discuss.jsonapi.org/t/share-propose-a-filtering-strategy/257 Filtering strategy}
    */
-  filter?: Record<
-    string,
-    // Provides IntelliSense
-    string[] | { [K in FieldType]?: string }
-  >;
+  filter?: Record<string, string[] | { [K in FieldType]?: string }>;
 
   /**
    * Relationships to include in the response.
@@ -44,10 +40,7 @@ export interface JsonApiQuery {
    * @see {@link https://jsonapi.org/format/#fetching-pagination Pagination}
    * @see {@link https://jsonapi.org/examples/#pagination Pagination examples}
    */
-  page?:
-    | Record<string, string>
-    // Provides IntelliSense
-    | { [K in "cursor" | "number" | "size"]?: string };
+  page?: { [K in "cursor" | "limit" | "number" | "offset" | "size"]?: string };
 
   /**
    * Sorting data. Include the "-" prefix for descending order.

--- a/packages/json-api/src/lib/types.ts
+++ b/packages/json-api/src/lib/types.ts
@@ -6,7 +6,7 @@
  * - le: Less than or equal to
  * - not: Not equal to
  */
-type Operator = ["gt", "ge", "lt", "le", "not"][number];
+type FieldType = "gt" | "ge" | "lt" | "le" | "not";
 
 /**
  * A JSON:API URL query string.
@@ -25,7 +25,11 @@ export interface JsonApiQuery {
    * @see {@link https://jsonapi.org/recommendations/#filtering Filtering}
    * @see {@link https://discuss.jsonapi.org/t/share-propose-a-filtering-strategy/257 Filtering strategy}
    */
-  filter?: Record<string, string[] | { [K in Operator]?: string }>;
+  filter?: Record<
+    string,
+    // Provides IntelliSense
+    string[] | { [K in FieldType]?: string }
+  >;
 
   /**
    * Relationships to include in the response.
@@ -40,7 +44,10 @@ export interface JsonApiQuery {
    * @see {@link https://jsonapi.org/format/#fetching-pagination Pagination}
    * @see {@link https://jsonapi.org/examples/#pagination Pagination examples}
    */
-  page?: Record<string, string>;
+  page?:
+    | Record<string, string>
+    // Provides IntelliSense
+    | { [K in "cursor" | "number" | "size"]?: string };
 
   /**
    * Sorting data. Include the "-" prefix for descending order.

--- a/packages/json-api/tsconfig.json
+++ b/packages/json-api/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.lint.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/json-api/tsconfig.lib.json
+++ b/packages/json-api/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/packages/json-api/tsconfig.lint.json
+++ b/packages/json-api/tsconfig.lint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  },
+  "include": ["."]
+}

--- a/packages/json-api/tsconfig.spec.json
+++ b/packages/json-api/tsconfig.spec.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  },
+  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/packages/json-api/typedoc.json
+++ b/packages/json-api/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,6 +11,7 @@
     "moduleResolution": "Node10",
     "paths": {
       "@clipboard-health/eslint-config": ["packages/eslint-config/src/index.js"],
+      "@clipboard-health/json-api": ["packages/json-api/src/index.ts"],
       "@clipboard-health/nx-plugin": ["packages/nx-plugin/src/index.ts"],
       "@clipboard-health/rules-engine": ["packages/rules-engine/src/index.ts"]
     },


### PR DESCRIPTION
Summary
===
Add `json-api` query helpers inspired by https://github.com/scoutforpets/bookshelf-jsonapi-params and https://github.com/kideh88/node-jsonapi-query-parser. See the README for example usage.
