### PR TITLE
feat: add execution-context package

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Clipboard Health's core libraries and utilities. See individual package `README`
 - [contract-core](./packages/contract-core/README.md): Shared Zod schemas for Clipboard Health's contracts.
 - [eslint-config](./packages/eslint-config/README.md): Our ESLint configuration.
 - [example-nestjs](./packages/example-nestjs/README.md): A NestJS application using our libraries, primarily for end-to-end testing.
+- [execution-context](./packages/execution-context/README.md):
 - [json-api](./packages/json-api/README.md): TypeScript-friendly utilities for adhering to the JSON:API specification.
 - [json-api-nestjs](./packages/json-api-nestjs/README.md): TypeScript-friendly utilities for adhering to the JSON:API specification with NestJS.
 - [nx-plugin](./packages/nx-plugin/README.md): An Nx plugin with generators to manage libraries and applications.

--- a/packages/execution-context/.eslintrc.json
+++ b/packages/execution-context/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "parserOptions": {
+    "project": "tsconfig.lint.json",
+    "tsconfigRootDir": "packages/execution-context"
+  }
+}

--- a/packages/execution-context/README.md
+++ b/packages/execution-context/README.md
@@ -1,0 +1,79 @@
+# @clipboard-health/execution-context <!-- omit from toc -->
+
+`ExecutionContext` is a lightweight Node.js package built with TypeScript that leverages `AsyncLocalStorage` to create a statically available context parallel to any execution. It provides a reliable, thread-safe context for attaching and accessing metadata throughout the lifecycle of an execution, such as API requests, background jobs, or message consumers. This allows various parts of your application to communicate and share metadata without needing to explicitly pass context objects.
+
+### Features
+
+- **Scoped Contexts**: Attach data to a context that is specific to each execution scope.
+- **Static Access**: Access context data statically anywhere in the codebase within an active execution.
+- **Metadata Aggregation**: Store and retrieve metadata across the lifespan of an execution, ideal for logging, tracing, and other observability tasks.
+
+## Table of Contents <!-- omit from toc -->
+
+- [Install](#install)
+- [Usage](#usage)
+- [Local development commands](#local-development-commands)
+
+## Install
+
+```bash
+npm install @clipboard-health/execution-context
+```
+
+## Usage
+
+This example demonstrates how to create a logging context, accumulate metadata from various function calls, and then log a single message containing all the gathered metadata.
+
+```typescript
+import {
+  ContextStore,
+  newExecutionContext,
+  addMetadataToLocalContext,
+} from "@clipboard-health/execution-context";
+
+async function processRequest() {
+  // Start a logging context for this request
+  await ContextStore.withContext(newExecutionContext("context-name"), async () => {
+    const context = ContextStore.getContext();
+
+    try {
+      // Add metadata from the current function
+      addMetadataToLocalContext({ userId: "1" });
+
+      // Simulate calling other functions that add their own context metadata
+      callFunctionThatAddsContext();
+      callFunctionThatCallsAnotherFunctionThatAddsContext();
+
+      // Log the successful processing event with accumulated metadata
+      console.log("event=MessageProcessed", { ...context?.metadata });
+    } catch (error) {
+      // Capture and log error metadata if something goes wrong
+      addMetadataToLocalContext({ errorMessage: error.message });
+      console.error("event=MessageProcessed", { ...context?.metadata });
+    }
+  });
+}
+
+// Example function that adds its own metadata to the current context
+function callFunctionThatAddsContext() {
+  addMetadataToLocalContext({ operation: "dataFetch", status: "success" });
+}
+
+// Example function that calls another function, both adding their own metadata
+function callFunctionThatCallsAnotherFunctionThatAddsContext() {
+  addMetadataToLocalContext({ operation: "validate", validationStep: "pre-check" });
+  callAnotherFunctionThatAddsContext();
+}
+
+function callAnotherFunctionThatAddsContext() {
+  addMetadataToLocalContext({
+    operation: "validate",
+    validationStep: "post-check",
+    result: "passed",
+  });
+}
+```
+
+## Local development commands
+
+See [`package.json`](./package.json) `scripts` for a list of commands.

--- a/packages/execution-context/jest.config.ts
+++ b/packages/execution-context/jest.config.ts
@@ -1,0 +1,19 @@
+export default {
+  coverageDirectory: "../../coverage/packages/execution-context",
+  coveragePathIgnorePatterns: [],
+  coverageThreshold: {
+    global: {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+  },
+  displayName: "execution-context",
+  moduleFileExtensions: ["ts", "js"],
+  preset: "../../jest.preset.js",
+  testEnvironment: "node",
+  transform: {
+    "^.+\\.[tj]s$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.spec.json" }],
+  },
+};

--- a/packages/execution-context/package.json
+++ b/packages/execution-context/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@clipboard-health/execution-context",
+  "description": "",
+  "version": "0.0.0",
+  "dependencies": {
+    "tslib": "2.8.0"
+  },
+  "keywords": [],
+  "license": "MIT",
+  "main": "./src/index.js",
+  "publishConfig": {
+    "access": "restricted"
+  },
+  "type": "commonjs",
+  "typings": "./src/index.d.ts"
+}

--- a/packages/execution-context/project.json
+++ b/packages/execution-context/project.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "execution-context",
+  "projectType": "library",
+  "sourceRoot": "packages/execution-context/src",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "options": {
+        "assets": ["packages/execution-context/*.md"],
+        "main": "packages/execution-context/src/index.js",
+        "outputPath": "dist/packages/execution-context",
+        "tsConfig": "packages/execution-context/tsconfig.lib.json"
+      },
+      "outputs": ["{options.outputPath}"]
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "options": {
+        "lintFilePatterns": ["packages/execution-context/**/*.[jt]s"],
+        "maxWarnings": 0
+      },
+      "outputs": ["{options.outputFile}"]
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "options": {
+        "jestConfig": "packages/execution-context/jest.config.ts"
+      }
+    }
+  }
+}

