### PR TITLE
feat: add pipe, flatMap, map, getOrElse, and match

### DIFF
--- a/.knip.jsonc
+++ b/.knip.jsonc
@@ -7,6 +7,7 @@
     "packages/json-api/examples/**/*.ts",
     "packages/rules-engine/examples/**/*.ts",
     "packages/testing-core/examples/**/*.ts",
+    "packages/util-typescript/examples/**/*.ts",
   ],
   "ignore": ["**/jest.config.ts", "**/generators/**/schema.d.ts", "**/webpack.*.js"],
   "ignoreBinaries": [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -22991,7 +22991,7 @@
     },
     "packages/config": {
       "name": "@clipboard-health/config",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "decamelize": "5.0.1",
@@ -23004,21 +23004,32 @@
         "@clipboard-health/contract-core": "0.3.0"
       }
     },
+    "packages/config/node_modules/@clipboard-health/contract-core": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@clipboard-health/contract-core/-/contract-core-0.3.0.tgz",
+      "integrity": "sha512-Koz/azLBuK2YRky2lIcyoVPyssk8STyZsm+Alrkj0GRkPVg8O0+56IiDwoXbEknCIjAJTelV28NFZuC+qmvxig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.0",
+        "zod": "3.23.8"
+      }
+    },
     "packages/contract-core": {
       "name": "@clipboard-health/contract-core",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.0",
         "zod": "3.23.8"
       },
       "devDependencies": {
-        "@clipboard-health/testing-core": "0.3.0"
+        "@clipboard-health/testing-core": "0.3.1"
       }
     },
     "packages/eslint-config": {
       "name": "@clipboard-health/eslint-config",
-      "version": "4.10.0",
+      "version": "4.10.1",
       "license": "MIT",
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": "^7",
@@ -23065,20 +23076,53 @@
         "webpack-cli": "5.1.4"
       }
     },
-    "packages/example-nestjs/node_modules/@clipboard-health/json-api-nestjs/node_modules/@clipboard-health/contract-core": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@clipboard-health/contract-core/-/contract-core-0.1.1.tgz",
-      "integrity": "sha512-ZDdqFQkrG9w6EossNxLTdo4KF2fVjhAjGO6jNZs8L/FeBFGSbnPwSWGBh2xnfpiweNuvQ5VCSlkRrWsUL0/fzA==",
-      "extraneous": true,
+    "packages/example-nestjs/node_modules/@clipboard-health/contract-core": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@clipboard-health/contract-core/-/contract-core-0.3.0.tgz",
+      "integrity": "sha512-Koz/azLBuK2YRky2lIcyoVPyssk8STyZsm+Alrkj0GRkPVg8O0+56IiDwoXbEknCIjAJTelV28NFZuC+qmvxig==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.0",
         "zod": "3.23.8"
       }
     },
