### PR TITLE
fix: makes URLSearchParams global and remove node import

### DIFF
--- a/packages/json-api/src/lib/toSearchParams.ts
+++ b/packages/json-api/src/lib/toSearchParams.ts
@@ -1,5 +1,3 @@
-import { URLSearchParams } from "node:url";
-
 import { type ClientJsonApiQuery, type ClientTypes } from "./types";
 
 function filterValueString(value: ClientTypes["filterTypeValue"]): string {


### PR DESCRIPTION
Summary
===
When using `json-api` in client side, we get the following warning
<img width="554" alt="image" src="https://github.com/user-attachments/assets/41af2fd1-8305-4df3-816d-7db91e15c327">

Node.js already supports using `URLSearchParams` under the `globalThis`. Hence we don't need to import them explicitly.

<!--
- For PR best practices, see https://www.notion.so/Best-Practices-797056a67747474ebe5b551d26958f61?p=efedc19c33da45f787033113a0be3b8e&pm=s
- For expectations after PR approval and merge, see the CONTRIBUTING.md file
-->

Changes
---
- remove `node:url` import to be compatible with client side

Videos/screenshots
---
