### PR TITLE
fix: make ServiceError easier to use

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22995,10 +22995,10 @@
     },
     "packages/config": {
       "name": "@clipboard-health/config",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
-        "@clipboard-health/util-typescript": "0.4.0",
+        "@clipboard-health/util-typescript": "0.5.0",
         "decamelize": "5.0.1",
         "dotenv": "16.4.5",
         "tslib": "2.8.0",
@@ -23022,19 +23022,19 @@
     },
     "packages/contract-core": {
       "name": "@clipboard-health/contract-core",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.0",
         "zod": "3.23.8"
       },
       "devDependencies": {
-        "@clipboard-health/testing-core": "0.6.0"
+        "@clipboard-health/testing-core": "0.7.0"
       }
     },
     "packages/eslint-config": {
       "name": "@clipboard-health/eslint-config",
-      "version": "4.13.0",
+      "version": "4.14.0",
       "license": "MIT",
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": "^7",
@@ -23127,7 +23127,7 @@
     },
     "packages/execution-context": {
       "name": "@clipboard-health/execution-context",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.0"
@@ -23135,7 +23135,7 @@
     },
     "packages/json-api": {
       "name": "@clipboard-health/json-api",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.0"
@@ -23143,7 +23143,7 @@
     },
     "packages/json-api-nestjs": {
       "name": "@clipboard-health/json-api-nestjs",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@clipboard-health/contract-core": "0.3.0",
@@ -23152,7 +23152,7 @@
         "zod": "3.23.8"
       },
       "devDependencies": {
-        "@clipboard-health/testing-core": "0.6.0"
+        "@clipboard-health/testing-core": "0.7.0"
       }
     },
     "packages/json-api-nestjs/node_modules/@clipboard-health/contract-core": {
@@ -23179,7 +23179,7 @@
     },
     "packages/nx-plugin": {
       "name": "@clipboard-health/nx-plugin",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@nx/devkit": "20.0.1",
@@ -23189,7 +23189,7 @@
     },
     "packages/rules-engine": {
       "name": "@clipboard-health/rules-engine",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.0",
@@ -23210,17 +23210,17 @@
     },
     "packages/testing-core": {
       "name": "@clipboard-health/testing-core",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@clipboard-health/util-typescript": "0.4.0",
+        "@clipboard-health/util-typescript": "0.5.0",
         "tslib": "2.8.0",
         "zod": "3.23.8"
       }
     },
     "packages/util-typescript": {
       "name": "@clipboard-health/util-typescript",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.0"

--- a/packages/util-typescript/README.md
+++ b/packages/util-typescript/README.md
@@ -30,55 +30,73 @@ See `./src/lib` for each utility.
 ```ts
 // ./examples/serviceError.ts
 
-import { deepEqual } from "node:assert/strict";
+import { deepEqual, equal } from "node:assert/strict";
 
 import { ERROR_CODES, ServiceError } from "@clipboard-health/util-typescript";
 
-const error = new ServiceError({
-  issues: [
-    {
-      code: ERROR_CODES.badRequest,
-      detail: "Invalid email format",
-      path: ["data", "attributes", "email"],
-    },
-    {
-      code: ERROR_CODES.unprocessableEntity,
-      detail: "Phone number too short",
-      path: ["data", "attributes", "phoneNumber"],
-    },
-  ],
-  cause: new Error("Validation failed"),
-});
+{
+  const error = new ServiceError("boom");
+  equal(error.toString(), `ServiceError[${error.id}]: [internal]: boom`);
+}
 
-deepEqual(
-  error.toString(),
-  `ServiceError[${error.id}]: [badRequest]: Invalid email format; [unprocessableEntity]: Phone number too short; [cause]: Error: Validation failed`,
-);
+{
+  const errorWithCause = new ServiceError({
+    issues: [{ message: "boom" }],
+    cause: new Error("Original error"),
+  });
+  equal(
+    errorWithCause.toString(),
+    `ServiceError[${errorWithCause.id}]: [internal]: boom; [cause]: Error: Original error`,
+  );
+}
 
-deepEqual(error.toJsonApi(), {
-  errors: [
-    {
-      id: error.id,
-      status: "400",
-      code: "badRequest",
-      title: "Invalid or malformed request",
-      detail: "Invalid email format",
-      source: {
-        pointer: "/data/attributes/email",
+{
+  const multipleIssues = new ServiceError({
+    issues: [
+      {
+        code: ERROR_CODES.badRequest,
+        message: "Invalid email format",
+        path: ["data", "attributes", "email"],
       },
-    },
-    {
-      id: error.id,
-      status: "422",
-      code: "unprocessableEntity",
-      title: "Request failed validation",
-      detail: "Phone number too short",
-      source: {
-        pointer: "/data/attributes/phoneNumber",
+      {
+        code: ERROR_CODES.unprocessableEntity,
+        message: "Phone number too short",
+        path: ["data", "attributes", "phoneNumber"],
       },
-    },
-  ],
-});
+    ],
+    cause: new Error("Original error"),
+  });
+
+  equal(
+    multipleIssues.toString(),
+    `ServiceError[${multipleIssues.id}]: [badRequest]: Invalid email format; [unprocessableEntity]: Phone number too short; [cause]: Error: Original error`,
+  );
+
+  deepEqual(multipleIssues.toJsonApi(), {
+    errors: [
+      {
+        id: multipleIssues.id,
+        status: "400",
+        code: "badRequest",
+        title: "Invalid or malformed request",
+        detail: "Invalid email format",
+        source: {
+          pointer: "/data/attributes/email",
+        },
+      },
+      {
+        id: multipleIssues.id,
+        status: "422",
+        code: "unprocessableEntity",
+        title: "Request failed validation",
+        detail: "Phone number too short",
+        source: {
+          pointer: "/data/attributes/phoneNumber",
+        },
+      },
+    ],
+  });
+}
 
 ```
 
@@ -103,11 +121,11 @@ function validateUser(params: { email: string; phone: string }): ServiceResult<{
   const code = ERROR_CODES.unprocessableEntity;
 
   if (!email.includes("@")) {
-    return failure({ issues: [{ code, detail: "Invalid email format" }] });
+    return failure({ issues: [{ code, message: "Invalid email format" }] });
   }
 
   if (phone.length !== 12) {
-    return failure({ issues: [{ code, detail: "Invalid phone number" }] });
+    return failure({ issues: [{ code, message: "Invalid phone number" }] });
   }
 
   return success({ id: "user-123" });

--- a/packages/util-typescript/examples/serviceError.ts
+++ b/packages/util-typescript/examples/serviceError.ts
@@ -1,49 +1,67 @@
-import { deepEqual } from "node:assert/strict";
+import { deepEqual, equal } from "node:assert/strict";
 
 import { ERROR_CODES, ServiceError } from "@clipboard-health/util-typescript";
 
-const error = new ServiceError({
-  issues: [
-    {
-      code: ERROR_CODES.badRequest,
-      detail: "Invalid email format",
-      path: ["data", "attributes", "email"],
-    },
-    {
-      code: ERROR_CODES.unprocessableEntity,
-      detail: "Phone number too short",
-      path: ["data", "attributes", "phoneNumber"],
-    },
-  ],
-  cause: new Error("Validation failed"),
-});
+{
+  const error = new ServiceError("boom");
+  equal(error.toString(), `ServiceError[${error.id}]: [internal]: boom`);
+}
 
-deepEqual(
-  error.toString(),
-  `ServiceError[${error.id}]: [badRequest]: Invalid email format; [unprocessableEntity]: Phone number too short; [cause]: Error: Validation failed`,
-);
+{
+  const errorWithCause = new ServiceError({
+    issues: [{ message: "boom" }],
+    cause: new Error("Original error"),
+  });
+  equal(
+    errorWithCause.toString(),
+    `ServiceError[${errorWithCause.id}]: [internal]: boom; [cause]: Error: Original error`,
+  );
+}
 
-deepEqual(error.toJsonApi(), {
-  errors: [
-    {
-      id: error.id,
-      status: "400",
-      code: "badRequest",
-      title: "Invalid or malformed request",
-      detail: "Invalid email format",
-      source: {
-        pointer: "/data/attributes/email",
+{
+  const multipleIssues = new ServiceError({
+    issues: [
+      {
+        code: ERROR_CODES.badRequest,
+        message: "Invalid email format",
+        path: ["data", "attributes", "email"],
       },
-    },
-    {
-      id: error.id,
-      status: "422",
-      code: "unprocessableEntity",
-      title: "Request failed validation",
-      detail: "Phone number too short",
-      source: {
-        pointer: "/data/attributes/phoneNumber",
+      {
+        code: ERROR_CODES.unprocessableEntity,
+        message: "Phone number too short",
+        path: ["data", "attributes", "phoneNumber"],
       },
-    },
-  ],
-});
+    ],
+    cause: new Error("Original error"),
+  });
+
+  equal(
+    multipleIssues.toString(),
+    `ServiceError[${multipleIssues.id}]: [badRequest]: Invalid email format; [unprocessableEntity]: Phone number too short; [cause]: Error: Original error`,
+  );
+
+  deepEqual(multipleIssues.toJsonApi(), {
+    errors: [
+      {
+        id: multipleIssues.id,
+        status: "400",
+        code: "badRequest",
+        title: "Invalid or malformed request",
+        detail: "Invalid email format",
+        source: {
+          pointer: "/data/attributes/email",
+        },
+      },
+      {
+        id: multipleIssues.id,
+        status: "422",
+        code: "unprocessableEntity",
+        title: "Request failed validation",
+        detail: "Phone number too short",
+        source: {
+          pointer: "/data/attributes/phoneNumber",
+        },
+      },
+    ],
+  });
+}

--- a/packages/util-typescript/examples/serviceResult.ts
+++ b/packages/util-typescript/examples/serviceResult.ts
@@ -13,11 +13,11 @@ function validateUser(params: { email: string; phone: string }): ServiceResult<{
   const code = ERROR_CODES.unprocessableEntity;
 
   if (!email.includes("@")) {
-    return failure({ issues: [{ code, detail: "Invalid email format" }] });
+    return failure({ issues: [{ code, message: "Invalid email format" }] });
   }
 
   if (phone.length !== 12) {
-    return failure({ issues: [{ code, detail: "Invalid phone number" }] });
+    return failure({ issues: [{ code, message: "Invalid phone number" }] });
   }
 
   return success({ id: "user-123" });

--- a/packages/util-typescript/src/lib/errors/serviceError.spec.ts
+++ b/packages/util-typescript/src/lib/errors/serviceError.spec.ts
@@ -1,12 +1,12 @@
-import { ERROR_CODES, ServiceError } from "./serviceError";
+import { ERROR_CODES, ServiceError, type ServiceErrorParams } from "./serviceError";
 
 describe("ServiceError", () => {
   it("creates error with single issue", () => {
-    const input = {
+    const input: ServiceErrorParams = {
       issues: [
         {
           code: ERROR_CODES.notFound,
-          detail: "User not found",
+          message: "User not found",
         },
       ],
     };
@@ -18,22 +18,22 @@ describe("ServiceError", () => {
     expect(actual.issues).toHaveLength(1);
     expect(actual.issues[0]).toMatchObject({
       code: ERROR_CODES.notFound,
-      detail: "User not found",
+      message: "User not found",
       title: "Resource not found",
     });
   });
 
   it("creates error with multiple issues", () => {
-    const input = {
+    const input: ServiceErrorParams = {
       issues: [
         {
           code: ERROR_CODES.badRequest,
-          detail: "Invalid email",
+          message: "Invalid email",
           path: ["data", "attributes", "email"],
         },
         {
           code: ERROR_CODES.badRequest,
-          detail: "Invalid phone",
+          message: "Invalid phone",
           path: ["data", "attributes", "phoneNumber"],
         },
       ],
@@ -46,13 +46,13 @@ describe("ServiceError", () => {
     expect(actual.issues).toEqual([
       {
         code: ERROR_CODES.badRequest,
-        detail: "Invalid email",
+        message: "Invalid email",
         path: ["data", "attributes", "email"],
         title: "Invalid or malformed request",
       },
       {
         code: ERROR_CODES.badRequest,
-        detail: "Invalid phone",
+        message: "Invalid phone",
         path: ["data", "attributes", "phoneNumber"],
         title: "Invalid or malformed request",
       },
@@ -87,8 +87,7 @@ describe("ServiceError", () => {
       issues: [
         {
           code: ERROR_CODES.badRequest,
-          title: "Custom title",
-          detail: "Invalid email format",
+          message: "Invalid email format",
           path: ["data", "attributes", "email"],
         },
       ],
@@ -101,7 +100,7 @@ describe("ServiceError", () => {
       id: actual.id,
       status: "400",
       code: ERROR_CODES.badRequest,
-      title: "Custom title",
+      title: "Invalid or malformed request",
       detail: "Invalid email format",
       source: {
         pointer: "/data/attributes/email",
@@ -168,7 +167,19 @@ describe("ServiceError", () => {
 
     const actual = new ServiceError(input);
 
-    expect(actual.message).toBe("[internal]: An unknown error occurred");
+    expect(actual.message).toBe("[unknown]");
     expect(actual.issues).toHaveLength(0);
+  });
+
+  it("creates error from string message", () => {
+    const actual = new ServiceError("Something went wrong");
+
+    expect(actual.message).toBe("[internal]: Something went wrong");
+    expect(actual.issues).toHaveLength(1);
+    expect(actual.issues[0]).toMatchObject({
+      code: ERROR_CODES.internal,
+      message: "Something went wrong",
+      title: "Internal server error",
+    });
   });
 });


### PR DESCRIPTION
Changes
---
- Allow ServiceError creation with just a message like a normal error, `new ServiceError("boom")`
- Make `code` optional
- Don't allow custom `title`s per the JSON:API spec
- Rename `detail` to `message` and only call it `detail` when converting to JSON:API error