### PR TITLE
feat: allow clients to pass boolean, Date, and number values

### DIFF
--- a/packages/json-api/examples/toJsonApiQuery.ts
+++ b/packages/json-api/examples/toJsonApiQuery.ts
@@ -1,14 +1,21 @@
-import { toJsonApiQuery } from "@clipboard-health/json-api";
+import { deepEqual } from "node:assert/strict";
 
+import { type ServerJsonApiQuery, toJsonApiQuery } from "@clipboard-health/json-api";
+
+const isoDate = "2024-01-01T15:00:00.000Z";
+// The URLSearchParams constructor also supports URL-encoded strings
 const searchParams = new URLSearchParams(
-  "fields%5Bdog%5D=age%2Cname&filter%5Bage%5D=2%2C5&include=vet&page%5Bsize%5D=10&sort=-age",
+  `fields[dog]=age&filter[age]=2&filter[createdAt][gte]=${isoDate}&filter[isGoodDog]=true&include=owner&page[size]=10&sort=-age`,
 );
 
-console.log(toJsonApiQuery(searchParams));
-// => {
-//   fields: { dog: ["age", "name"] },
-//   filter: { age: ["2", "5"] },
-//   include: ["vet"],
-//   page: { size: "10" },
-//   sort: ["-age"],
-// }
+const query: ServerJsonApiQuery = toJsonApiQuery(searchParams);
+
+deepEqual(query, {
+  fields: { dog: ["age"] },
+  filter: { age: ["2"], createdAt: { gte: isoDate }, isGoodDog: ["true"] },
+  include: ["owner"],
+  page: {
+    size: "10",
+  },
+  sort: ["-age"],
+});

--- a/packages/json-api/examples/toSearchParams.ts
+++ b/packages/json-api/examples/toSearchParams.ts
@@ -1,15 +1,21 @@
+import { deepEqual } from "node:assert/strict";
+
 import { toSearchParams } from "@clipboard-health/json-api";
 
-import { type JsonApiQuery } from "../src/lib/types";
+import { type ClientJsonApiQuery } from "../src/lib/types";
 
-const query: JsonApiQuery = {
-  fields: { dog: ["age", "name"] },
-  filter: { age: ["2", "5"] },
-  include: ["vet"],
-  page: { size: "10" },
+const isoDate = "2024-01-01T15:00:00.000Z";
+const query: ClientJsonApiQuery = {
+  fields: { dog: ["age"] },
+  filter: { age: [2], createdAt: { gte: new Date(isoDate) }, isGoodDog: true },
+  include: ["owner"],
+  page: { size: 10 },
   sort: ["-age"],
 };
 
-console.log(toSearchParams(query).toString());
-// Note: actual result is URL-encoded, but unencoded below for readability
-// => fields[dog]=age,name&filter[age]=2,5&include=vet&page[size]=10&sort=-age
+deepEqual(
+  toSearchParams(query).toString(),
+  new URLSearchParams(
+    "fields[dog]=age&filter[age]=2&filter[createdAt][gte]=2024-01-01T15:00:00.000Z&filter[isGoodDog]=true&include=owner&page[size]=10&sort=-age",
+  ).toString(),
+);

--- a/packages/json-api/src/lib/toJsonApiQuery.spec.ts
+++ b/packages/json-api/src/lib/toJsonApiQuery.spec.ts
@@ -13,6 +13,14 @@ describe("toJsonApiQuery", () => {
     });
   });
 
