### PR TITLE
feat: Zod schema for JSON:API include query parameters

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,3 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+reviews:
+  poem: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -16682,7 +16682,7 @@
     },
     "packages/json-api": {
       "name": "@clipboard-health/json-api",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.7.0"
@@ -16690,7 +16690,7 @@
     },
     "packages/json-api-nestjs": {
       "name": "@clipboard-health/json-api-nestjs",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.7.0",

--- a/packages/json-api-nestjs/README.md
+++ b/packages/json-api-nestjs/README.md
@@ -24,6 +24,54 @@ Create Zod schemas for your API's queries:
 <!-- prettier-ignore -->
 ```ts
 // ./examples/query.ts
+
+import {
+  booleanString,
+  createCursorPagination,
+  createFields,
+  createFilter,
+  createInclude,
+  createSort,
+} from "@clipboard-health/json-api-nestjs";
+import { z } from "zod";
+
+export const paginationQuery = z.object(createCursorPagination()).strict();
+
+export const fieldsQuery = z
+  .object(createFields({ user: ["age", "name"], article: ["title"] }))
+  .strict();
+
+export const filterQuery = z
+  .object(
+    createFilter({
+      age: {
+        filters: ["eq", "gt"],
+        schema: z.coerce.number().int().positive().max(125),
+      },
+      isActive: {
+        filters: ["eq"],
+        schema: booleanString,
+      },
+      dateOfBirth: {
+        filters: ["gte"],
+        schema: z.coerce.date().min(new Date("1900-01-01")),
+      },
+    }),
+  )
+  .strict();
+
+export const sortQuery = z.object(createSort(["age", "name"])).strict();
+
+export const includeQuery = z.object(createInclude(["articles", "articles.comments"])).strict();
+
+export const compoundQuery = z.object({
+  ...createCursorPagination(),
+  ...createFields({ user: ["age", "name"] }),
+  ...createFilter({ isActive: { filters: ["eq"], schema: booleanString } }),
+  ...createSort(["age"]),
+  ...createInclude(["articles"]),
+});
+
 ```
 
 ## Local development commands

--- a/packages/json-api-nestjs/README.md
+++ b/packages/json-api-nestjs/README.md
@@ -35,15 +35,11 @@ import {
 } from "@clipboard-health/json-api-nestjs";
 import { z } from "zod";
 
-export const paginationQuery = z.object(createCursorPagination()).strict();
-
-export const fieldsQuery = z
-  .object(createFields({ user: ["age", "name"], article: ["title"] }))
-  .strict();
-
-export const filterQuery = z
-  .object(
-    createFilter({
+export const query = z
+  .object({
+    ...createCursorPagination(),
+    ...createFields({ user: ["age", "name"], article: ["title"] }),
+    ...createFilter({
       age: {
         filters: ["eq", "gt"],
         schema: z.coerce.number().int().positive().max(125),
@@ -57,20 +53,10 @@ export const filterQuery = z
         schema: z.coerce.date().min(new Date("1900-01-01")),
       },
     }),
-  )
+    ...createSort(["age", "name"]),
+    ...createInclude(["articles", "articles.comments"]),
+  })
   .strict();
-
-export const sortQuery = z.object(createSort(["age", "name"])).strict();
-
-export const includeQuery = z.object(createInclude(["articles", "articles.comments"])).strict();
-
-export const compoundQuery = z.object({
-  ...createCursorPagination(),
-  ...createFields({ user: ["age", "name"] }),
-  ...createFilter({ isActive: { filters: ["eq"], schema: booleanString } }),
-  ...createSort(["age"]),
-  ...createInclude(["articles"]),
-});
 
 ```
 

--- a/packages/json-api-nestjs/examples/query.ts
+++ b/packages/json-api-nestjs/examples/query.ts
@@ -3,6 +3,7 @@ import {
   createCursorPagination,
   createFields,
   createFilter,
+  createInclude,
   createSort,
 } from "@clipboard-health/json-api-nestjs";
 import { z } from "zod";
@@ -34,9 +35,12 @@ export const filterQuery = z
 
 export const sortQuery = z.object(createSort(["age", "name"])).strict();
 
+export const includeQuery = z.object(createInclude(["articles", "articles.comments"])).strict();
+
 export const compoundQuery = z.object({
   ...createCursorPagination(),
   ...createFields({ user: ["age", "name"] }),
   ...createFilter({ isActive: { filters: ["eq"], schema: booleanString } }),
   ...createSort(["age"]),
+  ...createInclude(["articles"]),
 });

--- a/packages/json-api-nestjs/examples/query.ts
+++ b/packages/json-api-nestjs/examples/query.ts
@@ -8,15 +8,11 @@ import {
 } from "@clipboard-health/json-api-nestjs";
 import { z } from "zod";
 
-export const paginationQuery = z.object(createCursorPagination()).strict();
-
-export const fieldsQuery = z
-  .object(createFields({ user: ["age", "name"], article: ["title"] }))
-  .strict();
-
-export const filterQuery = z
-  .object(
-    createFilter({
+export const query = z
+  .object({
+    ...createCursorPagination(),
+    ...createFields({ user: ["age", "name"], article: ["title"] }),
+    ...createFilter({
       age: {
         filters: ["eq", "gt"],
         schema: z.coerce.number().int().positive().max(125),
@@ -30,17 +26,7 @@ export const filterQuery = z
         schema: z.coerce.date().min(new Date("1900-01-01")),
       },
     }),
-  )
+    ...createSort(["age", "name"]),
+    ...createInclude(["articles", "articles.comments"]),
+  })
   .strict();
-
-export const sortQuery = z.object(createSort(["age", "name"])).strict();
-
-export const includeQuery = z.object(createInclude(["articles", "articles.comments"])).strict();
-
-export const compoundQuery = z.object({
-  ...createCursorPagination(),
-  ...createFields({ user: ["age", "name"] }),
-  ...createFilter({ isActive: { filters: ["eq"], schema: booleanString } }),
-  ...createSort(["age"]),
-  ...createInclude(["articles"]),
-});

--- a/packages/json-api-nestjs/examples/type-checks/createCursorPagination.ts
+++ b/packages/json-api-nestjs/examples/type-checks/createCursorPagination.ts
@@ -1,37 +1,36 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { type z } from "zod";
 
-import { type paginationQuery } from "../query";
+import { type query } from "../query";
 
-type Query = z.infer<typeof paginationQuery>;
-let _queryTypeCheck: Query | undefined;
-//  ^? let _queryTypeCheck: {
-//         page: {
-//             size: number;
-//             cursor?: string | undefined;
-//         };
+type Page = z.infer<typeof query.shape.page>;
+let _typeCheck: Page | undefined;
+//  ^? let _typeCheck: {
+//         size: number;
+//         cursor?: string | undefined;
 //     } | undefined
 
-const _validSingleField: Query = {
-  page: { size: 10 },
+const _validSingleField: Page = {
+  size: 10,
 };
 
-const _validMultipleFields: Query = {
-  page: { size: 10, cursor: "1" },
+const _validMultipleFields: Page = {
+  size: 10,
+  cursor: "1",
 };
 
-const _invalidField: Query = {
+const _invalidField: Page = {
   // @ts-expect-error: invalid
-  page: { number: 1 },
+  number: 1,
 };
 
-const _invalidApiType: Query = {
+const _invalidKey: Page = {
   // @ts-expect-error: invalid
-  invalid: { size: 10 },
+  invalid: 10,
 };
 
-const _invalidFieldDataType: Query = {
+const _invalidFieldDataType: Page = {
   // @ts-expect-error: invalid
-  page: { size: "10" },
+  size: "10",
 };
 /* eslint-enable @typescript-eslint/no-unused-vars */

--- a/packages/json-api-nestjs/examples/type-checks/createFields.ts
+++ b/packages/json-api-nestjs/examples/type-checks/createFields.ts
@@ -1,37 +1,35 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { type z } from "zod";
 
-import { type fieldsQuery } from "../query";
+import { type query } from "../query";
 
-type Query = z.infer<typeof fieldsQuery>;
-let _queryTypeCheck: Query | undefined;
-//  ^? let _queryTypeCheck: {
-//         fields?: {
-//             user?: ("age" | "name")[] | undefined;
-//             article?: "title"[] | undefined;
-//         } | undefined;
+type Fields = z.infer<typeof query.shape.fields>;
+let _typeCheck: Fields | undefined;
+//  ^? let _typeCheck: {
+//         user?: ("age" | "name")[] | undefined;
+//         article?: "title"[] | undefined;
 //     } | undefined
 
-const _validSingleField: Query = {
-  fields: { user: ["name"] },
+const _validSingleField: Fields = {
+  user: ["name"],
 };
 
-const _validMultipleFields: Query = {
-  fields: { user: ["age", "name"] },
+const _validMultipleFields: Fields = {
+  user: ["age", "name"],
 };
 
-const _invalidField: Query = {
+const _invalidField: Fields = {
   // @ts-expect-error: invalid
-  fields: { user: ["email"] },
+  user: ["email"],
 };
 
-const _invalidApiType: Query = {
+const _invalidApiType: Fields = {
   // @ts-expect-error: invalid
-  fields: { invalid: ["name"] },
+  invalid: ["name"],
 };
 
-const _invalidFieldDataType: Query = {
+const _invalidFieldDataType: Fields = {
   // @ts-expect-error: invalid
-  fields: { user: "name" },
+  user: "name",
 };
 /* eslint-enable @typescript-eslint/no-unused-vars */

--- a/packages/json-api-nestjs/examples/type-checks/createFilter.ts
+++ b/packages/json-api-nestjs/examples/type-checks/createFilter.ts
@@ -1,63 +1,53 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { type z } from "zod";
 
-import { type filterQuery } from "../query";
+import { type query } from "../query";
 
-type Query = z.infer<typeof filterQuery>;
-let _queryTypeCheck: Query | undefined;
-//  ^? let _queryTypeCheck: {
-//         filter?: {
-//             age?: {
-//                 eq?: number[] | undefined;
-//                 gt?: number[] | undefined;
-//             } | undefined;
-//             isActive?: {
-//                 eq?: boolean[] | undefined;
-//             } | undefined;
-//             dateOfBirth?: {
-//                 gte?: Date[] | undefined;
-//             } | undefined;
+type Filter = z.infer<typeof query.shape.filter>;
+let _typeCheck: Filter | undefined;
+//  ^? let _typeCheck: {
+//         age?: {
+//             eq?: number[] | undefined;
+//             gt?: number[] | undefined;
+//         } | undefined;
+//         isActive?: {
+//             eq?: boolean[] | undefined;
+//         } | undefined;
+//         dateOfBirth?: {
+//             gte?: Date[] | undefined;
 //         } | undefined;
 //     } | undefined
 
-const _validSingleFilter: Query = {
-  filter: {
-    age: {
-      eq: [10],
-    },
+const _validSingleFilter: Filter = {
+  age: {
+    eq: [10],
   },
 };
 
-const _validMultipleFilters: Query = {
-  filter: {
-    age: {
-      eq: [10],
-      gt: [9],
-    },
-    dateOfBirth: {
-      gte: [new Date("1990-01-01")],
-    },
-    isActive: {
-      eq: [true],
-    },
+const _validMultipleFilters: Filter = {
+  age: {
+    eq: [10],
+    gt: [9],
+  },
+  dateOfBirth: {
+    gte: [new Date("1990-01-01")],
+  },
+  isActive: {
+    eq: [true],
   },
 };
 
-const _invalidFilterType: Query = {
-  filter: {
-    age: {
-      // @ts-expect-error: invalid
-      gte: [10],
-    },
+const _invalidFilterType: Filter = {
+  age: {
+    // @ts-expect-error: invalid
+    gte: [10],
   },
 };
 
-const _invalidFilterDataType: Query = {
-  filter: {
-    age: {
-      // @ts-expect-error: invalid
-      gt: ["10"],
-    },
+const _invalidFilterDataType: Filter = {
+  age: {
+    // @ts-expect-error: invalid
+    gt: ["10"],
   },
 };
 /* eslint-enable @typescript-eslint/no-unused-vars */

--- a/packages/json-api-nestjs/examples/type-checks/createInclude.ts
+++ b/packages/json-api-nestjs/examples/type-checks/createInclude.ts
@@ -1,29 +1,19 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { type z } from "zod";
 
-import { type includeQuery } from "../query";
+import { type query } from "../query";
 
-type Query = z.infer<typeof includeQuery>;
-let _queryTypeCheck: Query;
-//  ^? let _queryTypeCheck: {
-//         include?: ("articles" | "articles.comments")[] | undefined;
-//     }
+type Include = z.infer<typeof query.shape.include>;
+let _typeCheck: Include | undefined;
+//  ^? let _typeCheck: ("articles" | "articles.comments")[] | undefined
 
-const _validSingleInclude: Query = {
-  include: ["articles"],
-};
+const _validSingleInclude: Include = ["articles"];
 
-const _validMultipleInclude: Query = {
-  include: ["articles", "articles.comments"],
-};
+const _validMultipleIncludes: Include = ["articles", "articles.comments"];
 
-const _invalidIncludeField: Query = {
-  // @ts-expect-error: invalid
-  include: ["invalid"],
-};
+// @ts-expect-error: invalid
+const _invalidIncludeField: Include = ["invalid"];
 
-const _invalidIncludeDataType: Query = {
-  // @ts-expect-error: invalid
-  include: "articles",
-};
+// @ts-expect-error: invalid
+const _invalidIncludeDataType: Include = "articles";
 /* eslint-enable @typescript-eslint/no-unused-vars */

--- a/packages/json-api-nestjs/examples/type-checks/createInclude.ts
+++ b/packages/json-api-nestjs/examples/type-checks/createInclude.ts
@@ -1,0 +1,29 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { type z } from "zod";
+
+import { type includeQuery } from "../query";
+
+type Query = z.infer<typeof includeQuery>;
+let _queryTypeCheck: Query;
+//  ^? let _queryTypeCheck: {
+//         include?: ("articles" | "articles.comments")[] | undefined;
+//     }
+
+const _validSingleInclude: Query = {
+  include: ["articles"],
+};
+
+const _validMultipleInclude: Query = {
+  include: ["articles", "articles.comments"],
+};
+
+const _invalidIncludeField: Query = {
+  // @ts-expect-error: invalid
+  include: ["invalid"],
+};
+
+const _invalidIncludeDataType: Query = {
+  // @ts-expect-error: invalid
+  include: "articles",
+};
+/* eslint-enable @typescript-eslint/no-unused-vars */

--- a/packages/json-api-nestjs/examples/type-checks/createSort.ts
+++ b/packages/json-api-nestjs/examples/type-checks/createSort.ts
@@ -1,29 +1,19 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { type z } from "zod";
 
-import { type sortQuery } from "../query";
+import { type query } from "../query";
 
-type Query = z.infer<typeof sortQuery>;
-let _queryTypeCheck: Query;
-//  ^? let _queryTypeCheck: {
-//         sort?: ("age" | "name" | "-age" | "-name")[] | undefined;
-//     }
+type Sort = z.infer<typeof query.shape.sort>;
+let _typeCheck: Sort;
+//  ^? let _typeCheck: ("age" | "name" | "-age" | "-name")[] | undefined
 
-const _validSingleSort: Query = {
-  sort: ["age"],
-};
+const _validSingleSort: Sort = ["age"];
 
-const _validMultipleSort: Query = {
-  sort: ["-age", "name"],
-};
+const _validMultipleSort: Sort = ["-age", "name"];
 
-const _invalidSortField: Query = {
-  // @ts-expect-error: invalid
-  sort: ["invalid"],
-};
+// @ts-expect-error: invalid
+const _invalidSortField: Sort = ["invalid"];
 
-const _invalidSortDataType: Query = {
-  // @ts-expect-error: invalid
-  sort: "name",
-};
+// @ts-expect-error: invalid
+const _invalidSortDataType: Sort = "name";
 /* eslint-enable @typescript-eslint/no-unused-vars */

--- a/packages/json-api-nestjs/package.json
+++ b/packages/json-api-nestjs/package.json
@@ -12,6 +12,9 @@
   "publishConfig": {
     "access": "restricted"
   },
+  "scripts": {
+    "embed": "embedme README.md"
+  },
   "type": "commonjs",
   "typings": "./src/index.d.ts"
 }

--- a/packages/json-api-nestjs/src/index.ts
+++ b/packages/json-api-nestjs/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./lib/query/createCursorPagination";
 export * from "./lib/query/createFields";
 export * from "./lib/query/createFilter";
+export * from "./lib/query/createInclude";
 export * from "./lib/query/createSort";
 export * from "./lib/schemas";
 export * from "./lib/types";

--- a/packages/json-api-nestjs/src/lib/query/createInclude.spec.ts
+++ b/packages/json-api-nestjs/src/lib/query/createInclude.spec.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+
+import { expectToBeError, expectToBeSuccess } from "../../test";
+import { createInclude } from "./createInclude";
+
+describe("createInclude", () => {
+  const includeSchema = z.object(createInclude(["articles", "articles.comments"]));
+
+  it("accepts valid include parameters", () => {
+    const input = {
+      include: "articles",
+    };
+
+    const actual = includeSchema.safeParse(input);
+
+    expectToBeSuccess(actual);
+    expect(actual.data).toEqual({
+      include: ["articles"],
+    });
+  });
+
+  it("accepts nested include parameters", () => {
+    const input = {
+      include: "articles.comments",
+    };
+
+    const actual = includeSchema.safeParse(input);
+
+    expectToBeSuccess(actual);
+    expect(actual.data).toEqual({
+      include: ["articles.comments"],
+    });
+  });
+
+  it("rejects invalid include fields", () => {
+    const input = {
+      include: "invalid",
+    };
+
+    const actual = includeSchema.safeParse(input);
+
+    expectToBeError(actual);
+    expect(actual.error.message).toContain("Invalid include field: 'invalid'");
+  });
+
+  it("rejects invalid nested include fields", () => {
+    const input = {
+      include: "articles.invalid",
+    };
+
+    const actual = includeSchema.safeParse(input);
+
+    expectToBeError(actual);
+    expect(actual.error.message).toContain("Invalid include field: 'articles.invalid'");
+  });
+
+  it("allows omitting include parameter", () => {
+    const input = {};
+
+    const actual = includeSchema.safeParse(input);
+
+    expectToBeSuccess(actual);
+    expect(actual.data).toEqual({});
+  });
+
+  it("rejects on empty include parameter", () => {
+    const input = {
+      include: "",
+    };
+
+    const actual = includeSchema.safeParse(input);
+
+    expectToBeError(actual);
+    expect(actual.error.message).toContain("Invalid include field: ''");
+  });
+
+  it("rejects non-string include parameter", () => {
+    const input = {
+      include: 123,
+    };
+
+    const actual = includeSchema.safeParse(input);
+
+    expectToBeError(actual);
+    expect(actual.error.message).toContain("Expected array, received number");
+  });
+});

--- a/packages/json-api-nestjs/src/lib/query/createInclude.ts
+++ b/packages/json-api-nestjs/src/lib/query/createInclude.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+import { splitString } from "../internal/splitString";
+
+/**
+ * Creates a Zod schema for JSON:API include parameters.
+ *
+ * @param fields An array of valid include fields.
+ * @returns A Zod schema for the include parameter.
+ *
+ * @see {@link https://jsonapi.org/format/#fetching-includes JSON:API includes}
+ */
+export function createInclude<const FieldT extends readonly string[]>(fields: FieldT) {
+  const fieldSet = new Set(fields);
+
+  return {
+    include: z
+      .preprocess(splitString, z.array(z.string()).optional())
+      .superRefine((value, context) => {
+        if (!value) {
+          return;
+        }
+
+        for (const field of value) {
+          if (!fieldSet.has(field)) {
+            context.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: `Invalid include field: '${field}'`,
+              path: ["include", field],
+            });
+            break;
+          }
+        }
+      })
+      .transform((value) => value as Array<FieldT[number]> | undefined),
+  };
+}

--- a/packages/json-api-nestjs/src/lib/query/createInclude.ts
+++ b/packages/json-api-nestjs/src/lib/query/createInclude.ts
@@ -28,7 +28,6 @@ export function createInclude<const FieldT extends readonly string[]>(fields: Fi
               message: `Invalid include field: '${field}'`,
               path: ["include", field],
             });
-            break;
           }
         }
       })

--- a/packages/json-api-nestjs/src/lib/query/createSort.ts
+++ b/packages/json-api-nestjs/src/lib/query/createSort.ts
@@ -3,14 +3,6 @@ import { z } from "zod";
 import { splitString } from "../internal/splitString";
 import { type Field } from "../types";
 
-export type SortSchema<T extends readonly Field[]> = z.ZodEffects<
-  z.ZodEffects<
-    z.ZodOptional<z.ZodArray<z.ZodEffects<z.ZodString>>>,
-    Array<`-${T[number]}` | T[number]> | undefined,
-    unknown
-  >
->;
-
 /**
  * Creates a Zod schema for JSON:API sort parameters.
  *
@@ -34,7 +26,9 @@ export function createSort<const FieldT extends readonly [Field, ...Field[]]>(fi
             context.addIssue({
               code: z.ZodIssueCode.custom,
               message: `Invalid sort field: '${field}'`,
+              path: ["sort", field],
             });
+            break;
           }
         }
       })

--- a/packages/json-api-nestjs/src/lib/query/createSort.ts
+++ b/packages/json-api-nestjs/src/lib/query/createSort.ts
@@ -28,7 +28,6 @@ export function createSort<const FieldT extends readonly [Field, ...Field[]]>(fi
               message: `Invalid sort field: '${field}'`,
               path: ["sort", field],
             });
-            break;
           }
         }
       })


### PR DESCRIPTION
Summary
===
- **New Features**
  - Introduced a `createInclude` function for validating JSON:API include parameters.
  - Enhanced query handling with a consolidated `query` constant that includes pagination, fields, filters, sorting, and related resource inclusion.

- **Bug Fixes**
  - Improved error handling and validation feedback for sorting and include parameters.

- **Documentation**
  - Updated the README to include examples of using query helpers for better clarity.

- **Tests**
  - Added a comprehensive suite of unit tests for the `createInclude` function to ensure robust validation.

- **Chores**
  - Updated configuration files and package scripts for improved functionality.