--- a/packages/execution-context/src/index.ts
+++ b/packages/execution-context/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./lib/contextStore";
+export * from "./types/global";
+export * from "./types/types";

--- a/packages/execution-context/src/lib/contextStore.spec.ts
+++ b/packages/execution-context/src/lib/contextStore.spec.ts
@@ -1,0 +1,44 @@
+import {
+  addMetadataToLocalContext,
+  addToMetadataList,
+  ContextStore,
+  newExecutionContext,
+} from "./contextStore";
+
+const addMetadataIfContextIsPresent = () => {
+  addMetadataToLocalContext({
+    key1: "value1",
+    key2: "value2",
+  });
+  addToMetadataList("list", { listKey: "listValue" });
+  addToMetadataList("list", { listKey: "listValue" });
+};
+
+describe("Context Store", () => {
+  it("should create a context that lives throughout the execution of a thread", async () => {
+    await ContextStore.withContext(newExecutionContext("test"), async () => {
+      addMetadataIfContextIsPresent();
+      const context = ContextStore.getContext();
+
+      expect(context?.metadata).toEqual({
+        key1: "value1",
+        key2: "value2",
+        list: [{ listKey: "listValue" }, { listKey: "listValue" }],
+      });
+    });
+  });
+
+  it("should not add anything but should not throw an error if there is no context", () => {
+    addMetadataIfContextIsPresent();
+    const context = ContextStore.getContext();
+    expect(context).toBeUndefined();
+  });
+
+  it("should throw exception if the underlying function throws one", async () => {
+    await expect(
+      ContextStore.withContext(newExecutionContext("test"), async () => {
+        throw new Error("testing error");
+      }),
+    ).rejects.toThrow("testing error");
+  });
+});