+    "packages/example-nestjs/node_modules/@clipboard-health/json-api-nestjs": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@clipboard-health/json-api-nestjs/-/json-api-nestjs-0.7.0.tgz",
+      "integrity": "sha512-5ofQC+FV4KWISiswSs8FkFd78SzMTtr5uOYnXDNZAk+J4Jv8R/oeSWnjPcDKePy6K+diO4jl2w5Ymixv4q7UWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@clipboard-health/contract-core": "0.2.0",
+        "tslib": "2.8.0",
+        "type-fest": "4.26.1",
+        "zod": "3.23.8"
+      }
+    },
+    "packages/example-nestjs/node_modules/@clipboard-health/json-api-nestjs/node_modules/@clipboard-health/contract-core": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@clipboard-health/contract-core/-/contract-core-0.2.0.tgz",
+      "integrity": "sha512-albtoM2k9tTed6yJ281yV7fyqgOEr5hGOJ/Xj/cLUKOklovEn9bE9nUZNtWKbFlDiqeUMUNwnt4J9d6vXfNAgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.0",
+        "zod": "3.23.8"
+      }
+    },
+    "packages/example-nestjs/node_modules/type-fest": {
+      "version": "4.26.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
+      "integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "packages/json-api": {
       "name": "@clipboard-health/json-api",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.0"
@@ -23086,7 +23130,7 @@
     },
     "packages/json-api-nestjs": {
       "name": "@clipboard-health/json-api-nestjs",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "@clipboard-health/contract-core": "0.3.0",
@@ -23095,7 +23139,17 @@
         "zod": "3.23.8"
       },
       "devDependencies": {
-        "@clipboard-health/testing-core": "0.3.0"
+        "@clipboard-health/testing-core": "0.3.1"
+      }
+    },
+    "packages/json-api-nestjs/node_modules/@clipboard-health/contract-core": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@clipboard-health/contract-core/-/contract-core-0.3.0.tgz",
+      "integrity": "sha512-Koz/azLBuK2YRky2lIcyoVPyssk8STyZsm+Alrkj0GRkPVg8O0+56IiDwoXbEknCIjAJTelV28NFZuC+qmvxig==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.0",
+        "zod": "3.23.8"
       }
     },
     "packages/json-api-nestjs/node_modules/type-fest": {
@@ -23112,7 +23166,7 @@
     },
     "packages/nx-plugin": {
       "name": "@clipboard-health/nx-plugin",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@nx/devkit": "20.0.1",
@@ -23122,7 +23176,7 @@
     },
     "packages/rules-engine": {
       "name": "@clipboard-health/rules-engine",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.0",
@@ -23143,17 +23197,17 @@
     },
     "packages/testing-core": {
       "name": "@clipboard-health/testing-core",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "@clipboard-health/util-typescript": "0.1.0",
+        "@clipboard-health/util-typescript": "0.1.1",
         "tslib": "2.8.0",
         "zod": "3.23.8"
       }
     },
     "packages/util-typescript": {
       "name": "@clipboard-health/util-typescript",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.0"

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -58,9 +58,7 @@ dotenv.config();
  * **IMPORTANT**: To avoid runtime errors:
  * 1. Environment variables are strings, so use `z.coerce` Zod types for those you plan to override.
  *    Note that `z.coerce.boolean()` coerces any truthy value to `true`. To restrict to `"true" |
- *    "false"`, use the
- *    {@link https://github.com/ClipboardHealth/core-utils/blob/main/packages/contract-core/src/lib/schemas/booleanString.ts
- *    `booleanString` schema} from `@clipboard-health/contract-core`.
+ *    "false"`, use the `booleanString` schema from `@clipboard-health/contract-core`.
  * 2. The resulting configuration is deeply frozen and will throw a runtime error if you attempt to
  *    modify it. The actual return type is `ReadonlyDeep<SchemaT>`, but the library returns a
  *    `Readonly<SchemaT>` because the former prevents clients from passing configuration values to

--- a/packages/config/src/lib/createConfig.ts
+++ b/packages/config/src/lib/createConfig.ts
@@ -31,9 +31,7 @@ dotenv.config();
  * **IMPORTANT**: To avoid runtime errors:
  * 1. Environment variables are strings, so use `z.coerce` Zod types for those you plan to override.
  *    Note that `z.coerce.boolean()` coerces any truthy value to `true`. To restrict to `"true" |
- *    "false"`, use the
- *    {@link https://github.com/ClipboardHealth/core-utils/blob/main/packages/contract-core/src/lib/schemas/booleanString.ts
- *    `booleanString` schema} from `@clipboard-health/contract-core`.
+ *    "false"`, use the `booleanString` schema from `@clipboard-health/contract-core`.
  * 2. The resulting configuration is deeply frozen and will throw a runtime error if you attempt to
  *    modify it. The actual return type is `ReadonlyDeep<SchemaT>`, but the library returns a
  *    `Readonly<SchemaT>` because the former prevents clients from passing configuration values to

--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -77,6 +77,9 @@ module.exports = {
     // Too many false positives
     "@typescript-eslint/naming-convention": "off",
 
+    // Makes functional programming difficult
+    "@typescript-eslint/no-unsafe-call": "off",
+
     // Prefer an escape hatch instead of an outright ban
     "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
     "@typescript-eslint/return-await": ["error", "always"],
@@ -192,6 +195,9 @@ module.exports = {
 
     // Sort imports and exports
     "simple-import-sort/imports": "warn",
+
+    // Makes functional programming difficult
+    "unicorn/no-array-callback-reference": "off",
 
     // "Better readability" is subjective
     "unicorn/no-array-for-each": "off",

--- a/packages/eslint-config/src/index.spec.ts
+++ b/packages/eslint-config/src/index.spec.ts
@@ -81,6 +81,9 @@ describe("eslint-config", () => {
         // Too many false positives
         "@typescript-eslint/naming-convention": "off",
 
+        // Makes functional programming difficult
+        "@typescript-eslint/no-unsafe-call": "off",
+
         // Prefer an escape hatch instead of an outright ban
         "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
         "@typescript-eslint/return-await": ["error", "always"],
@@ -196,6 +199,9 @@ describe("eslint-config", () => {
 
         // Sort imports and exports
         "simple-import-sort/imports": "warn",
+
+        // Makes functional programming difficult
+        "unicorn/no-array-callback-reference": "off",
 
         // "Better readability" is subjective
         "unicorn/no-array-for-each": "off",

--- a/packages/testing-core/README.md
+++ b/packages/testing-core/README.md
@@ -62,14 +62,14 @@ ok(length === 2);
 import { ok } from "node:assert/strict";
 
 import { expectToBeLeft } from "@clipboard-health/testing-core";
-import { type Either, left, right } from "@clipboard-health/util-typescript";
+import { either as E } from "@clipboard-health/util-typescript";
 
-function divide(numerator: number, denominator: number): Either<string, number> {
+function divide(numerator: number, denominator: number): E.Either<string, number> {
   if (denominator === 0) {
-    return left("Cannot divide by zero");
+    return E.left("Cannot divide by zero");
   }
 
-  return right(numerator / denominator);
+  return E.right(numerator / denominator);
 }
 
 const value = divide(10, 0);
@@ -87,14 +87,14 @@ ok(value.left === "Cannot divide by zero");
 import { ok } from "node:assert/strict";
 
 import { expectToBeRight } from "@clipboard-health/testing-core";
-import { type Either, left, right } from "@clipboard-health/util-typescript";
+import { either as E } from "@clipboard-health/util-typescript";
 
-function divide(numerator: number, denominator: number): Either<string, number> {
+function divide(numerator: number, denominator: number): E.Either<string, number> {
   if (denominator === 0) {
-    return left("Cannot divide by zero");
+    return E.left("Cannot divide by zero");
   }
 
-  return right(numerator / denominator);
+  return E.right(numerator / denominator);
 }
 
 const value = divide(10, 2);

--- a/packages/testing-core/examples/expectToBeLeft.ts
+++ b/packages/testing-core/examples/expectToBeLeft.ts
@@ -1,14 +1,14 @@
 import { ok } from "node:assert/strict";
 
 import { expectToBeLeft } from "@clipboard-health/testing-core";
-import { type Either, left, right } from "@clipboard-health/util-typescript";
+import { either as E } from "@clipboard-health/util-typescript";
 
-function divide(numerator: number, denominator: number): Either<string, number> {
+function divide(numerator: number, denominator: number): E.Either<string, number> {
   if (denominator === 0) {
-    return left("Cannot divide by zero");
+    return E.left("Cannot divide by zero");
   }
 
-  return right(numerator / denominator);
+  return E.right(numerator / denominator);
 }
 
 const value = divide(10, 0);

--- a/packages/testing-core/examples/expectToBeRight.ts
+++ b/packages/testing-core/examples/expectToBeRight.ts
@@ -1,14 +1,14 @@
 import { ok } from "node:assert/strict";
 
 import { expectToBeRight } from "@clipboard-health/testing-core";
-import { type Either, left, right } from "@clipboard-health/util-typescript";
+import { either as E } from "@clipboard-health/util-typescript";
 
-function divide(numerator: number, denominator: number): Either<string, number> {
+function divide(numerator: number, denominator: number): E.Either<string, number> {
   if (denominator === 0) {
-    return left("Cannot divide by zero");
+    return E.left("Cannot divide by zero");
   }
 
-  return right(numerator / denominator);
+  return E.right(numerator / denominator);
 }
 
 const value = divide(10, 2);

--- a/packages/testing-core/src/lib/expectToBeDefined.ts
+++ b/packages/testing-core/src/lib/expectToBeDefined.ts
@@ -1,4 +1,4 @@
-import { ok } from "node:assert";
+import { ok } from "node:assert/strict";
 
 /**
  * Asserts and narrows the type for defined values.

--- a/packages/testing-core/src/lib/expectToBeLeft.spec.ts
+++ b/packages/testing-core/src/lib/expectToBeLeft.spec.ts
@@ -1,17 +1,17 @@
-import { type Either, left, right } from "@clipboard-health/util-typescript";
+import { either as E } from "@clipboard-health/util-typescript";
 
 import { expectToBeLeft } from "./expectToBeLeft";
 
 describe("expectToBeLeft", () => {
   interface TestCase {
-    input: Either<string, number> | undefined;
+    input: E.Either<string, number> | undefined;
     name: string;
   }
 
   it.each<TestCase>([
     {
       name: "passes for Left",
-      input: left("error"),
+      input: E.left("error"),
     },
   ])("$name", ({ input }) => {
     expect(() => {
@@ -22,7 +22,7 @@ describe("expectToBeLeft", () => {
   it.each<TestCase>([
     {
       name: "throws for Right",
-      input: right(123),
+      input: E.right(123),
     },
     {
       name: "throws for undefined",
@@ -35,7 +35,7 @@ describe("expectToBeLeft", () => {
   });
 
   it("narrows type", () => {
-    const actual = left("error");
+    const actual = E.left("error");
 
     expectToBeLeft(actual);
 

--- a/packages/testing-core/src/lib/expectToBeLeft.ts
+++ b/packages/testing-core/src/lib/expectToBeLeft.ts
@@ -1,9 +1,14 @@
-import { ok } from "node:assert";
+import { ok } from "node:assert/strict";
 
 import { either as E } from "@clipboard-health/util-typescript";
 
 import { expectToBeDefined } from "./expectToBeDefined";
 
+/**
+ * Asserts and narrows the type of the provided Either value to Left.
+ * @param value - The Either value to check
+ * @throws {AssertionError} If the value is undefined or not a Left
+ */
 export function expectToBeLeft<E, A>(
   value: E.Either<E, A> | undefined,
 ): asserts value is E.Left<E> {

--- a/packages/testing-core/src/lib/expectToBeLeft.ts
+++ b/packages/testing-core/src/lib/expectToBeLeft.ts
@@ -1,10 +1,12 @@
 import { ok } from "node:assert";
 
-import { type Either, isLeft, type Left } from "@clipboard-health/util-typescript";
+import { either as E } from "@clipboard-health/util-typescript";
 
 import { expectToBeDefined } from "./expectToBeDefined";
 
-export function expectToBeLeft<E, A>(value: Either<E, A> | undefined): asserts value is Left<E> {
+export function expectToBeLeft<E, A>(
+  value: E.Either<E, A> | undefined,
+): asserts value is E.Left<E> {
   expectToBeDefined(value);
-  ok(isLeft(value));
+  ok(E.isLeft(value));
 }

--- a/packages/testing-core/src/lib/expectToBeNone.spec.ts
+++ b/packages/testing-core/src/lib/expectToBeNone.spec.ts
@@ -1,17 +1,17 @@
-import { isNone, none, type Option, some } from "@clipboard-health/util-typescript";
+import { option as O } from "@clipboard-health/util-typescript";
 
 import { expectToBeNone } from "./expectToBeNone";
 
 describe("expectToBeNone", () => {
   interface TestCase {
-    input: Option<number> | undefined;
+    input: O.Option<number> | undefined;
     name: string;
   }
 
   it.each<TestCase>([
     {
       name: "passes for None",
-      input: none,
+      input: O.none,
     },
   ])("$name", ({ input }) => {
     expect(() => {
@@ -22,7 +22,7 @@ describe("expectToBeNone", () => {
   it.each<TestCase>([
     {
       name: "throws for Some",
-      input: some(123),
+      input: O.some(123),
     },
     {
       name: "throws for undefined",
@@ -35,12 +35,12 @@ describe("expectToBeNone", () => {
   });
 
   it("narrows type", () => {
-    const actual = none;
+    const actual = O.none;
 
     expectToBeNone(actual);
 
     // Narrowed to None
     expect(actual.isSome).toBe(false);
-    expect(isNone(actual)).toBe(true);
+    expect(O.isNone(actual)).toBe(true);
   });
 });

--- a/packages/testing-core/src/lib/expectToBeNone.ts
+++ b/packages/testing-core/src/lib/expectToBeNone.ts
@@ -1,10 +1,10 @@
 import { ok } from "node:assert";
 
-import { isNone, type None, type Option } from "@clipboard-health/util-typescript";
+import { option as O } from "@clipboard-health/util-typescript";
 
 import { expectToBeDefined } from "./expectToBeDefined";
 
-export function expectToBeNone<A>(value: Option<A> | undefined): asserts value is None {
+export function expectToBeNone<A>(value: O.Option<A> | undefined): asserts value is O.None {
   expectToBeDefined(value);
-  ok(isNone(value));
+  ok(O.isNone(value));
 }

--- a/packages/testing-core/src/lib/expectToBeNone.ts
+++ b/packages/testing-core/src/lib/expectToBeNone.ts
@@ -1,9 +1,14 @@
-import { ok } from "node:assert";
+import { ok } from "node:assert/strict";
 
 import { option as O } from "@clipboard-health/util-typescript";
 
 import { expectToBeDefined } from "./expectToBeDefined";
 
+/**
+ * Asserts and narrows the type of the provided Option value to None.
+ * @param value - The Option value to check
+ * @throws {AssertionError} If the value is undefined or not a None
+ */
 export function expectToBeNone<A>(value: O.Option<A> | undefined): asserts value is O.None {
   expectToBeDefined(value);
   ok(O.isNone(value));

--- a/packages/testing-core/src/lib/expectToBeRight.spec.ts
+++ b/packages/testing-core/src/lib/expectToBeRight.spec.ts
@@ -1,17 +1,17 @@
-import { type Either, left, right } from "@clipboard-health/util-typescript";
+import { either as E } from "@clipboard-health/util-typescript";
 
 import { expectToBeRight } from "./expectToBeRight";
 
 describe("expectToBeRight", () => {
   interface TestCase {
-    input: Either<string, number> | undefined;
+    input: E.Either<string, number> | undefined;
     name: string;
   }
 
   it.each<TestCase>([
     {
       name: "passes for Right",
-      input: right(123),
+      input: E.right(123),
     },
   ])("$name", ({ input }) => {
     expect(() => {
@@ -22,7 +22,7 @@ describe("expectToBeRight", () => {
   it.each<TestCase>([
     {
       name: "throws for Left",
-      input: left("error"),
+      input: E.left("error"),
     },
     {
       name: "throws for undefined",
@@ -35,7 +35,7 @@ describe("expectToBeRight", () => {
   });
 
   it("narrows type", () => {
-    const actual = right(123);
+    const actual = E.right(123);
 
     expectToBeRight(actual);
 

--- a/packages/testing-core/src/lib/expectToBeRight.ts
+++ b/packages/testing-core/src/lib/expectToBeRight.ts
@@ -1,10 +1,12 @@
 import { ok } from "node:assert";
 
-import { type Either, isRight, type Right } from "@clipboard-health/util-typescript";
+import { either as E } from "@clipboard-health/util-typescript";
 
 import { expectToBeDefined } from "./expectToBeDefined";
 
-export function expectToBeRight<A, E>(value: Either<E, A> | undefined): asserts value is Right<A> {
+export function expectToBeRight<A, E>(
+  value: E.Either<E, A> | undefined,
+): asserts value is E.Right<A> {
   expectToBeDefined(value);
-  ok(isRight(value));
+  ok(E.isRight(value));
 }

--- a/packages/testing-core/src/lib/expectToBeRight.ts
+++ b/packages/testing-core/src/lib/expectToBeRight.ts
@@ -1,9 +1,14 @@
-import { ok } from "node:assert";
+import { ok } from "node:assert/strict";
 
 import { either as E } from "@clipboard-health/util-typescript";
 
 import { expectToBeDefined } from "./expectToBeDefined";
 
+/**
+ * Asserts and narrows the type of the provided Either value to Right.
+ * @param value - The Either value to check
+ * @throws {AssertionError} If the value is undefined or not a Right
+ */
 export function expectToBeRight<A, E>(
   value: E.Either<E, A> | undefined,
 ): asserts value is E.Right<A> {

--- a/packages/testing-core/src/lib/expectToBeSafeParseError.ts
+++ b/packages/testing-core/src/lib/expectToBeSafeParseError.ts
@@ -1,4 +1,4 @@
-import { ok } from "node:assert";
+import { ok } from "node:assert/strict";
 
 import { type SafeParseError, type SafeParseReturnType } from "zod";
 
@@ -6,7 +6,7 @@ import { expectToBeDefined } from "./expectToBeDefined";
 
 /**
  * Asserts and narrows the type for Zod SafeParseReturnType to a SafeParseError.
- *
+ * @param value - The SafeParseReturnType value to check
  * @throws {AssertionError} for SafeParseSuccess.
  */
 export function expectToBeSafeParseError<Input, Output>(

--- a/packages/testing-core/src/lib/expectToBeSafeParseSuccess.ts
+++ b/packages/testing-core/src/lib/expectToBeSafeParseSuccess.ts
@@ -1,4 +1,4 @@
-import { ok } from "node:assert";
+import { ok } from "node:assert/strict";
 
 import { type SafeParseReturnType, type SafeParseSuccess } from "zod";
 
@@ -6,7 +6,7 @@ import { expectToBeDefined } from "./expectToBeDefined";
 
 /**
  * Asserts and narrows the type for Zod SafeParseReturnType to a SafeParseSuccess.
- *
+ * @param value - The SafeParseReturnType value to check
  * @throws {AssertionError} for SafeParseError.
  */
 export function expectToBeSafeParseSuccess<Input, Output>(

--- a/packages/testing-core/src/lib/expectToBeSome.spec.ts
+++ b/packages/testing-core/src/lib/expectToBeSome.spec.ts
@@ -1,17 +1,17 @@
-import { none, type Option, some } from "@clipboard-health/util-typescript";
+import { option as O } from "@clipboard-health/util-typescript";
 
 import { expectToBeSome } from "./expectToBeSome";
 
 describe("expectToBeSome", () => {
   interface TestCase {
-    input: Option<number> | undefined;
+    input: O.Option<number> | undefined;
     name: string;
   }
 
   it.each<TestCase>([
     {
       name: "passes for Some",
-      input: some(123),
+      input: O.some(123),
     },
   ])("$name", ({ input }) => {
     expect(() => {
@@ -22,7 +22,7 @@ describe("expectToBeSome", () => {
   it.each<TestCase>([
     {
       name: "throws for None",
-      input: none,
+      input: O.none,
     },
     {
       name: "throws for undefined",
@@ -35,7 +35,7 @@ describe("expectToBeSome", () => {
   });
 
   it("narrows type", () => {
-    const actual = some(123);
+    const actual = O.some(123);
 
     expectToBeSome(actual);
 

--- a/packages/testing-core/src/lib/expectToBeSome.ts
+++ b/packages/testing-core/src/lib/expectToBeSome.ts
@@ -1,9 +1,14 @@
-import { ok } from "node:assert";
+import { ok } from "node:assert/strict";
 
 import { option as O } from "@clipboard-health/util-typescript";
 
 import { expectToBeDefined } from "./expectToBeDefined";
 
+/**
+ * Asserts and narrows the type of the provided Option value to Some.
+ * @param value - The Option value to check
+ * @throws {AssertionError} If the value is undefined or not Some
+ */
 export function expectToBeSome<A>(value: O.Option<A> | undefined): asserts value is O.Some<A> {
   expectToBeDefined(value);
   ok(O.isSome(value));

--- a/packages/testing-core/src/lib/expectToBeSome.ts
+++ b/packages/testing-core/src/lib/expectToBeSome.ts
@@ -1,10 +1,10 @@
 import { ok } from "node:assert";
 
-import { isSome, type Option, type Some } from "@clipboard-health/util-typescript";
+import { option as O } from "@clipboard-health/util-typescript";
 
 import { expectToBeDefined } from "./expectToBeDefined";
 
-export function expectToBeSome<A>(value: Option<A> | undefined): asserts value is Some<A> {
+export function expectToBeSome<A>(value: O.Option<A> | undefined): asserts value is O.Some<A> {
   expectToBeDefined(value);
-  ok(isSome(value));
+  ok(O.isSome(value));
 }

--- a/packages/util-typescript/README.md
+++ b/packages/util-typescript/README.md
@@ -6,6 +6,7 @@ TypeScript utilities.
 
 - [Install](#install)
 - [Usage](#usage)
+  - [Functional utilities](#functional-utilities)
 - [Local development commands](#local-development-commands)
 
 ## Install
@@ -15,6 +16,90 @@ npm install @clipboard-health/util-typescript
 ```
 
 ## Usage
+
+See `./src/lib` for each utility.
+
+### Functional utilities
+
+<!-- prettier-ignore -->
+```ts
+// ./examples/pipe.ts
+
+import { equal } from "node:assert/strict";
+
+import { pipe } from "@clipboard-health/util-typescript";
+
+const result = pipe(
+  "  hello world  ",
+  (s) => s.trim(),
+  (s) => s.split(" "),
+  (array) => array.map((word) => word.charAt(0).toUpperCase() + word.slice(1)),
+  (array) => array.join(" "),
+);
+
+equal(result, "Hello World");
+
+```
+
+<!-- prettier-ignore -->
+```ts
+// ./examples/option.ts
+
+import { equal } from "node:assert/strict";
+
+import { option as O, pipe } from "@clipboard-health/util-typescript";
+
+function double(n: number) {
+  return n * 2;
+}
+
+function inverse(n: number): O.Option<number> {
+  return n === 0 ? O.none : O.some(1 / n);
+}
+
+const result = pipe(
+  O.some(5),
+  O.map(double),
+  O.flatMap(inverse),
+  O.match(
+    (n) => `Result is ${n}`,
+    () => "No result",
+  ),
+);
+
+equal(result, "Result is 0.1");
+
+```
+
+<!-- prettier-ignore -->
+```ts
+// ./examples/either.ts
+
+import { equal } from "node:assert/strict";
+
+import { either as E, pipe } from "@clipboard-health/util-typescript";
+
+function double(n: number): number {
+  return n * 2;
+}
+
+function inverse(n: number): E.Either<string, number> {
+  return n === 0 ? E.left("Division by zero") : E.right(1 / n);
+}
+
+const result = pipe(
+  E.right(5),
+  E.map(double),
+  E.flatMap(inverse),
+  E.match(
+    (error) => `Error: ${error}`,
+    (result) => `Result is ${result}`,
+  ),
+);
+
+equal(result, "Result is 0.1");
+
+```
 
 ## Local development commands
 

--- a/packages/util-typescript/examples/either.ts
+++ b/packages/util-typescript/examples/either.ts
@@ -1,0 +1,23 @@
+import { equal } from "node:assert/strict";
+
+import { either as E, pipe } from "@clipboard-health/util-typescript";
+
+function double(n: number): number {
+  return n * 2;
+}
+
+function inverse(n: number): E.Either<string, number> {
+  return n === 0 ? E.left("Division by zero") : E.right(1 / n);
+}
+
+const result = pipe(
+  E.right(5),
+  E.map(double),
+  E.flatMap(inverse),
+  E.match(
+    (error) => `Error: ${error}`,
+    (result) => `Result is ${result}`,
+  ),
+);
+
+equal(result, "Result is 0.1");

--- a/packages/util-typescript/examples/option.ts
+++ b/packages/util-typescript/examples/option.ts
@@ -1,0 +1,23 @@
+import { equal } from "node:assert/strict";
+
+import { option as O, pipe } from "@clipboard-health/util-typescript";
+
+function double(n: number) {
+  return n * 2;
+}
+
+function inverse(n: number): O.Option<number> {
+  return n === 0 ? O.none : O.some(1 / n);
+}
+
+const result = pipe(
+  O.some(5),
+  O.map(double),
+  O.flatMap(inverse),
+  O.match(
+    (n) => `Result is ${n}`,
+    () => "No result",
+  ),
+);
+
+equal(result, "Result is 0.1");

--- a/packages/util-typescript/examples/pipe.ts
+++ b/packages/util-typescript/examples/pipe.ts
@@ -1,0 +1,13 @@
+import { equal } from "node:assert/strict";
+
+import { pipe } from "@clipboard-health/util-typescript";
+
+const result = pipe(
+  "  hello world  ",
+  (s) => s.trim(),
+  (s) => s.split(" "),
+  (array) => array.map((word) => word.charAt(0).toUpperCase() + word.slice(1)),
+  (array) => array.join(" "),
+);
+
+equal(result, "Hello World");

--- a/packages/util-typescript/package.json
+++ b/packages/util-typescript/package.json
@@ -11,6 +11,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "scripts": {
+    "embed": "embedme README.md"
+  },
   "type": "commonjs",
   "typings": "./src/index.d.ts"
 }

--- a/packages/util-typescript/src/index.ts
+++ b/packages/util-typescript/src/index.ts
@@ -4,7 +4,7 @@ export * from "./lib/isError";
 export * from "./lib/isNil";
 export * from "./lib/isString";
 export * as option from "./lib/option";
-export * as pipe from "./lib/pipe";
+export * from "./lib/pipe";
 export * from "./lib/stringify";
 export * from "./lib/toError";
 export * from "./lib/types";

--- a/packages/util-typescript/src/index.ts
+++ b/packages/util-typescript/src/index.ts
@@ -1,9 +1,10 @@
-export * from "./lib/either";
+export * as either from "./lib/either";
 export * from "./lib/isDefined";
 export * from "./lib/isError";
 export * from "./lib/isNil";
 export * from "./lib/isString";
-export * from "./lib/option";
+export * as option from "./lib/option";
+export * as pipe from "./lib/pipe";
 export * from "./lib/stringify";
 export * from "./lib/toError";
 export * from "./lib/types";

--- a/packages/util-typescript/src/lib/either.spec.ts
+++ b/packages/util-typescript/src/lib/either.spec.ts
@@ -1,23 +1,126 @@
-import { isLeft, isRight, type Left, left, type Right, right } from "./either";
+import * as E from "./either";
+import { pipe } from "./pipe";
 
 describe("Either", () => {
   it("left works", () => {
     const error = new Error("boom");
-    const either = left(error) as Left<Error>;
+    const either = E.left(error) as E.Left<Error>;
 
-    expect(isLeft(either)).toBe(true);
-    expect(isRight(either)).toBe(false);
+    expect(E.isLeft(either)).toBe(true);
+    expect(E.isRight(either)).toBe(false);
     expect(either.isRight).toBe(false);
     expect(either.left).toBe(error);
   });
 
   it("right works", () => {
     const value = "my-value";
-    const either = right(value) as Right<string>;
+    const either = E.right(value) as E.Right<string>;
 
-    expect(isRight(either)).toBe(true);
-    expect(isLeft(either)).toBe(false);
+    expect(E.isRight(either)).toBe(true);
+    expect(E.isLeft(either)).toBe(false);
     expect(either.isRight).toBe(true);
     expect(either.right).toBe(value);
   });
+
+  describe("map", () => {
+    it("maps Right value", () => {
+      const actual = pipe(E.right(5), E.map(double));
+      expect(actual).toEqual(E.right(10));
+    });
+
+    it("does not map Left", () => {
+      const error = new Error("boom");
+      const actual = pipe(E.left(error), E.map(double));
+      expect(actual).toEqual(E.left(error));
+    });
+  });
+
+  describe("mapLeft", () => {
+    it("maps Left value", () => {
+      const actual = pipe(E.left("boom"), E.mapLeft(addPrefix));
+      expect(actual).toEqual(E.left("Error: boom"));
+    });
+
+    it("does not map Right", () => {
+      const actual = pipe(E.right(5), E.mapLeft(addPrefix));
+      expect(actual).toEqual(E.right(5));
+    });
+  });
+
+  describe("flatMap", () => {
+    it("flatMaps Right operations", () => {
+      const actual = pipe(E.right(2), E.flatMap(inverse));
+      expect(actual).toEqual(E.right(0.5));
+    });
+
+    it("does not flatMap Left", () => {
+      const error = "Initial error";
+      const actual = pipe(E.left(error), E.flatMap(inverse));
+      expect(actual).toEqual(E.left(error));
+    });
+  });
+
+  describe("getOrElse", () => {
+    it("returns Right", () => {
+      const actual = pipe(
+        E.right(5),
+        E.getOrElse(() => 1),
+      );
+      expect(actual).toBe(5);
+    });
+
+    it("returns default for Left", () => {
+      const actual = pipe(
+        E.left("error"),
+        E.getOrElse(() => 1),
+      );
+      expect(actual).toBe(1);
+    });
+  });
+
+  describe("match", () => {
+    it("handles Right case", () => {
+      const actual = pipe(E.right(5), E.match(onLeft, onRight));
+      expect(actual).toBe("Got 5");
+    });
+
+    it("handles Left case", () => {
+      const actual = pipe(E.left("boom"), E.match(onLeft, onRight));
+      expect(actual).toBe("Error: boom");
+    });
+  });
+
+  it("works with complex pipe operations", () => {
+    const actual = pipe(
+      E.right(5),
+      E.map(double),
+      E.flatMap(inverse),
+      E.match(
+        (error) => `Error: ${error}`,
+        (result) => `Result is ${result}`,
+      ),
+    );
+
+    expect(actual).toBe("Result is 0.1");
+  });
 });
+
+function onRight(result: number) {
+  return `Got ${result}`;
+}
+
+function onLeft(error: string) {
+  return `Error: ${error}`;
+}
+
+function addPrefix(left: string) {
+  return `Error: ${left}`;
+}
+
+function double(n: number): number {
+  return n * 2;
+}
+
+function inverse(n: number): E.Either<string, number> {
+  return n === 0 ? E.left("Division by zero") : E.right(1 / n);
+}

--- a/packages/util-typescript/src/lib/either.ts
+++ b/packages/util-typescript/src/lib/either.ts
@@ -13,7 +13,7 @@ export type Right<A> = Readonly<{
  *
  * A common use case is as an alternative to {@link Option} where `Left<E>` contains useful
  * information. Convention dictates that `Left<E>` is used for failure and `Right<A>` for success.
- * To help remember, the success case is “right”; it’s the result you want.
+ * To help remember, the success case is "right"; it's the result you want.
  */
 export type Either<E, A> = Left<E> | Right<A>;
 
@@ -55,4 +55,44 @@ export function isLeft<E, A>(either: Either<E, A>): either is Left<E> {
  */
 export function isRight<E, A>(either: Either<E, A>): either is Right<A> {
   return either.isRight;
+}
+
+/**
+ * Maps over the value in a Right if it exists.
+ */
+export function map<A, B>(f: (right: A) => B): <E>(either: Either<E, A>) => Either<E, B> {
+  return (either) => (isRight(either) ? right(f(either.right)) : either);
+}
+
+/**
+ * Maps over the value in a Left if it exists.
+ */
+export function mapLeft<E, G>(f: (left: E) => G): <A>(either: Either<E, A>) => Either<G, A> {
+  return (either) => (isLeft(either) ? left(f(either.left)) : either);
+}
+
+/**
+ * Chains Either operations together.
+ */
+export function flatMap<E, A, B>(
+  f: (right: A) => Either<E, B>,
+): (either: Either<E, A>) => Either<E, B> {
+  return (either) => (isRight(either) ? f(either.right) : either);
+}
+
+/**
+ * Gets the value from a Right or returns a default.
+ */
+export function getOrElse<E, A>(onLeft: (left: E) => A): (either: Either<E, A>) => A {
+  return (either) => (isRight(either) ? either.right : onLeft(either.left));
+}
+
+/**
+ * Pattern matches on an Either, handling both Right and Left cases.
+ */
+export function match<E, A, B>(
+  onLeft: (left: E) => B,
+  onRight: (right: A) => B,
+): (either: Either<E, A>) => B {
+  return (either) => (isRight(either) ? onRight(either.right) : onLeft(either.left));
 }

--- a/packages/util-typescript/src/lib/either.ts
+++ b/packages/util-typescript/src/lib/either.ts
@@ -9,11 +9,14 @@ export type Right<A> = Readonly<{
 }>;
 
 /**
- * A value of either type `Left<E>` or type `Right<A>`; a disjoint union.
+ * A value of `Either` type `Left<E>` or type `Right<A>`; a disjoint union.
  *
  * A common use case is as an alternative to {@link Option} where `Left<E>` contains useful
  * information. Convention dictates that `Left<E>` is used for failure and `Right<A>` for success.
  * To help remember, the success case is "right"; it's the result you want.
+ *
+ * @includeExample ./packages/util-typescript/examples/either.ts
+ * @see [Usage example](../../util-typescript/examples/either.ts)
  */
 export type Either<E, A> = Left<E> | Right<A>;
 
@@ -40,8 +43,8 @@ export function right<A, E = never>(right: A): Either<E, A> {
 /**
  * Type guard that checks if an either is `Left<E>`.
  *
- * @param either - The either to check
- * @returns `true` if the either is `Left<E>`, `false` if it is `Right<A>`
+ * @param either - The `Either` to check
+ * @returns `true` if the `Either` is `Left<E>`, `false` if it is `Right<A>`
  */
 export function isLeft<E, A>(either: Either<E, A>): either is Left<E> {
   return !either.isRight;
@@ -50,29 +53,40 @@ export function isLeft<E, A>(either: Either<E, A>): either is Left<E> {
 /**
  * Type guard that checks if an either is `Right<A>`.
  *
- * @param either - The either to check
- * @returns `true` if the either is `Right<A>`, `false` if it is `Left<E>`
+ * @param either - The `Either` to check
+ * @returns `true` if the `Either` is `Right<A>`, `false` if it is `Left<E>`
  */
 export function isRight<E, A>(either: Either<E, A>): either is Right<A> {
   return either.isRight;
 }
 
 /**
- * Maps over the value in a Right if it exists.
+ * Transforms the value inside an `Either` using the provided function. If the `Either` is
+ * `Right(value)`, returns `Right(f(value))`. If the `Either` is `Left(value)`, returns
+ * `Left(value)`.
+ *
+ * @param f - The function to apply to the `Right` value
+ * @returns A function that transforms `Either<E, A>` to `Either<E, B>`
  */
 export function map<A, B>(f: (right: A) => B): <E>(either: Either<E, A>) => Either<E, B> {
   return (either) => (isRight(either) ? right(f(either.right)) : either);
 }
 
 /**
- * Maps over the value in a Left if it exists.
+ * Transforms the value inside an `Either` using the provided function. If the `Either` is
+ * `Left(value)`, returns `Left(f(value))`. If the `Either` is `Right(value)`, returns
+ * `Right(value)`.
  */
 export function mapLeft<E, G>(f: (left: E) => G): <A>(either: Either<E, A>) => Either<G, A> {
   return (either) => (isLeft(either) ? left(f(either.left)) : either);
 }
 
 /**
- * Chains Either operations together.
+ * Chains `Either` operations that return `Either`s. Unlike `map` which wraps the result in a new
+ * `Either`, `flatMap` prevents nested `Either`s like `Right(Right(value))`.
+ *
+ * @param f - A function that returns an `Either`
+ * @returns The `Either` returned by the function if the input is `Right`, `Left` otherwise
  */
 export function flatMap<E, A, B>(
   f: (right: A) => Either<E, B>,
@@ -81,14 +95,21 @@ export function flatMap<E, A, B>(
 }
 
 /**
- * Gets the value from a Right or returns a default.
+ * Safely extracts the value from an `Either` with a fallback. Use this function when you need to
+ * convert an `Either<E, A>` to an `A`, providing a default value for the `Left` case.
+ *
+ * @param defaultValue - The value to return if the `Either` is `Left`
+ * @returns The contained value if `Right`, `defaultValue` if `Left`
  */
 export function getOrElse<E, A>(onLeft: (left: E) => A): (either: Either<E, A>) => A {
   return (either) => (isRight(either) ? either.right : onLeft(either.left));
 }
 
 /**
- * Pattern matches on an Either, handling both Right and Left cases.
+ * Pattern matches on an `Either`, handling both `Right` and `Left` cases.
+ *
+ * @param onLeft - Function to handle the `Left` case
+ * @param onRight - Function to handle the `Right` case
  */
 export function match<E, A, B>(
   onLeft: (left: E) => B,

--- a/packages/util-typescript/src/lib/either.ts
+++ b/packages/util-typescript/src/lib/either.ts
@@ -110,6 +110,7 @@ export function getOrElse<E, A>(onLeft: (left: E) => A): (either: Either<E, A>) 
  *
  * @param onLeft - Function to handle the `Left` case
  * @param onRight - Function to handle the `Right` case
+ * @returns The result of `Either` `onLeft` or `onRight` based on the `Either` state
  */
 export function match<E, A, B>(
   onLeft: (left: E) => B,

--- a/packages/util-typescript/src/lib/option.spec.ts
+++ b/packages/util-typescript/src/lib/option.spec.ts
@@ -1,5 +1,5 @@
 import * as O from "./option";
-import { some } from "./option";
+import { pipe } from "./pipe";
 
 describe("Option", () => {
   it("none is not some", () => {
@@ -12,12 +12,89 @@ describe("Option", () => {
 
   it("some is some", () => {
     const value = "my-value";
-
-    const option = some(value);
+    const option = O.some(value);
 
     expect(O.isNone(option)).toBe(false);
     expect(O.isSome(option)).toBe(true);
     expect(option.isSome).toBe(true);
     expect(option.value).toBe(value);
   });
+
+  describe("map", () => {
+    it("should transform Some value", () => {
+      const actual = pipe(O.some(5), O.map(double));
+      expect(actual).toEqual(O.some(10));
+    });
+
+    it("should handle None", () => {
+      const actual = pipe(O.none, O.map(double));
+      expect(actual).toBe(O.none);
+    });
+  });
+
+  describe("flatMap", () => {
+    it("should flatMap Some operations", () => {
+      const actual = pipe(O.some(2), O.flatMap(inverse));
+      expect(actual).toEqual(O.some(0.5));
+    });
+
+    it("should handle None", () => {
+      const actual = pipe(O.none, O.flatMap(inverse));
+      expect(actual).toBe(O.none);
+    });
+  });
+
+  describe("getOrElse", () => {
+    it("should return value for Some", () => {
+      const actual = pipe(O.some(5), O.getOrElse(1));
+      expect(actual).toBe(5);
+    });
+
+    it("should return default for None", () => {
+      const actual = pipe(O.none, O.getOrElse(1));
+      expect(actual).toBe(1);
+    });
+  });
+
+  describe("match", () => {
+    it("should handle Some case", () => {
+      const actual = pipe(O.some(5), O.match(onSome, onNone));
+      expect(actual).toBe("Got 5");
+    });
+
+    it("should handle None case", () => {
+      const actual = pipe(O.none, O.match(onSome, onNone));
+      expect(actual).toBe("Nothing");
+    });
+  });
+
+  it("should work with complex pipe operations", () => {
+    const actual = pipe(
+      O.some(5),
+      O.map(double),
+      O.flatMap(inverse),
+      O.match(
+        (n) => `Result is ${n}`,
+        () => "no result",
+      ),
+    );
+
+    expect(actual).toBe("Result is 0.1");
+  });
 });
+
+function onSome(x: number) {
+  return `Got ${x}`;
+}
+
+function onNone() {
+  return "Nothing";
+}
+
+function double(n: number) {
+  return n * 2;
+}
+
+function inverse(n: number): O.Option<number> {
+  return n === 0 ? O.none : O.some(1 / n);
+}

--- a/packages/util-typescript/src/lib/option.spec.ts
+++ b/packages/util-typescript/src/lib/option.spec.ts
@@ -58,12 +58,12 @@ describe("Option", () => {
 
   describe("match", () => {
     it("should handle Some case", () => {
-      const actual = pipe(O.some(5), O.match(onSome, onNone));
+      const actual = pipe(O.some(5), O.match(onNone, onSome));
       expect(actual).toBe("Got 5");
     });
 
     it("should handle None case", () => {
-      const actual = pipe(O.none, O.match(onSome, onNone));
+      const actual = pipe(O.none, O.match(onNone, onSome));
       expect(actual).toBe("Nothing");
     });
   });
@@ -74,8 +74,8 @@ describe("Option", () => {
       O.map(double),
       O.flatMap(inverse),
       O.match(
+        () => "No result",
         (n) => `Result is ${n}`,
-        () => "no result",
       ),
     );
 

--- a/packages/util-typescript/src/lib/option.ts
+++ b/packages/util-typescript/src/lib/option.ts
@@ -88,6 +88,7 @@ export function getOrElse<A>(defaultValue: A): (option: Option<A>) => A {
  *
  * @param onNone - Function to handle the `None` case
  * @param onSome - Function to handle the `Some` case
+ * @returns The result of either `onNone` or `onSome` based on the `Option` state
  */
 export function match<A, B>(onNone: () => B, onSome: (value: A) => B): (option: Option<A>) => B {
   return (option) => (isSome(option) ? onSome(option.value) : onNone());

--- a/packages/util-typescript/src/lib/option.ts
+++ b/packages/util-typescript/src/lib/option.ts
@@ -46,3 +46,34 @@ export function isNone<A>(option: Option<A>): option is None {
 export function isSome<A>(option: Option<A>): option is Some<A> {
   return option.isSome;
 }
+
+/**
+ * Maps over the value in an Option if it exists.
+ */
+export function map<A, B>(f: (a: A) => B): (option: Option<A>) => Option<B> {
+  return (option) => (isSome(option) ? some(f(option.value)) : none);
+}
+
+/**
+ * Chains Option operations together.
+ */
+export function flatMap<A, B>(f: (a: A) => Option<B>): (option: Option<A>) => Option<B> {
+  return (option) => (isSome(option) ? f(option.value) : none);
+}
+
+/**
+ * Gets the value from an Option or returns a default.
+ */
+export function getOrElse<A>(defaultValue: A): (option: Option<A>) => A {
+  return (option) => (isSome(option) ? option.value : defaultValue);
+}
+
+/**
+ * Pattern matches on an Option, handling both Some and None cases.
+ *
+ * @param onSome - Function to handle the Some case
+ * @param onNone - Function to handle the None case
+ */
+export function match<A, B>(onSome: (value: A) => B, onNone: () => B): (option: Option<A>) => B {
+  return (option) => (isSome(option) ? onSome(option.value) : onNone());
+}

--- a/packages/util-typescript/src/lib/option.ts
+++ b/packages/util-typescript/src/lib/option.ts
@@ -9,6 +9,9 @@ export type Some<A> = Readonly<{
 
 /**
  * An optional value. If the value exists, it's of type `Some<A>`, otherwise it's of type `None`.
+ *
+ * @includeExample ./packages/util-typescript/examples/option.ts
+ * @see [Usage example](../../util-typescript/examples/option.ts)
  */
 export type Option<A> = None | Some<A>;
 
@@ -28,52 +31,64 @@ export function some<A>(value: A): Some<A> {
 }
 
 /**
- * Type guard that checks if an option is `None`.
+ * Type guard that checks if an `Option` is `None`.
  *
- * @param option - The option to check
- * @returns `true` if the option is `None`, `false` if it is `Some<A>`
+ * @param option - The `Option` to check
+ * @returns `true` if the `Option` is `None`, `false` if it is `Some<A>`
  */
 export function isNone<A>(option: Option<A>): option is None {
   return !option.isSome;
 }
 
 /**
- * Type guard that checks if an option is `Some<A>`.
+ * Type guard that checks if an `Option` is `Some<A>`.
  *
- * @param option - The option to check
- * @returns `true` if the option is `Some<A>`, `false` if it is `None`
+ * @param option - The `Option` to check
+ * @returns `true` if the `Option` is `Some<A>`, `false` if it is `None`
  */
 export function isSome<A>(option: Option<A>): option is Some<A> {
   return option.isSome;
 }
 
 /**
- * Maps over the value in an Option if it exists.
+ * Transforms the value inside an `Option` using the provided function. If the `Option` is
+ * `Some(value)`, returns `Some(f(value))`. If the `Option` is `None`, returns `None`.
+ *
+ * @param f - The function to apply to the value if it exists
+ * @returns A new `Option` containing the transformed value
  */
 export function map<A, B>(f: (a: A) => B): (option: Option<A>) => Option<B> {
   return (option) => (isSome(option) ? some(f(option.value)) : none);
 }
 
 /**
- * Chains Option operations together.
+ * Chains `Option` operations that return `Option`s. Unlike `map` which wraps the result in a new
+ * `Option`, `flatMap` prevents nested `Option`s like `Some(Some(value))`.
+ *
+ * @param f - A function that returns an `Option`
+ * @returns The `Option` returned by the function if the input is `Some`, `None` otherwise
  */
 export function flatMap<A, B>(f: (a: A) => Option<B>): (option: Option<A>) => Option<B> {
   return (option) => (isSome(option) ? f(option.value) : none);
 }
 
 /**
- * Gets the value from an Option or returns a default.
+ * Safely extracts the value from an `Option` with a fallback. Use this function when you need to
+ * convert an `Option<A>` to an `A`, providing a default value for the `None` case.
+ *
+ * @param defaultValue - The value to return if the `Option` is `None`
+ * @returns The contained value if `Some`, `defaultValue` if `None`
  */
 export function getOrElse<A>(defaultValue: A): (option: Option<A>) => A {
   return (option) => (isSome(option) ? option.value : defaultValue);
 }
 
 /**
- * Pattern matches on an Option, handling both Some and None cases.
+ * Pattern matches on an `Option`, handling both `Some` and `None` cases.
  *
- * @param onSome - Function to handle the Some case
- * @param onNone - Function to handle the None case
+ * @param onNone - Function to handle the `None` case
+ * @param onSome - Function to handle the `Some` case
  */
-export function match<A, B>(onSome: (value: A) => B, onNone: () => B): (option: Option<A>) => B {
+export function match<A, B>(onNone: () => B, onSome: (value: A) => B): (option: Option<A>) => B {
   return (option) => (isSome(option) ? onSome(option.value) : onNone());
 }

--- a/packages/util-typescript/src/lib/pipe.spec.ts
+++ b/packages/util-typescript/src/lib/pipe.spec.ts
@@ -1,0 +1,30 @@
+import { pipe } from "./pipe";
+
+describe("pipe", () => {
+  it("pipes values through functions", () => {
+    const result = pipe(
+      5,
+      (x) => x * 2,
+      (x) => x + 1,
+    );
+
+    expect(result).toBe(11);
+  });
+
+  it("handles 10 arguments", () => {
+    const result = pipe(
+      1,
+      (x) => x + 1, // 2
+      (x) => x * 2, // 4
+      (x) => x + 3, // 7
+      (x) => x * 2, // 14
+      (x) => x - 4, // 10
+      (x) => x / 2, // 5
+      (x) => x * 2, // 10
+      (x) => x + 5, // 15
+      (x) => x / 3,
+    );
+
+    expect(result).toBe(5);
+  });
+});

--- a/packages/util-typescript/src/lib/pipe.ts
+++ b/packages/util-typescript/src/lib/pipe.ts
@@ -1,0 +1,78 @@
+/**
+ * Pipes a value through a series of functions from left to right.
+ *
+ * @example
+ * const result = pipe(
+ *   1,
+ *   (x) => x + 1, // 2
+ *   (x) => x * 2, // 4
+ *   (x) => x + 3, // 7
+ *   (x) => x * 2, // 14
+ *   (x) => x - 4, // 10
+ *   (x) => x / 2, // 5
+ * );
+ */
+export function pipe<A>(a: A): A;
+export function pipe<A, B>(a: A, ab: (a: A) => B): B;
+export function pipe<A, B, C>(a: A, ab: (a: A) => B, bc: (b: B) => C): C;
+export function pipe<A, B, C, D>(a: A, ab: (a: A) => B, bc: (b: B) => C, cd: (c: C) => D): D;
+export function pipe<A, B, C, D, E>(
+  a: A,
+  ab: (a: A) => B,
+  bc: (b: B) => C,
+  cd: (c: C) => D,
+  de: (d: D) => E,
+): E;
+export function pipe<A, B, C, D, E, F>(
+  a: A,
+  ab: (a: A) => B,
+  bc: (b: B) => C,
+  cd: (c: C) => D,
+  de: (d: D) => E,
+  ef: (ef: E) => F,
+): F;
+export function pipe<A, B, C, D, E, F, G>(
+  a: A,
+  ab: (a: A) => B,
+  bc: (b: B) => C,
+  cd: (c: C) => D,
+  de: (d: D) => E,
+  ef: (ef: E) => F,
+  fg: (f: F) => G,
+): G;
+export function pipe<A, B, C, D, E, F, G, H>(
+  a: A,
+  ab: (a: A) => B,
+  bc: (b: B) => C,
+  cd: (c: C) => D,
+  de: (d: D) => E,
+  ef: (ef: E) => F,
+  fg: (f: F) => G,
+  gh: (g: G) => H,
+): H;
+export function pipe<A, B, C, D, E, F, G, H, I>(
+  a: A,
+  ab: (a: A) => B,
+  bc: (b: B) => C,
+  cd: (c: C) => D,
+  de: (d: D) => E,
+  ef: (ef: E) => F,
+  fg: (f: F) => G,
+  gh: (g: G) => H,
+  hi: (h: H) => I,
+): I;
+export function pipe<A, B, C, D, E, F, G, H, I, J>(
+  a: A,
+  ab: (a: A) => B,
+  bc: (b: B) => C,
+  cd: (c: C) => D,
+  de: (d: D) => E,
+  ef: (ef: E) => F,
+  fg: (f: F) => G,
+  gh: (g: G) => H,
+  hi: (h: H) => I,
+  ij: (ij: I) => J,
+): J;
+export function pipe(a: unknown, ...fs: Array<(a: unknown) => unknown>): unknown {
+  return fs.reduce((accumulator, f) => f(accumulator), a);
+}

--- a/packages/util-typescript/src/lib/pipe.ts
+++ b/packages/util-typescript/src/lib/pipe.ts
@@ -1,16 +1,13 @@
 /**
- * Pipes a value through a series of functions from left to right.
+ * Pipes a value through a series of functions from left to right. Currently supports up to 10
+ * functions.
  *
- * @example
- * const result = pipe(
- *   1,
- *   (x) => x + 1, // 2
- *   (x) => x * 2, // 4
- *   (x) => x + 3, // 7
- *   (x) => x * 2, // 14
- *   (x) => x - 4, // 10
- *   (x) => x / 2, // 5
- * );
+ * @includeExample ./packages/util-typescript/examples/pipe.ts
+ * @see [Usage example](../../util-typescript/examples/pipe.ts)
+ *
+ * @param a - The initial value to transform
+ * @param fs - Functions to apply sequentially
+ * @returns The final transformed value
  */
 export function pipe<A>(a: A): A;
 export function pipe<A, B>(a: A, ab: (a: A) => B): B;


### PR DESCRIPTION
Summary
===
Add `pipe` to pass a value through a series of functions from left to right. This allows adding `map`, `flatMap`, `getOrElse`, and `match` to `Either` and `Option`.

Changes
---
- Remove link that could get out of date from TypeDoc comment
- Turned off a couple of duplicate ESLint errors that interfere with functional programming