+  it("parses multiple fields", () => {
+    expect(
+      toJsonApiQuery(new URL(`${BASE_URL}?fields[dog]=age&fields[vet]=name`).searchParams),
+    ).toEqual({
+      fields: { dog: ["age"], vet: ["name"] },
+    });
+  });
+
   it("parses fields with multiple values", () => {
     expect(toJsonApiQuery(new URL(`${BASE_URL}?fields[dog]=age,name`).searchParams)).toEqual({
       fields: { dog: ["age", "name"] },
@@ -39,9 +47,15 @@ describe("toJsonApiQuery", () => {
     });
   });
 
-  it("parses filter type gte", () => {
-    expect(toJsonApiQuery(new URL(`${BASE_URL}?filter[age][gte]=2`).searchParams)).toEqual({
-      filter: { age: { gte: "2" } },
+  it("parses multiple filter types", () => {
+    expect(
+      toJsonApiQuery(
+        new URL(
+          `${BASE_URL}?filter[age][gt]=2&filter[age][gte]=3&filter[age][lt]=6&filter[age][lte]=5&filter[age][not]=4`,
+        ).searchParams,
+      ),
+    ).toEqual({
+      filter: { age: { gt: "2", gte: "3", lt: "6", lte: "5", not: "4" } },
     });
   });
 
@@ -68,6 +82,20 @@ describe("toJsonApiQuery", () => {
     });
   });
 
+  it("parses limit/offset page", () => {
+    expect(
+      toJsonApiQuery(
+        new URL(`${BASE_URL}?page[limit]=10&page[number]=2&page[offset]=20`).searchParams,
+      ),
+    ).toEqual({
+      page: {
+        limit: "10",
+        number: "2",
+        offset: "20",
+      },
+    });
+  });
+
   it("parses sort", () => {
     expect(toJsonApiQuery(new URL(`${BASE_URL}?sort=age`).searchParams)).toEqual({
       sort: ["age"],
@@ -81,19 +109,21 @@ describe("toJsonApiQuery", () => {
   });
 
   it("parses combinations", () => {
+    const isoDate = "2024-01-01T15:00:00.000Z";
     expect(
       toJsonApiQuery(
-        new URL(`${BASE_URL}?filter[age]=2&include=vet&sort=age&fields[dog]=age&page[size]=10`)
-          .searchParams,
+        new URL(
+          `${BASE_URL}?fields[dog]=age&filter[age]=2&filter[createdAt][gte]=${isoDate}&include=owner&page[size]=10&sort=-age`,
+        ).searchParams,
       ),
     ).toEqual({
       fields: { dog: ["age"] },
-      filter: { age: ["2"] },
-      include: ["vet"],
+      filter: { age: ["2"], createdAt: { gte: isoDate } },
+      include: ["owner"],
       page: {
         size: "10",
       },
-      sort: ["age"],
+      sort: ["-age"],
     });
   });
 });

--- a/packages/json-api/src/lib/toJsonApiQuery.spec.ts
+++ b/packages/json-api/src/lib/toJsonApiQuery.spec.ts
@@ -28,22 +28,22 @@ describe("toJsonApiQuery", () => {
   });
 
   it("parses filter", () => {
-    expect(toJsonApiQuery(new URL(`${BASE_URL}?filter[name]=alice`).searchParams)).toEqual({
-      filter: { name: ["alice"] },
+    expect(toJsonApiQuery(new URL(`${BASE_URL}?filter[name]=snoopy`).searchParams)).toEqual({
+      filter: { name: ["snoopy"] },
     });
   });
 
   it("parses multiple filters", () => {
     expect(
-      toJsonApiQuery(new URL(`${BASE_URL}?filter[name]=alice&filter[age]=2`).searchParams),
+      toJsonApiQuery(new URL(`${BASE_URL}?filter[name]=snoopy&filter[age]=2`).searchParams),
     ).toEqual({
-      filter: { age: ["2"], name: ["alice"] },
+      filter: { age: ["2"], name: ["snoopy"] },
     });
   });
 
   it("parses filters with multiple values", () => {
-    expect(toJsonApiQuery(new URL(`${BASE_URL}?filter[name]=alice,bob`).searchParams)).toEqual({
-      filter: { name: ["alice", "bob"] },
+    expect(toJsonApiQuery(new URL(`${BASE_URL}?filter[name]=snoopy,lassie`).searchParams)).toEqual({
+      filter: { name: ["snoopy", "lassie"] },
     });
   });
 

--- a/packages/json-api/src/lib/toJsonApiQuery.spec.ts
+++ b/packages/json-api/src/lib/toJsonApiQuery.spec.ts
@@ -113,12 +113,12 @@ describe("toJsonApiQuery", () => {
     expect(
       toJsonApiQuery(
         new URL(
-          `${BASE_URL}?fields[dog]=age&filter[age]=2&filter[createdAt][gte]=${isoDate}&include=owner&page[size]=10&sort=-age`,
+          `${BASE_URL}?fields[dog]=age&filter[age]=2&filter[createdAt][gte]=${isoDate}&filter[isGoodDog]=true&include=owner&page[size]=10&sort=-age`,
         ).searchParams,
       ),
     ).toEqual({
       fields: { dog: ["age"] },
-      filter: { age: ["2"], createdAt: { gte: isoDate } },
+      filter: { age: ["2"], createdAt: { gte: isoDate }, isGoodDog: ["true"] },
       include: ["owner"],
       page: {
         size: "10",

--- a/packages/json-api/src/lib/toJsonApiQuery.ts
+++ b/packages/json-api/src/lib/toJsonApiQuery.ts
@@ -1,4 +1,4 @@
-import { type JsonApiQuery } from "./types";
+import { type ServerJsonApiQuery } from "./types";
 
 const REGEX = {
   fields: /^fields\[(.*?)]$/i,
@@ -10,12 +10,12 @@ const REGEX = {
 } as const;
 
 /**
- * Call this function from clients to convert from {@link URLSearchParams} to {@link JsonApiQuery}.
+ * Call this function from clients to convert from {@link URLSearchParams} to {@link ServerJsonApiQuery}.
  *
  * @see [Example](https://github.com/ClipboardHealth/core-utils/blob/main/packages/json-api/examples/toJsonApiQuery.ts)
  */
-export function toJsonApiQuery(searchParams: URLSearchParams): JsonApiQuery {
-  return [...searchParams].reduce<JsonApiQuery>((accumulator, [key, value]) => {
+export function toJsonApiQuery(searchParams: URLSearchParams): ServerJsonApiQuery {
+  return [...searchParams].reduce<ServerJsonApiQuery>((accumulator, [key, value]) => {
     const match = Object.entries(REGEX).find(([, regex]) => regex.test(key));
     if (!match) {
       return accumulator;

--- a/packages/json-api/src/lib/toSearchParams.spec.ts
+++ b/packages/json-api/src/lib/toSearchParams.spec.ts
@@ -30,16 +30,16 @@ describe("toSearchParams", () => {
   });
 
   it("converts simple filter", () => {
-    const actual = toSearchParams({ filter: { name: ["alice"] } });
+    const actual = toSearchParams({ filter: { name: ["snoopy"] } });
 
-    expect(actual.get("filter[name]")).toBe("alice");
+    expect(actual.get("filter[name]")).toBe("snoopy");
     expect([...actual.values()]).toHaveLength(1);
   });
 
   it("converts multiple filters", () => {
-    const actual = toSearchParams({ filter: { name: ["alice"], age: ["2"] } });
+    const actual = toSearchParams({ filter: { name: ["snoopy"], age: ["2"] } });
 
-    expect(actual.get("filter[name]")).toBe("alice");
+    expect(actual.get("filter[name]")).toBe("snoopy");
     expect(actual.get("filter[age]")).toBe("2");
     expect([...actual.values()]).toHaveLength(2);
   });
@@ -62,9 +62,9 @@ describe("toSearchParams", () => {
   });
 
   it("converts filters with multiple values", () => {
-    const actual = toSearchParams({ filter: { name: ["alice", "bob"] } });
+    const actual = toSearchParams({ filter: { name: ["snoopy", "lassie"] } });
 
-    expect(actual.get("filter[name]")).toBe("alice,bob");
+    expect(actual.get("filter[name]")).toBe("snoopy,lassie");
     expect([...actual.values()]).toHaveLength(1);
   });
 

--- a/packages/json-api/src/lib/toSearchParams.spec.ts
+++ b/packages/json-api/src/lib/toSearchParams.spec.ts
@@ -29,7 +29,7 @@ describe("toSearchParams", () => {
     expect([...actual.values()]).toHaveLength(1);
   });
 
-  it("converts simple filter", () => {
+  it("converts filter", () => {
     const actual = toSearchParams({ filter: { name: ["snoopy"] } });
 
     expect(actual.get("filter[name]")).toBe("snoopy");
@@ -44,10 +44,10 @@ describe("toSearchParams", () => {
     expect([...actual.values()]).toHaveLength(2);
   });
 
-  it("converts number filter", () => {
-    const actual = toSearchParams({ filter: { age: [2, 4] } });
+  it("converts boolean filter", () => {
+    const actual = toSearchParams({ filter: { isGoodDog: true } });
 
-    expect(actual.get("filter[age]")).toBe("2,4");
+    expect(actual.get("filter[isGoodDog]")).toBe("true");
     expect([...actual.values()]).toHaveLength(1);
   });
 
@@ -61,24 +61,17 @@ describe("toSearchParams", () => {
     expect([...actual.values()]).toHaveLength(1);
   });
 
+  it("converts number filter", () => {
+    const actual = toSearchParams({ filter: { age: [2, 4] } });
+
+    expect(actual.get("filter[age]")).toBe("2,4");
+    expect([...actual.values()]).toHaveLength(1);
+  });
+
   it("converts filters with multiple values", () => {
     const actual = toSearchParams({ filter: { name: ["snoopy", "lassie"] } });
 
     expect(actual.get("filter[name]")).toBe("snoopy,lassie");
-    expect([...actual.values()]).toHaveLength(1);
-  });
-
-  it("converts number filter type", () => {
-    const actual = toSearchParams({ filter: { age: { gte: 2 } } });
-
-    expect(actual.get("filter[age][gte]")).toBe("2");
-    expect([...actual.values()]).toHaveLength(1);
-  });
-
-  it("converts boolean filter type", () => {
-    const actual = toSearchParams({ filter: { isGoodDog: true } });
-
-    expect(actual.get("filter[isGoodDog]")).toBe("true");
     expect([...actual.values()]).toHaveLength(1);
   });
 
@@ -87,6 +80,13 @@ describe("toSearchParams", () => {
     const actual = toSearchParams({ filter: { createdAt: { gte: new Date(isoDate) } } });
 
     expect(actual.get("filter[createdAt][gte]")).toBe(isoDate);
+    expect([...actual.values()]).toHaveLength(1);
+  });
+
+  it("converts number filter type", () => {
+    const actual = toSearchParams({ filter: { age: { gte: 2 } } });
+
+    expect(actual.get("filter[age][gte]")).toBe("2");
     expect([...actual.values()]).toHaveLength(1);
   });
 

--- a/packages/json-api/src/lib/toSearchParams.spec.ts
+++ b/packages/json-api/src/lib/toSearchParams.spec.ts
@@ -5,27 +5,35 @@ describe("toSearchParams", () => {
     const actual = toSearchParams({});
 
     expect(actual.toString()).toBe("");
+    expect([...actual.values()]).toHaveLength(0);
   });
 
   it("converts fields", () => {
     const actual = toSearchParams({ fields: { dog: ["age"] } });
 
     expect(actual.get("fields[dog]")).toBe("age");
-    expect(actual.toString()).toBe("fields%5Bdog%5D=age");
+    expect([...actual.values()]).toHaveLength(1);
+  });
+
+  it("converts multiple fields", () => {
+    const actual = toSearchParams({ fields: { dog: ["age", "name"] } });
+
+    expect(actual.get("fields[dog]")).toBe("age,name");
+    expect([...actual.values()]).toHaveLength(1);
   });
 
   it("converts fields with multiple values", () => {
     const actual = toSearchParams({ fields: { dog: ["age", "name"] } });
 
     expect(actual.get("fields[dog]")).toBe("age,name");
-    expect(actual.toString()).toBe("fields%5Bdog%5D=age%2Cname");
+    expect([...actual.values()]).toHaveLength(1);
   });
 
   it("converts simple filter", () => {
     const actual = toSearchParams({ filter: { name: ["alice"] } });
 
     expect(actual.get("filter[name]")).toBe("alice");
-    expect(actual.toString()).toBe("filter%5Bname%5D=alice");
+    expect([...actual.values()]).toHaveLength(1);
   });
 
   it("converts multiple filters", () => {
@@ -33,35 +41,80 @@ describe("toSearchParams", () => {
 
     expect(actual.get("filter[name]")).toBe("alice");
     expect(actual.get("filter[age]")).toBe("2");
-    expect(actual.toString()).toBe("filter%5Bname%5D=alice&filter%5Bage%5D=2");
+    expect([...actual.values()]).toHaveLength(2);
+  });
+
+  it("converts number filter", () => {
+    const actual = toSearchParams({ filter: { age: [2, 4] } });
+
+    expect(actual.get("filter[age]")).toBe("2,4");
+    expect([...actual.values()]).toHaveLength(1);
+  });
+
+  it("converts Date filter", () => {
+    const isoDate = "2024-01-01T15:00:00.000Z";
+    const actual = toSearchParams({
+      filter: { createdAt: [new Date(isoDate)] },
+    });
+
+    expect(actual.get("filter[createdAt]")).toBe(isoDate);
+    expect([...actual.values()]).toHaveLength(1);
   });
 
   it("converts filters with multiple values", () => {
     const actual = toSearchParams({ filter: { name: ["alice", "bob"] } });
 
     expect(actual.get("filter[name]")).toBe("alice,bob");
-    expect(actual.toString()).toBe("filter%5Bname%5D=alice%2Cbob");
+    expect([...actual.values()]).toHaveLength(1);
   });
 
-  it("converts complex filter", () => {
-    const actual = toSearchParams({ filter: { age: { gte: "2" } } });
+  it("converts number filter type", () => {
+    const actual = toSearchParams({ filter: { age: { gte: 2 } } });
 
     expect(actual.get("filter[age][gte]")).toBe("2");
-    expect(actual.toString()).toBe("filter%5Bage%5D%5Bgte%5D=2");
+    expect([...actual.values()]).toHaveLength(1);
+  });
+
+  it("converts boolean filter type", () => {
+    const actual = toSearchParams({ filter: { isGoodDog: true } });
+
+    expect(actual.get("filter[isGoodDog]")).toBe("true");
+    expect([...actual.values()]).toHaveLength(1);
+  });
+
+  it("converts Date filter type", () => {
+    const isoDate = "2024-01-01T15:00:00.000Z";
+    const actual = toSearchParams({ filter: { createdAt: { gte: new Date(isoDate) } } });
+
+    expect(actual.get("filter[createdAt][gte]")).toBe(isoDate);
+    expect([...actual.values()]).toHaveLength(1);
+  });
+
+  it("converts multiple filter types", () => {
+    const actual = toSearchParams({
+      filter: { age: { gt: "2", gte: "3", lt: "6", lte: "5", not: "4" } },
+    });
+
+    expect(actual.get("filter[age][gt]")).toBe("2");
+    expect(actual.get("filter[age][gte]")).toBe("3");
+    expect(actual.get("filter[age][lt]")).toBe("6");
+    expect(actual.get("filter[age][lte]")).toBe("5");
+    expect(actual.get("filter[age][not]")).toBe("4");
+    expect([...actual.values()]).toHaveLength(5);
   });
 
   it("converts include", () => {
     const actual = toSearchParams({ include: ["owner"] });
 
     expect(actual.get("include")).toBe("owner");
-    expect(actual.toString()).toBe("include=owner");
+    expect([...actual.values()]).toHaveLength(1);
   });
 
   it("converts include with multiple values", () => {
     const actual = toSearchParams({ include: ["owner", "vet"] });
 
     expect(actual.get("include")).toBe("owner,vet");
-    expect(actual.toString()).toBe("include=owner%2Cvet");
+    expect([...actual.values()]).toHaveLength(1);
   });
 
   it("converts page", () => {
@@ -69,39 +122,48 @@ describe("toSearchParams", () => {
 
     expect(actual.get("page[size]")).toBe("10");
     expect(actual.get("page[cursor]")).toBe("a2c12");
-    expect(actual.toString()).toBe("page%5Bsize%5D=10&page%5Bcursor%5D=a2c12");
+    expect([...actual.values()]).toHaveLength(2);
+  });
+
+  it("converts limit/offset page", () => {
+    const actual = toSearchParams({ page: { limit: 10, number: 2, offset: 20 } });
+
+    expect(actual.get("page[limit]")).toBe("10");
+    expect(actual.get("page[number]")).toBe("2");
+    expect(actual.get("page[offset]")).toBe("20");
+    expect([...actual.values()]).toHaveLength(3);
   });
 
   it("converts sort", () => {
     const actual = toSearchParams({ sort: ["age"] });
 
     expect(actual.get("sort")).toBe("age");
-    expect(actual.toString()).toBe("sort=age");
+    expect([...actual.values()]).toHaveLength(1);
   });
 
   it("converts sort with multiple values", () => {
     const actual = toSearchParams({ sort: ["age", "-name"] });
 
     expect(actual.get("sort")).toBe("age,-name");
-    expect(actual.toString()).toBe("sort=age%2C-name");
+    expect([...actual.values()]).toHaveLength(1);
   });
 
   it("converts combinations", () => {
+    const isoDate = "2024-01-01T15:00:00.000Z";
     const actual = toSearchParams({
       fields: { dog: ["age"] },
-      filter: { age: ["2"] },
-      include: ["vet"],
-      page: { size: "10" },
-      sort: ["age"],
+      filter: { age: [2], createdAt: { gte: new Date(isoDate) } },
+      include: ["owner"],
+      page: { size: 10 },
+      sort: ["-age"],
     });
 
     expect(actual.get("fields[dog]")).toBe("age");
     expect(actual.get("filter[age]")).toBe("2");
-    expect(actual.get("include")).toBe("vet");
+    expect(actual.get("filter[createdAt][gte]")).toBe(isoDate);
+    expect(actual.get("include")).toBe("owner");
     expect(actual.get("page[size]")).toBe("10");
-    expect(actual.get("sort")).toBe("age");
-    expect(actual.toString()).toBe(
-      "fields%5Bdog%5D=age&filter%5Bage%5D=2&include=vet&page%5Bsize%5D=10&sort=age",
-    );
+    expect(actual.get("sort")).toBe("-age");
+    expect([...actual.values()]).toHaveLength(6);
   });
 });

--- a/packages/json-api/src/lib/toSearchParams.ts
+++ b/packages/json-api/src/lib/toSearchParams.ts
@@ -26,16 +26,14 @@ export function toSearchParams(query: ClientJsonApiQuery): URLSearchParams {
 
   if (query.filter) {
     Object.entries(query.filter).forEach(([field, values]) => {
+      const filterField = `filter[${field}]`;
       if (Array.isArray(values)) {
-        searchParams.append(
-          `filter[${field}]`,
-          join(values.map((value) => filterValueString(value))),
-        );
+        searchParams.append(filterField, join(values.map((value) => filterValueString(value))));
       } else if (typeof values === "boolean") {
-        searchParams.append(`filter[${field}]`, String(values));
+        searchParams.append(filterField, String(values));
       } else if (typeof values === "object") {
         Object.entries(values).forEach(([fieldType, value]) => {
-          searchParams.append(`filter[${field}][${fieldType}]`, filterValueString(value));
+          searchParams.append(`${filterField}[${fieldType}]`, filterValueString(value));
         });
       }
     });

--- a/packages/json-api/src/lib/toSearchParams.ts
+++ b/packages/json-api/src/lib/toSearchParams.ts
@@ -1,45 +1,58 @@
 import { URLSearchParams } from "node:url";
 
-import { type JsonApiQuery } from "./types";
+import { type ClientJsonApiQuery, type ClientTypes } from "./types";
+
+function filterValueString(value: ClientTypes["filterTypeValue"]): string {
+  return value instanceof Date ? value.toISOString() : String(value);
+}
+
+function join(values: string[]): string {
+  return values.join(",");
+}
 
 /**
- * Call this function from clients to convert from {@link JsonApiQuery} to {@link URLSearchParams}.
+ * Call this function from clients to convert from {@link ClientJsonApiQuery} to {@link URLSearchParams}.
  *
  * @see [Example](https://github.com/ClipboardHealth/core-utils/blob/main/packages/json-api/examples/toSearchParams.ts)
  */
-export function toSearchParams(query: JsonApiQuery): URLSearchParams {
+export function toSearchParams(query: ClientJsonApiQuery): URLSearchParams {
   const searchParams = new URLSearchParams();
 
   if (query.fields) {
     Object.entries(query.fields).forEach(([type, fields]) => {
-      searchParams.append(`fields[${type}]`, fields.join(","));
+      searchParams.append(`fields[${type}]`, join(fields));
     });
   }
 
   if (query.filter) {
     Object.entries(query.filter).forEach(([field, values]) => {
       if (Array.isArray(values)) {
-        searchParams.append(`filter[${field}]`, values.join(","));
+        searchParams.append(
+          `filter[${field}]`,
+          join(values.map((value) => filterValueString(value))),
+        );
+      } else if (typeof values === "boolean") {
+        searchParams.append(`filter[${field}]`, String(values));
       } else if (typeof values === "object") {
         Object.entries(values).forEach(([fieldType, value]) => {
-          searchParams.append(`filter[${field}][${fieldType}]`, value);
+          searchParams.append(`filter[${field}][${fieldType}]`, filterValueString(value));
         });
       }
     });
   }
 
   if (query.include) {
-    searchParams.append("include", query.include.join(","));
+    searchParams.append("include", join(query.include));
   }
 
   if (query.page) {
     Object.entries(query.page).forEach(([key, value]) => {
-      searchParams.append(`page[${key}]`, value);
+      searchParams.append(`page[${key}]`, String(value));
     });
   }
 
   if (query.sort) {
-    searchParams.append("sort", query.sort.join(","));
+    searchParams.append("sort", join(query.sort));
   }
 
   return searchParams;

--- a/packages/json-api/src/lib/types.ts
+++ b/packages/json-api/src/lib/types.ts
@@ -1,17 +1,37 @@
 /**
- * Filter operators to build complex filter queries.
+ * Filter types to build complex filter queries.
  * - gt: Greater than
  * - gte: Greater than or equal to
  * - lt: Less than
  * - lte: Less than or equal to
  * - not: Not equal to
  */
-type FieldType = "gt" | "gte" | "lt" | "lte" | "not";
+type FilterType = "gt" | "gte" | "lt" | "lte" | "not";
+
+type PageKey = "cursor" | "limit" | "number" | "offset" | "size";
+
+interface JsonApiQueryTypes {
+  filterValue: unknown;
+  filterTypeValue: unknown;
+  pageValue: unknown;
+}
+
+export interface ClientTypes {
+  filterValue: Array<Date | number | string> | boolean;
+  filterTypeValue: Date | number | string;
+  pageValue: number | string;
+}
+
+interface ServerTypes {
+  filterValue: string[];
+  filterTypeValue: string;
+  pageValue: string;
+}
 
 /**
  * A JSON:API URL query string.
  */
-export interface JsonApiQuery {
+interface JsonApiQuery<T extends JsonApiQueryTypes> {
   /**
    * Fields to include in the response.
    *
@@ -25,7 +45,7 @@ export interface JsonApiQuery {
    * @see {@link https://jsonapi.org/recommendations/#filtering Filtering}
    * @see {@link https://discuss.jsonapi.org/t/share-propose-a-filtering-strategy/257 Filtering strategy}
    */
-  filter?: Record<string, string[] | { [K in FieldType]?: string }>;
+  filter?: Record<string, T["filterValue"] | { [K in FilterType]?: T["filterTypeValue"] }>;
 
   /**
    * Relationships to include in the response.
@@ -40,7 +60,7 @@ export interface JsonApiQuery {
    * @see {@link https://jsonapi.org/format/#fetching-pagination Pagination}
    * @see {@link https://jsonapi.org/examples/#pagination Pagination examples}
    */
-  page?: { [K in "cursor" | "limit" | "number" | "offset" | "size"]?: string };
+  page?: { [K in PageKey]?: T["pageValue"] };
 
   /**
    * Sorting data. Include the "-" prefix for descending order.
@@ -49,3 +69,7 @@ export interface JsonApiQuery {
    */
   sort?: string[];
 }
+
+export type ClientJsonApiQuery = JsonApiQuery<ClientTypes>;
+
+export type ServerJsonApiQuery = JsonApiQuery<ServerTypes>;


### PR DESCRIPTION
Changes
---
- Create `ClientJsonApiQuery` and `ServerJsonApiQuery` types. The former provide better type safety while the latter remain `string`.
- Client-side, support `boolean`, `Date`, and `number` types in addition to `string`.
- Add `deepEqual` asserts to the examples to quickly verify correctness.
- More complete tests
- Better 🐶 names