--- a/packages/execution-context/src/lib/contextStore.ts
+++ b/packages/execution-context/src/lib/contextStore.ts
@@ -1,0 +1,75 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+import { type ExecutionContext } from "../types/types";
+
+globalThis.threadLocalStorage ||= new AsyncLocalStorage();
+
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+export class ContextStore {
+  static getStorage(): AsyncLocalStorage<ExecutionContext> {
+    return globalThis.threadLocalStorage;
+  }
+
+  public static getContext(): ExecutionContext | undefined {
+    return ContextStore.getStorage().getStore();
+  }
+
+  /**
+   * This is the function that essentially wraps a call with a context object.
+   *
+   * If you want to make use of this thread-local context then wrap your function call with
+   * `withContext` and within it you'll be able to use the `ContextStore` and its utility functions
+   *
+   * @param context - The context object that will be accessible anywhere in the execution.
+   * @param function_ - The function that will have a context available to it.
+   */
+  public static async withContext<T = void>(
+    context: ExecutionContext,
+    function_: () => Promise<T>,
+  ): Promise<T> {
+    return await new Promise((resolve, reject) => {
+      ContextStore.getStorage().run(context, () => {
+        function_().then(resolve).catch(reject);
+      });
+    });
+  }
+}
+
+/**
+ * This function is simply a convenience to initialize an empty context object
+ * @param source - The class/service that initializes the context
+ */
+export function newExecutionContext(source: string): ExecutionContext {
+  return {
+    source,
+    metadata: {},
+  };
+}
+
+/**
+ * A utility function that will add metadata to the current context
+ * @param metadata - the metadata (key-value pair), to be added to the context
+ */
+export function addMetadataToLocalContext(metadata: Record<string, unknown>): void {
+  const context = ContextStore.getContext();
+  if (context) {
+    context.metadata = { ...context.metadata, ...metadata };
+  }
+}
+
+function getMetadataListByKey(key: string): unknown[] {
+  const context = ContextStore.getContext();
+  if (context?.metadata && key in context.metadata) {
+    const metadataForKey = context.metadata[key];
+    if (Array.isArray(metadataForKey)) {
+      return metadataForKey;
+    }
+  }
+
+  return [];
+}
+
+export function addToMetadataList(key: string, metadata: Record<string, unknown>): void {
+  const metadataList = [...getMetadataListByKey(key), metadata];
+  addMetadataToLocalContext({ [key]: metadataList });
+}

--- a/packages/execution-context/src/types/global.d.ts
+++ b/packages/execution-context/src/types/global.d.ts
@@ -1,0 +1,8 @@
+import { type AsyncLocalStorage } from "node:async_hooks";
+
+import { type ExecutionContext } from "./types";
+
+declare global {
+  // eslint-disable-next-line vars-on-top, no-var
+  var threadLocalStorage: AsyncLocalStorage<ExecutionContext>;
+}

--- a/packages/execution-context/src/types/types.ts
+++ b/packages/execution-context/src/types/types.ts
@@ -1,0 +1,44 @@
+/**
+ * This interface contains the common attributes that we often want to know about
+ * in any execution within our domain.
+ */
+interface KnownMetadata {
+  /**
+   * the id of the shift being referenced in the execution
+   */
+  shiftId?: string;
+
+  /**
+   * @deprecated use `workerId` instead.
+   */
+  agentId?: string;
+
+  /**
+   * the id of the worker being referenced in the execution
+   */
+  workerId?: string;
+
+  /**
+   * @deprecated use `workplaceId` instead.
+   */
+  facilityId?: string;
+
+  /**
+   * the id of the workplace being referenced in the execution
+   */
+  workplaceId?: string;
+}
+
+export type Metadata = KnownMetadata & Record<string, unknown>;
+
+export interface ExecutionContext {
+  /**
+   * the class/file/service that originated the thread that owns this context
+   */
+  source: string;
+  /**
+   * everything added to the metadata will eventually be logged at the end of
+   * the execution context
+   */
+  metadata: Metadata;
+}

--- a/packages/execution-context/tsconfig.json
+++ b/packages/execution-context/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.lint.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/execution-context/tsconfig.lib.json
+++ b/packages/execution-context/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/packages/execution-context/tsconfig.lint.json
+++ b/packages/execution-context/tsconfig.lint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  },
+  "include": ["."]
+}

--- a/packages/execution-context/tsconfig.spec.json
+++ b/packages/execution-context/tsconfig.spec.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  },
+  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/packages/execution-context/typedoc.json
+++ b/packages/execution-context/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,6 +13,7 @@
       "@clipboard-health/config": ["packages/config/src/index.ts"],
       "@clipboard-health/contract-core": ["packages/contract-core/src/index.ts"],
       "@clipboard-health/eslint-config": ["packages/eslint-config/src/index.js"],
+      "@clipboard-health/execution-context": ["packages/execution-context/src/index.ts"],
       "@clipboard-health/json-api": ["packages/json-api/src/index.ts"],
       "@clipboard-health/json-api-nestjs": ["packages/json-api-nestjs/src/index.ts"],
       "@clipboard-health/nx-plugin": ["packages/nx-plugin/src/index.ts"],


### PR DESCRIPTION
Summary
===
<!--
- For expectations after PR approval and merge, see the CONTRIBUTING.md file
-->

Creating the execution context package. This package already exists on `core-utils` as `context-logger`. But we decided to move it to `core-utils` without any logging dependencies. This will be the cornerstone of our metadata aggregation solution for consolidated logging standards

Changes
---
- Created the `execution-context` package

Videos/screenshots
---
