### PR TITLE
feat: add example-embedder

### DIFF
--- a/.knip.jsonc
+++ b/.knip.jsonc
@@ -3,6 +3,7 @@
   "entry": [
     "packages/config/examples/**/*.ts",
     "packages/contract-core/examples/**/*.ts",
+    "packages/example-embedder/src/bin/cli.ts",
     "packages/example-nestjs/examples/**/*.ts",
     "packages/execution-context/examples/**/*.ts",
     "packages/json-api/examples/**/*.ts",

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Clipboard Health's core libraries and utilities. See individual package `README`
 - [config](./packages/config/README.md): Type-safe static configuration management: a pure function to resolve, validate against a Zod schema, and freeze configuration values.
 - [contract-core](./packages/contract-core/README.md): Shared Zod schemas for Clipboard Health's contracts.
 - [eslint-config](./packages/eslint-config/README.md): Our ESLint configuration.
+- [example-embedder](./packages/example-embedder/README.md): Command-line interface (CLI) to embed example TypeScript code into TypeDoc comments and markdown files.
 - [example-nestjs](./packages/example-nestjs/README.md): A NestJS application using our libraries, primarily for end-to-end testing.
 - [execution-context](./packages/execution-context/README.md): A lightweight Node.js utility for managing execution contexts and metadata aggregation using AsyncLocalStorage.
 - [json-api](./packages/json-api/README.md): TypeScript-friendly utilities for adhering to the JSON:API specification.

--- a/cspell.json
+++ b/cspell.json
@@ -22,6 +22,7 @@
     "datetime",
     "decamelize",
     "devkit",
+    "embedder",
     "embedme",
     "fieldsets",
     "gitleaks",

--- a/nx.json
+++ b/nx.json
@@ -61,7 +61,7 @@
       "commit": true,
       "commitMessage": "chore(release): publish {projectName} {version} [skip actions]"
     },
-    "projects": ["packages/*", "!packages/example-*"],
+    "projects": ["packages/*", "!packages/example-nestjs"],
     "projectsRelationship": "independent",
     "version": {
       "conventionalCommits": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1905,6 +1905,10 @@
       "resolved": "packages/eslint-config",
       "link": true
     },
+    "node_modules/@clipboard-health/example-embedder": {
+      "resolved": "packages/example-embedder",
+      "link": true
+    },
     "node_modules/@clipboard-health/example-nestjs": {
       "resolved": "packages/example-nestjs",
       "link": true
@@ -23083,6 +23087,14 @@
         "eslint-plugin-simple-import-sort": "^10",
         "eslint-plugin-sonarjs": "^0.23",
         "eslint-plugin-unicorn": "^48"
+      }
+    },
+    "packages/example-embedder": {
+      "name": "@clipboard-health/example-embedder",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.0"
       }
     },
     "packages/example-nestjs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23095,6 +23095,9 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.0"
+      },
+      "bin": {
+        "example-embedder": "src/bin/cli.js"
       }
     },
     "packages/example-nestjs": {

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -22,7 +22,7 @@ npm install @clipboard-health/config
 The TypeDoc comment for the `createConfig` function:
 
 <!-- prettier-ignore -->
-```ts
+```typescript
 // ./src/lib/createConfig.ts
 
 import { deepFreeze } from "@clipboard-health/util-ts";
@@ -92,7 +92,7 @@ export function createConfig<
 A usage example:
 
 <!-- prettier-ignore -->
-```ts
+```typescript
 // ./examples/config.ts
 
 import { ok } from "node:assert/strict";

--- a/packages/contract-core/README.md
+++ b/packages/contract-core/README.md
@@ -20,7 +20,7 @@ npm install @clipboard-health/contract-core
 ### Zod schemas
 
 <!-- prettier-ignore -->
-```ts
+```typescript
 // ./examples/schemas.ts
 
 import { apiErrors, booleanString, nonEmptyString, uuid } from "@clipboard-health/contract-core";

--- a/packages/example-embedder/.eslintrc.json
+++ b/packages/example-embedder/.eslintrc.json
@@ -7,5 +7,17 @@
   },
   "rules": {
     "security/detect-non-literal-fs-filename": "off"
-  }
+  },
+  "overrides": [
+    {
+      "files": ["./src/bin/**/*.ts"],
+      "rules": {
+        "n/no-process-exit": "off",
+        "n/shebang": "off",
+        "no-console": "off",
+        "unicorn/no-process-exit": "off",
+        "unicorn/prefer-top-level-await": "off"
+      }
+    }
+  ]
 }

--- a/packages/example-embedder/.eslintrc.json
+++ b/packages/example-embedder/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "parserOptions": {
+    "project": "tsconfig.lint.json",
+    "tsconfigRootDir": "packages/example-embedder"
+  },
+  "rules": {
+    "security/detect-non-literal-fs-filename": "off"
+  }
+}

--- a/packages/example-embedder/README.md
+++ b/packages/example-embedder/README.md
@@ -1,0 +1,21 @@
+# @clipboard-health/example-embedder <!-- omit from toc -->
+
+Command-line interface (CLI) to embed example TypeScript code into TypeDoc comments and markdown files.
+
+## Table of contents <!-- omit from toc -->
+
+- [Install](#install)
+- [Usage](#usage)
+- [Local development commands](#local-development-commands)
+
+## Install
+
+```bash
+npm install @clipboard-health/example-embedder
+```
+
+## Usage
+
+## Local development commands
+
+See [`package.json`](./package.json) `scripts` for a list of commands.

--- a/packages/example-embedder/jest.config.ts
+++ b/packages/example-embedder/jest.config.ts
@@ -1,0 +1,26 @@
+export default {
+  coverageDirectory: "../../coverage/packages/example-embedder",
+  coveragePathIgnorePatterns: ["<rootDir>/src/bin/cli.ts"],
+  coverageThreshold: {
+    global: {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+  },
+  displayName: "example-embedder",
+  moduleFileExtensions: ["ts", "js"],
+  preset: "../../jest.preset.js",
+  testEnvironment: "node",
+  transform: {
+    "^.+\\.[tj]s$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.spec.json" }],
+  },
+  watchPathIgnorePatterns: [
+    "<rootDir>/test-1",
+    "<rootDir>/test-2",
+    "<rootDir>/test-3",
+    "<rootDir>/test-4",
+    "<rootDir>/test-5",
+  ],
+};

--- a/packages/example-embedder/package.json
+++ b/packages/example-embedder/package.json
@@ -2,6 +2,9 @@
   "name": "@clipboard-health/example-embedder",
   "description": "Command-line interface (CLI) to embed example TypeScript code into TypeDoc comments and markdown files.",
   "version": "0.0.0",
+  "bin": {
+    "example-embedder": "./src/bin/cli.js"
+  },
   "dependencies": {
     "tslib": "2.8.0"
   },

--- a/packages/example-embedder/package.json
+++ b/packages/example-embedder/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@clipboard-health/example-embedder",
+  "description": "Command-line interface (CLI) to embed example TypeScript code into TypeDoc comments and markdown files.",
+  "version": "0.0.0",
+  "dependencies": {
+    "tslib": "2.8.0"
+  },
+  "keywords": [
+    "documentation",
+    "embed",
+    "examples",
+    "typedoc",
+    "typescript"
+  ],
+  "license": "MIT",
+  "main": "./src/index.js",
+  "publishConfig": {
+    "access": "restricted"
+  },
+  "type": "commonjs",
+  "typings": "./src/index.d.ts"
+}

--- a/packages/example-embedder/project.json
+++ b/packages/example-embedder/project.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "example-embedder",
+  "projectType": "library",
+  "sourceRoot": "packages/example-embedder/src",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "options": {
+        "assets": ["packages/example-embedder/*.md"],
+        "main": "packages/example-embedder/src/index.js",
+        "outputPath": "dist/packages/example-embedder",
+        "tsConfig": "packages/example-embedder/tsconfig.lib.json"
+      },
+      "outputs": ["{options.outputPath}"]
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "options": {
+        "lintFilePatterns": ["packages/example-embedder/**/*.[jt]s"],
+        "maxWarnings": 0
+      },
+      "outputs": ["{options.outputFile}"]
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "options": {
+        "jestConfig": "packages/example-embedder/jest.config.ts"
+      }
+    }
+  }
+}

--- a/packages/example-embedder/src/bin/cli.ts
+++ b/packages/example-embedder/src/bin/cli.ts
@@ -1,19 +1,41 @@
-import { embedder } from "..";
+#!/usr/bin/env node
+import { embedder } from "../lib/embedder";
 import { parseOptions } from "./parseOptions";
 
 async function cli(): Promise<void> {
+  if (process.argv.includes("--help")) {
+    printHelp();
+  }
+
   const { check, directory } = parseOptions();
 
   await embedder({
     check,
     directory,
   }).catch((error) => {
-    // eslint-disable-next-line no-console
-    console.error(error);
-    // eslint-disable-next-line n/no-process-exit, unicorn/no-process-exit
+    console.error(error.message);
     process.exit(1);
   });
 }
 
-// eslint-disable-next-line unicorn/prefer-top-level-await
+function printHelp(): never {
+  console.log(`
+example-embedder
+
+Command-line interface (CLI) to embed example TypeScript code into TypeDoc comments and markdown files.
+
+Options:
+  --check    Verify embedded examples are up to date without modifying files
+  --help     Show this help message
+
+Arguments:
+  directory  Directory containing example files (default: "examples")
+
+Usage:
+  $ example-embedder [directory]
+  $ example-embedder [directory] --check
+`);
+  process.exit(0);
+}
+
 void cli();

--- a/packages/example-embedder/src/bin/cli.ts
+++ b/packages/example-embedder/src/bin/cli.ts
@@ -1,0 +1,19 @@
+import { embedder } from "..";
+import { parseOptions } from "./parseOptions";
+
+async function cli(): Promise<void> {
+  const { check, directory } = parseOptions();
+
+  await embedder({
+    check,
+    directory,
+  }).catch((error) => {
+    // eslint-disable-next-line no-console
+    console.error(error);
+    // eslint-disable-next-line n/no-process-exit, unicorn/no-process-exit
+    process.exit(1);
+  });
+}
+
+// eslint-disable-next-line unicorn/prefer-top-level-await
+void cli();

--- a/packages/example-embedder/src/bin/parseOptions.spec.ts
+++ b/packages/example-embedder/src/bin/parseOptions.spec.ts
@@ -1,14 +1,14 @@
 import { parseOptions } from "./parseOptions";
 
 describe("parseOptions", () => {
-  const mockProcessArgv = process.argv;
+  const originalProcessArgv = process.argv;
 
   beforeEach(() => {
     process.argv = ["node", "script.js"];
   });
 
   afterEach(() => {
-    process.argv = mockProcessArgv;
+    process.argv = originalProcessArgv;
   });
 
   it("returns default options when no flags provided", () => {
@@ -31,8 +31,8 @@ describe("parseOptions", () => {
     });
   });
 
-  it("sets custom directory when --directory provided", () => {
-    process.argv.push("--directory", "custom/directory");
+  it("sets custom directory when provided", () => {
+    process.argv.push("custom/directory");
 
     const actual = parseOptions();
 
@@ -42,9 +42,7 @@ describe("parseOptions", () => {
     });
   });
 
-  it("uses default directory when --directory flag has no value", () => {
-    process.argv.push("--directory");
-
+  it("uses default directory", () => {
     const actual = parseOptions();
 
     expect(actual).toEqual({

--- a/packages/example-embedder/src/bin/parseOptions.spec.ts
+++ b/packages/example-embedder/src/bin/parseOptions.spec.ts
@@ -1,0 +1,55 @@
+import { parseOptions } from "./parseOptions";
+
+describe("parseOptions", () => {
+  const mockProcessArgv = process.argv;
+
+  beforeEach(() => {
+    process.argv = ["node", "script.js"];
+  });
+
+  afterEach(() => {
+    process.argv = mockProcessArgv;
+  });
+
+  it("returns default options when no flags provided", () => {
+    const actual = parseOptions();
+
+    expect(actual).toEqual({
+      check: false,
+      directory: "examples",
+    });
+  });
+
+  it("sets check flag when --check provided", () => {
+    process.argv.push("--check");
+
+    const actual = parseOptions();
+
+    expect(actual).toEqual({
+      check: true,
+      directory: "examples",
+    });
+  });
+
+  it("sets custom directory when --directory provided", () => {
+    process.argv.push("--directory", "custom/directory");
+
+    const actual = parseOptions();
+
+    expect(actual).toEqual({
+      check: false,
+      directory: "custom/directory",
+    });
+  });
+
+  it("uses default directory when --directory flag has no value", () => {
+    process.argv.push("--directory");
+
+    const actual = parseOptions();
+
+    expect(actual).toEqual({
+      check: false,
+      directory: "examples",
+    });
+  });
+});

--- a/packages/example-embedder/src/bin/parseOptions.spec.ts
+++ b/packages/example-embedder/src/bin/parseOptions.spec.ts
@@ -42,6 +42,17 @@ describe("parseOptions", () => {
     });
   });
 
+  it("sets check flag and custom directory when both provided", () => {
+    process.argv.push("--check", "custom/directory");
+
+    const actual = parseOptions();
+
+    expect(actual).toEqual({
+      check: true,
+      directory: "custom/directory",
+    });
+  });
+
   it("uses default directory", () => {
     const actual = parseOptions();
 

--- a/packages/example-embedder/src/bin/parseOptions.ts
+++ b/packages/example-embedder/src/bin/parseOptions.ts
@@ -3,16 +3,17 @@ interface CliOptions {
   directory: string;
 }
 
-const DEFAULTS = {
+const DEFAULTS: CliOptions = {
+  check: false,
   directory: "examples",
 };
 
 export function parseOptions(): CliOptions {
-  const { directory } = DEFAULTS;
-  const directoryIndex = process.argv.indexOf("--directory");
+  const check = process.argv.includes("--check") ?? DEFAULTS.check;
+  const rest = process.argv.filter((argument) => argument !== "--check");
 
   return {
-    check: process.argv.includes("--check"),
-    directory: directoryIndex === -1 ? directory : (process.argv[directoryIndex + 1] ?? directory),
+    check,
+    directory: rest[2] ?? DEFAULTS.directory,
   };
 }

--- a/packages/example-embedder/src/bin/parseOptions.ts
+++ b/packages/example-embedder/src/bin/parseOptions.ts
@@ -1,0 +1,18 @@
+interface CliOptions {
+  check: boolean;
+  directory: string;
+}
+
+const DEFAULTS = {
+  directory: "examples",
+};
+
+export function parseOptions(): CliOptions {
+  const { directory } = DEFAULTS;
+  const directoryIndex = process.argv.indexOf("--directory");
+
+  return {
+    check: process.argv.includes("--check"),
+    directory: directoryIndex === -1 ? directory : (process.argv[directoryIndex + 1] ?? directory),
+  };
+}

--- a/packages/example-embedder/src/index.ts
+++ b/packages/example-embedder/src/index.ts
@@ -1,0 +1,1 @@
+export { embedder } from "./lib/embedder";

--- a/packages/example-embedder/src/lib/embedder.spec.ts
+++ b/packages/example-embedder/src/lib/embedder.spec.ts
@@ -1,0 +1,98 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { embedder } from "./embedder";
+
+const TEST_DIR = join(__dirname, "..", "..", "test-1");
+const EXAMPLES_DIR = join(TEST_DIR, "examples");
+const SRC_DIR = join(TEST_DIR, "src");
+
+describe("embedder", () => {
+  beforeEach(async () => {
+    await rm(TEST_DIR, { recursive: true, force: true });
+    await mkdir(EXAMPLES_DIR, { recursive: true });
+    await mkdir(SRC_DIR, { recursive: true });
+    process.chdir(TEST_DIR);
+  });
+
+  afterAll(async () => {
+    await rm(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("embeds examples in target files", async () => {
+    const examplePath = join(EXAMPLES_DIR, "example.ts");
+    const targetPath = join(SRC_DIR, "target.ts");
+    const code = "const example = true;";
+    await writeFile(examplePath, [`// @example src/target.ts`, code].join("\n"));
+    await writeFile(
+      targetPath,
+      [
+        "/**",
+        " * @example examples/example.ts",
+        " * ```typescript",
+        " * const old = false;",
+        " * ```",
+        " */",
+        "export const x = 1;",
+      ].join("\n"),
+    );
+
+    await embedder({ directory: EXAMPLES_DIR });
+
+    const actual = await readFile(targetPath, "utf8");
+    expect(actual).toBe(
+      [
+        "/**",
+        " * @example examples/example.ts",
+        " * ```typescript",
+        " * const example = true;",
+        " * ```",
+        " */",
+        "export const x = 1;",
+      ].join("\n"),
+    );
+  });
+
+  it("throws error in check mode when examples don't match", async () => {
+    const examplePath = join(EXAMPLES_DIR, "example.ts");
+    const targetPath = join(SRC_DIR, "target.ts");
+    await writeFile(examplePath, [`// @example src/target.ts`, "const example = true;"].join("\n"));
+    await writeFile(
+      targetPath,
+      [
+        "/**",
+        " * @example examples/example.ts",
+        " * ```typescript",
+        " * const old = false;",
+        " * ```",
+        " */",
+        "export const x = 1;",
+      ].join("\n"),
+    );
+
+    await expect(embedder({ directory: EXAMPLES_DIR, check: true })).rejects.toThrow(
+      "Mismatch in file",
+    );
+  });
+
+  it("succeeds in check mode when examples match", async () => {
+    const examplePath = join(EXAMPLES_DIR, "example.ts");
+    const targetPath = join(SRC_DIR, "target.ts");
+    const code = "const example = true;";
+    await writeFile(examplePath, [`// @example src/target.ts`, code].join("\n"));
+    await writeFile(
+      targetPath,
+      [
+        "/**",
+        " * @example examples/example.ts",
+        " * ```typescript",
+        ` * ${code}`,
+        " * ```",
+        " */",
+        "export const x = 1;",
+      ].join("\n"),
+    );
+
+    await expect(embedder({ directory: EXAMPLES_DIR, check: true })).resolves.not.toThrow();
+  });
+});

--- a/packages/example-embedder/src/lib/embedder.ts
+++ b/packages/example-embedder/src/lib/embedder.ts
@@ -1,0 +1,31 @@
+import { checkExamples } from "./internal/checkExamples";
+import { embedExamples } from "./internal/embedExamples";
+import { findFilePaths } from "./internal/findFilePaths";
+import { targetToExampleMap } from "./internal/targetToExampleMap";
+
+interface EmbedderOptions {
+  directory: string;
+  check?: boolean;
+}
+
+export async function embedder(options: EmbedderOptions): Promise<void> {
+  const { directory, check = false } = options;
+  const paths = await findFilePaths({ directory, extension: ".ts" });
+  const map = await targetToExampleMap(paths);
+
+  if (check) {
+    const mismatches = await checkExamples(map);
+    if (mismatches.length > 0) {
+      const errors = mismatches.map(
+        (m) => `Mismatch in file '${m.targetPath}' for example '${m.examplePath}'`,
+      );
+      throw new Error(errors.join("\n"));
+    }
+  } else {
+    await Promise.all(
+      Object.entries(map).map(async ([targetPath, exampleMap]) => {
+        await embedExamples(targetPath, exampleMap);
+      }),
+    );
+  }
+}

--- a/packages/example-embedder/src/lib/internal/checkExamples.spec.ts
+++ b/packages/example-embedder/src/lib/internal/checkExamples.spec.ts
@@ -1,0 +1,89 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { checkExamples } from "./checkExamples";
+
+const TEST_DIR = join(__dirname, "..", "..", "..", `test-2`);
+const EXAMPLES_DIR = join(TEST_DIR, "examples");
+const SRC_DIR = join(TEST_DIR, "src");
+
+describe("checkExamples", () => {
+  beforeEach(async () => {
+    await rm(TEST_DIR, { recursive: true, force: true });
+    await mkdir(EXAMPLES_DIR, { recursive: true });
+    await mkdir(SRC_DIR, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await rm(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("returns mismatches when example code differs from file content", async () => {
+    const targetPath = join(SRC_DIR, "target.ts");
+    const targetContent = [
+      "/**",
+      " * Some docs",
+      " * @example examples/first.ts",
+      " * ```typescript",
+      " * const old = 'code';",
+      " * ```",
+      " */",
+      "export const x = 1;",
+    ].join("\n");
+    const exampleMap = {
+      "examples/first.ts": "const new = 'example';",
+    };
+    await writeFile(targetPath, targetContent);
+
+    const result = await checkExamples({ [targetPath]: exampleMap });
+
+    expect(result).toEqual([
+      {
+        targetPath,
+        examplePath: "examples/first.ts",
+      },
+    ]);
+  });
+
+  it("returns empty array when all examples match", async () => {
+    const targetPath = join(SRC_DIR, "target.ts");
+    const code = "const example = 'code';";
+    const targetContent = [
+      "/**",
+      " * Some docs",
+      " * @example examples/first.ts",
+      " * ```typescript",
+      ` * ${code}`,
+      " * ```",
+      " */",
+      "export const x = 1;",
+    ].join("\n");
+    const exampleMap = {
+      "examples/first.ts": code,
+    };
+    await writeFile(targetPath, targetContent);
+
+    const result = await checkExamples({ [targetPath]: exampleMap });
+
+    expect(result).toEqual([]);
+  });
+
+  it("ignores examples not found in example map", async () => {
+    const targetPath = join(SRC_DIR, "target.ts");
+    const targetContent = [
+      "/**",
+      " * Some docs",
+      " * @example examples/missing.ts",
+      " * ```typescript",
+      " * const code = 'example';",
+      " * ```",
+      " */",
+      "export const x = 1;",
+    ].join("\n");
+    await writeFile(targetPath, targetContent);
+
+    const result = await checkExamples({ [targetPath]: {} });
+
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/example-embedder/src/lib/internal/checkExamples.ts
+++ b/packages/example-embedder/src/lib/internal/checkExamples.ts
@@ -1,0 +1,43 @@
+import { readFile } from "node:fs/promises";
+import { relative } from "node:path";
+
+import { findExampleMatches } from "./findExampleMatches";
+import { type ExampleMap } from "./types";
+
+interface CheckResult {
+  targetPath: string;
+  examplePath: string;
+}
+
+export async function checkExamples(examples: Record<string, ExampleMap>): Promise<CheckResult[]> {
+  const targetPaths = Object.entries(examples);
+  const contents = await Promise.all(
+    targetPaths.map(async ([targetPath]) => await readFile(targetPath, "utf8")),
+  );
+
+  return targetPaths.flatMap(([targetPath, exampleMap], index) => {
+    const matches = findExampleMatches(contents[index]!, targetPath);
+    const relativeExampleMap = Object.fromEntries(
+      Object.entries(exampleMap).map(([path, content]) => [relative(process.cwd(), path), content]),
+    );
+
+    return matches
+      .filter(
+        ({ examplePath, code }) =>
+          relativeExampleMap[examplePath] &&
+          normalize(relativeExampleMap[examplePath]) !== normalize(code),
+      )
+      .map(({ examplePath }) => ({ targetPath, examplePath }));
+  });
+}
+
+function normalize(code: string): string {
+  return code
+    .split("\n")
+    .map((line) => line.trim())
+    .map((line) => line.replace(/^\s*\*\s*/, ""))
+    .filter(Boolean)
+    .join(" ")
+    .replaceAll(/\s+/g, " ")
+    .replaceAll(/;$/g, "");
+}

--- a/packages/example-embedder/src/lib/internal/embedExamples.spec.ts
+++ b/packages/example-embedder/src/lib/internal/embedExamples.spec.ts
@@ -1,0 +1,255 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { embedExamples } from "./embedExamples";
+
+const TEST_DIR = join(__dirname, "..", "..", "..", `test-3`);
+const EXAMPLES_DIR = join(TEST_DIR, "examples");
+const SRC_DIR = join(TEST_DIR, "src");
+const DOCS_DIR = join(TEST_DIR, "docs");
+
+describe("embedExamples", () => {
+  beforeEach(async () => {
+    await rm(TEST_DIR, { recursive: true, force: true });
+    await mkdir(EXAMPLES_DIR, { recursive: true });
+    await mkdir(SRC_DIR, { recursive: true });
+    await mkdir(DOCS_DIR, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await rm(TEST_DIR, { recursive: true, force: true });
+  });
+
+  describe("typescript files", () => {
+    it("updates multiple example blocks with their corresponding examples", async () => {
+      const targetPath = join(SRC_DIR, "target.ts");
+      const targetContent = [
+        "/**",
+        " * Some docs",
+        " * @example examples/first.ts",
+        " * ```typescript",
+        " * const old1 = 'code';",
+        " * ```",
+        " *",
+        " * @example examples/second.ts",
+        " * ```typescript",
+        " * const old2 = 'code';",
+        " * ```",
+        " */",
+        "export const x = 1;",
+      ].join("\n");
+      const exampleMap = {
+        "examples/first.ts": "const first = 'example1';",
+        "examples/second.ts": "const second = 'example2';",
+      };
+      await writeFile(targetPath, targetContent);
+
+      await embedExamples(targetPath, exampleMap);
+
+      const result = await readFile(targetPath, "utf8");
+      expect(result).toBe(
+        [
+          "/**",
+          " * Some docs",
+          " * @example examples/first.ts",
+          " * ```typescript",
+          " * const first = 'example1';",
+          " * ```",
+          " *",
+          " * @example examples/second.ts",
+          " * ```typescript",
+          " * const second = 'example2';",
+          " * ```",
+          " */",
+          "export const x = 1;",
+        ].join("\n"),
+      );
+    });
+
+    it("preserves non-matching example blocks", async () => {
+      const targetPath = join(SRC_DIR, "target.ts");
+      const targetContent = [
+        "/**",
+        " * Some docs",
+        " * @example examples/first.ts",
+        " * ```typescript",
+        " * const old1 = 'code';",
+        " * ```",
+        " *",
+        " * @example",
+        " * ```typescript",
+        " * const shouldNotChange = 'code';",
+        " * ```",
+        " *",
+        " * @example examples/second.ts",
+        " * ```typescript",
+        " * const old2 = 'code';",
+        " * ```",
+        " */",
+        "export const x = 1;",
+      ].join("\n");
+      const exampleMap = {
+        "examples/first.ts": "const first = 'example1';",
+        "examples/second.ts": "const second = 'example2';",
+      };
+      await writeFile(targetPath, targetContent);
+
+      await embedExamples(targetPath, exampleMap);
+
+      const result = await readFile(targetPath, "utf8");
+      expect(result).toBe(
+        [
+          "/**",
+          " * Some docs",
+          " * @example examples/first.ts",
+          " * ```typescript",
+          " * const first = 'example1';",
+          " * ```",
+          " *",
+          " * @example",
+          " * ```typescript",
+          " * const shouldNotChange = 'code';",
+          " * ```",
+          " *",
+          " * @example examples/second.ts",
+          " * ```typescript",
+          " * const second = 'example2';",
+          " * ```",
+          " */",
+          "export const x = 1;",
+        ].join("\n"),
+      );
+    });
+
+    it("handles multiline example code correctly", async () => {
+      const targetPath = join(SRC_DIR, "target.ts");
+      const targetContent = [
+        "/**",
+        " * Some docs",
+        " * @example examples/multiline.ts",
+        " * ```typescript",
+        " * const old = 'code';",
+        " * ```",
+        " */",
+        "export const x = 1;",
+      ].join("\n");
+      const exampleMap = {
+        "examples/multiline.ts":
+          "const first = 'line1';\nconst second = 'line2';\n\nconst third = 'line3';",
+      };
+      await writeFile(targetPath, targetContent);
+
+      await embedExamples(targetPath, exampleMap);
+
+      const result = await readFile(targetPath, "utf8");
+      expect(result).toBe(
+        [
+          "/**",
+          " * Some docs",
+          " * @example examples/multiline.ts",
+          " * ```typescript",
+          " * const first = 'line1';",
+          " * const second = 'line2';",
+          " *",
+          " * const third = 'line3';",
+          " * ```",
+          " */",
+          "export const x = 1;",
+        ].join("\n"),
+      );
+    });
+
+    it("ignores example paths not found in example map", async () => {
+      const targetPath = join(SRC_DIR, "target.ts");
+      const targetContent = [
+        "/**",
+        " * Some docs",
+        " * @example examples/missing.ts",
+        " * ```typescript",
+        " * const old = 'code';",
+        " * ```",
+        " */",
+        "export const x = 1;",
+      ].join("\n");
+      const exampleMap = {};
+      await writeFile(targetPath, targetContent);
+
+      await embedExamples(targetPath, exampleMap);
+
+      const result = await readFile(targetPath, "utf8");
+      expect(result).toBe(targetContent);
+    });
+  });
+
+  describe("markdown files", () => {
+    it("updates example blocks in markdown files", async () => {
+      const targetPath = join(DOCS_DIR, "README.md");
+      const targetContent = [
+        "# Title",
+        "",
+        "@example examples/example.ts",
+        "```typescript",
+        "const old = 'code';",
+        "```",
+        "",
+        "Some text",
+      ].join("\n");
+      const exampleMap = {
+        "examples/example.ts": "const example = 'new';",
+      };
+      await writeFile(targetPath, targetContent);
+
+      await embedExamples(targetPath, exampleMap);
+
+      const result = await readFile(targetPath, "utf8");
+      expect(result).toBe(
+        [
+          "# Title",
+          "",
+          "@example examples/example.ts",
+          "```typescript",
+          "const example = 'new';",
+          "```",
+          "",
+          "Some text",
+        ].join("\n"),
+      );
+    });
+
+    it("preserves markdown formatting", async () => {
+      const targetPath = join(DOCS_DIR, "README.md");
+      const targetContent = [
+        "# Title",
+        "",
+        "@example examples/example.ts",
+        "```typescript",
+        "const old = 'code';",
+        "```",
+        "",
+        "- List item",
+        "  - Nested item",
+      ].join("\n");
+      const exampleMap = {
+        "examples/example.ts": "const example = 'new';",
+      };
+      await writeFile(targetPath, targetContent);
+
+      await embedExamples(targetPath, exampleMap);
+
+      const result = await readFile(targetPath, "utf8");
+      expect(result).toBe(
+        [
+          "# Title",
+          "",
+          "@example examples/example.ts",
+          "```typescript",
+          "const example = 'new';",
+          "```",
+          "",
+          "- List item",
+          "  - Nested item",
+        ].join("\n"),
+      );
+    });
+  });
+});

--- a/packages/example-embedder/src/lib/internal/embedExamples.ts
+++ b/packages/example-embedder/src/lib/internal/embedExamples.ts
@@ -1,0 +1,52 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { extname, relative } from "node:path";
+
+import { findExampleMatches } from "./findExampleMatches";
+import type { ExampleMap } from "./types";
+
+export async function embedExamples(targetPath: string, exampleMap: ExampleMap): Promise<void> {
+  const content = await readFile(targetPath, "utf8");
+  const matches = findExampleMatches(content, targetPath);
+  const isMarkdown = extname(targetPath) === ".md";
+  const normalize = isMarkdown ? normalizeMarkdown : normalizeTypescript;
+  const relativeExampleMap = Object.fromEntries(
+    Object.entries(exampleMap).map(([path, content]) => [relative(process.cwd(), path), content]),
+  );
+
+  let updatedContent = content;
+  for (const { prefix, examplePath } of matches) {
+    const exampleCode = relativeExampleMap[examplePath];
+    if (exampleCode) {
+      const normalizedCode = normalize(exampleCode);
+      const codeBlock = `\`\`\`typescript\n${normalizedCode}\n${isMarkdown ? "" : " * "}\`\`\``;
+      // eslint-disable-next-line security/detect-non-literal-regexp
+      const pattern = new RegExp(`${escapeRegExp(prefix)}\\s*\`\`\`typescript\\n[^]*?\`\`\``, "g");
+      updatedContent = updatedContent.replace(pattern, `${prefix}${codeBlock}`);
+    }
+  }
+
+  if (updatedContent !== content) {
+    await writeFile(targetPath, updatedContent);
+  }
+}
+
+function normalizeTypescript(code: string): string {
+  return code
+    .split("\n")
+    .map((line) => {
+      const trimmed = line.trim();
+      return trimmed ? ` * ${trimmed}` : " *";
+    })
+    .join("\n");
+}
+
+function normalizeMarkdown(code: string): string {
+  return code
+    .split("\n")
+    .map((line) => line.trim())
+    .join("\n");
+}
+
+function escapeRegExp(string: string): string {
+  return string.replaceAll(/[$()*+.?[\\\]^{|}]/g, "\\$&");
+}

--- a/packages/example-embedder/src/lib/internal/findExampleMatches.ts
+++ b/packages/example-embedder/src/lib/internal/findExampleMatches.ts
@@ -1,0 +1,30 @@
+import { extname } from "node:path";
+
+const EXAMPLE_PATH = "examples\\/[^\\n]+";
+const CODE_BLOCK = "(```typescript\\n([^`]*)```)";
+const PATTERNS = {
+  ts: new RegExp(`(@example\\s+(${EXAMPLE_PATH})\n\\s*\\*\\s*${CODE_BLOCK})`, "g"),
+  md: new RegExp(`(@example\\s+(${EXAMPLE_PATH})\n\\s*${CODE_BLOCK})`, "g"),
+} as const;
+
+interface ExampleMatch {
+  prefix: string;
+  examplePath: string;
+  code: string;
+}
+
+export function findExampleMatches(content: string, filePath: string): ExampleMatch[] {
+  const matches: ExampleMatch[] = [];
+  for (const match of content.matchAll(PATTERNS[extname(filePath) === ".md" ? "md" : "ts"])) {
+    const [, prefix, examplePath, codeBlock, code] = match;
+    if (prefix && examplePath && codeBlock && code) {
+      matches.push({
+        prefix: prefix.replace(codeBlock, ""),
+        examplePath,
+        code: code.trim(),
+      });
+    }
+  }
+
+  return matches;
+}

--- a/packages/example-embedder/src/lib/internal/findFilePaths.spec.ts
+++ b/packages/example-embedder/src/lib/internal/findFilePaths.spec.ts
@@ -1,5 +1,5 @@
 import { mkdir, rm, writeFile } from "node:fs/promises";
-import { join } from "node:path/posix";
+import { join } from "node:path";
 
 import { findFilePaths } from "./findFilePaths";
 

--- a/packages/example-embedder/src/lib/internal/findFilePaths.spec.ts
+++ b/packages/example-embedder/src/lib/internal/findFilePaths.spec.ts
@@ -1,0 +1,64 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path/posix";
+
+import { findFilePaths } from "./findFilePaths";
+
+const TEST_DIR = join(__dirname, "..", "..", "..", `test-4`);
+
+describe("findFilePaths", () => {
+  beforeEach(async () => {
+    await rm(TEST_DIR, { recursive: true, force: true });
+    await mkdir(TEST_DIR, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await rm(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("finds files with matching extension", async () => {
+    const filePath = join(TEST_DIR, "test.ts");
+    await writeFile(filePath, "");
+
+    const result = await findFilePaths({
+      directory: TEST_DIR,
+      extension: ".ts",
+    });
+
+    expect(result).toEqual([filePath]);
+  });
+
+  it("ignores files with non-matching extension", async () => {
+    const filePath = join(TEST_DIR, "test.js");
+    await writeFile(filePath, "");
+
+    const result = await findFilePaths({
+      directory: TEST_DIR,
+      extension: ".ts",
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("finds files in nested directories", async () => {
+    const nested = join(TEST_DIR, "nested");
+    await mkdir(nested);
+    const filePath = join(nested, "test.ts");
+    await writeFile(filePath, "");
+
+    const result = await findFilePaths({
+      directory: TEST_DIR,
+      extension: ".ts",
+    });
+
+    expect(result).toEqual([filePath]);
+  });
+
+  it("returns empty array for empty directory", async () => {
+    const result = await findFilePaths({
+      directory: TEST_DIR,
+      extension: ".ts",
+    });
+
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/example-embedder/src/lib/internal/findFilePaths.ts
+++ b/packages/example-embedder/src/lib/internal/findFilePaths.ts
@@ -1,0 +1,24 @@
+import { readdir } from "node:fs/promises";
+import { join } from "node:path/posix";
+
+export interface FindExamplesParams {
+  directory: string;
+  extension: string;
+}
+
+export async function findFilePaths(params: FindExamplesParams): Promise<readonly string[]> {
+  const { directory, extension } = params;
+  const items = await readdir(directory, { withFileTypes: true });
+  const result = await Promise.all(
+    items.map(async (item) => {
+      const path = join(directory, item.name);
+      if (item.isDirectory()) {
+        return await findFilePaths({ directory: path, extension });
+      }
+
+      return item.isFile() && path.endsWith(extension) ? [path] : [];
+    }),
+  );
+
+  return result.flat();
+}

--- a/packages/example-embedder/src/lib/internal/findFilePaths.ts
+++ b/packages/example-embedder/src/lib/internal/findFilePaths.ts
@@ -1,5 +1,5 @@
 import { readdir } from "node:fs/promises";
-import { join } from "node:path/posix";
+import { join } from "node:path";
 
 export interface FindExamplesParams {
   directory: string;

--- a/packages/example-embedder/src/lib/internal/targetToExampleMap.spec.ts
+++ b/packages/example-embedder/src/lib/internal/targetToExampleMap.spec.ts
@@ -1,0 +1,81 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { targetToExampleMap } from "./targetToExampleMap";
+
+const TEST_DIR = join(__dirname, "..", "..", "..", `test-5`);
+const EXAMPLES_DIR = join(TEST_DIR, "examples");
+const SRC_DIR = join(TEST_DIR, "src");
+
+describe("targetToExampleMap", () => {
+  beforeEach(async () => {
+    await rm(TEST_DIR, { recursive: true, force: true });
+    await mkdir(EXAMPLES_DIR, { recursive: true });
+    await mkdir(SRC_DIR, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await rm(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("finds examples and maps them to target files", async () => {
+    const examplePath = join(EXAMPLES_DIR, "example.ts");
+    const targetPath = join(SRC_DIR, "target.ts");
+    const path = "src/target.ts";
+    await writeFile(examplePath, [`// @example ${path}`, "const example = true;"].join("\n"));
+    await writeFile(
+      targetPath,
+      ["/**", " * @example examples/example.ts", " */", "export const x = 1;"].join("\n"),
+    );
+
+    const result = await targetToExampleMap([examplePath]);
+
+    expect(result).toMatchObject({
+      [path]: {
+        [examplePath]: "const example = true;",
+      },
+    });
+  });
+
+  it("finds multiple examples for the same target file", async () => {
+    const example1Path = join(EXAMPLES_DIR, "example1.ts");
+    const example2Path = join(EXAMPLES_DIR, "example2.ts");
+    const path = "src/target.ts";
+    await writeFile(example1Path, [`// @example ${path}`, "const example1 = true;"].join("\n"));
+    await writeFile(example2Path, [`// @example ${path}`, "const example2 = true;"].join("\n"));
+
+    const result = await targetToExampleMap([example1Path, example2Path]);
+
+    expect(result).toMatchObject({
+      [path]: {
+        [example1Path]: "const example1 = true;",
+        [example2Path]: "const example2 = true;",
+      },
+    });
+  });
+
+  it("finds examples in nested directories", async () => {
+    const nested = join(EXAMPLES_DIR, "nested");
+    await mkdir(nested, { recursive: true });
+    const examplePath = join(nested, "example.ts");
+    const path = "src/target.ts";
+    await writeFile(examplePath, [`// @example ${path}`, "const example = true;"].join("\n"));
+
+    const result = await targetToExampleMap([examplePath]);
+
+    expect(result).toMatchObject({
+      [path]: {
+        [examplePath]: "const example = true;",
+      },
+    });
+  });
+
+  it("ignores files without @example annotation", async () => {
+    const examplePath = join(EXAMPLES_DIR, "example.ts");
+    await writeFile(examplePath, "const example = true;");
+
+    const result = await targetToExampleMap([examplePath]);
+
+    expect(result).toEqual({});
+  });
+});

--- a/packages/example-embedder/src/lib/internal/targetToExampleMap.spec.ts
+++ b/packages/example-embedder/src/lib/internal/targetToExampleMap.spec.ts
@@ -78,4 +78,13 @@ describe("targetToExampleMap", () => {
 
     expect(result).toEqual({});
   });
+
+  it("throws error for invalid target paths", async () => {
+    const examplePath = join(EXAMPLES_DIR, "example.ts");
+    await writeFile(examplePath, "// @example ../invalid/path\nconst example = true;");
+
+    await expect(targetToExampleMap([examplePath])).rejects.toThrow(
+      "Invalid target path: ../invalid/path",
+    );
+  });
 });

--- a/packages/example-embedder/src/lib/internal/targetToExampleMap.ts
+++ b/packages/example-embedder/src/lib/internal/targetToExampleMap.ts
@@ -1,0 +1,31 @@
+import { readFile } from "node:fs/promises";
+
+import { type ExampleMap } from "./types";
+
+export async function targetToExampleMap(
+  paths: readonly string[],
+): Promise<Record<string, ExampleMap>> {
+  const files = await Promise.all(
+    paths.map(async (path) => ({ path, content: await readFile(path, "utf8") })),
+  );
+
+  return files.reduce<Record<string, ExampleMap>>((accumulator, file) => {
+    const [firstLine, ...code] = file.content.split("\n");
+    const targetPaths = firstLine?.match(/\/\/ @example\s+(.+)/)?.[1]?.split(",");
+
+    if (!targetPaths) {
+      return accumulator;
+    }
+
+    return targetPaths.reduce((intermediateResult, targetPath) => {
+      const trimmedPath = targetPath.trim();
+      return {
+        ...intermediateResult,
+        [trimmedPath]: {
+          ...intermediateResult[trimmedPath],
+          [file.path]: code.join("\n"),
+        },
+      };
+    }, accumulator);
+  }, {});
+}

--- a/packages/example-embedder/src/lib/internal/types.ts
+++ b/packages/example-embedder/src/lib/internal/types.ts
@@ -1,0 +1,1 @@
+export type ExampleMap = Record<string, string>;

--- a/packages/example-embedder/tsconfig.json
+++ b/packages/example-embedder/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.lint.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/example-embedder/tsconfig.lib.json
+++ b/packages/example-embedder/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts"]
+}

--- a/packages/example-embedder/tsconfig.lint.json
+++ b/packages/example-embedder/tsconfig.lint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  },
+  "include": ["."]
+}

--- a/packages/example-embedder/tsconfig.spec.json
+++ b/packages/example-embedder/tsconfig.spec.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  },
+  "include": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/packages/example-embedder/typedoc.json
+++ b/packages/example-embedder/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/example-nestjs/README.md
+++ b/packages/example-nestjs/README.md
@@ -25,7 +25,7 @@ Install the [REST Client](https://marketplace.visualstudio.com/items?itemName=hu
 The following makes requests to the example application using the `ts-rest` client.
 
 <!-- prettier-ignore -->
-```ts
+```typescript
 // ./examples/client.ts
 
 import { initClient, type ServerInferRequest } from "@ts-rest/core";

--- a/packages/execution-context/README.md
+++ b/packages/execution-context/README.md
@@ -24,7 +24,7 @@ npm install @clipboard-health/execution-context
 
 This example demonstrates how to create a logging context, accumulate metadata from various function calls, and then log a single message containing all the gathered metadata.
 
-```ts
+```typescript
 // ./examples/executionContext.ts
 
 import {

--- a/packages/json-api-nestjs/README.md
+++ b/packages/json-api-nestjs/README.md
@@ -22,7 +22,7 @@ npm install @clipboard-health/json-api-nestjs
 Create Zod schemas for your API's queries:
 
 <!-- prettier-ignore -->
-```ts
+```typescript
 // ../example-nestjs/examples/query.ts
 
 import { booleanString } from "@clipboard-health/contract-core";

--- a/packages/json-api/README.md
+++ b/packages/json-api/README.md
@@ -22,7 +22,7 @@ npm install @clipboard-health/json-api
 From the client, call `toClientSearchParams` to convert from `ClientJsonApiQuery` to `URLSearchParams`:
 
 <!-- prettier-ignore -->
-```ts
+```typescript
 // ./examples/toClientSearchParams.ts
 
 import { deepEqual } from "node:assert/strict";
@@ -58,7 +58,7 @@ deepEqual(
 From the server, call `toServerJsonApiQuery` to convert from `URLSearchParams` to `ServerJsonApiQuery`:
 
 <!-- prettier-ignore -->
-```ts
+```typescript
 // ./examples/toServerJsonApiQuery.ts
 
 import { deepEqual } from "node:assert/strict";

--- a/packages/rules-engine/README.md
+++ b/packages/rules-engine/README.md
@@ -18,7 +18,7 @@ npm install @clipboard-health/rules-engine
 
 ## Usage
 
-```ts
+```typescript
 // ./examples/rules.ts
 
 import {

--- a/packages/testing-core/README.md
+++ b/packages/testing-core/README.md
@@ -23,7 +23,7 @@ Jest's [`expect(...).toBeDefined()`](https://jestjs.io/docs/expect#tobedefined) 
 
 This gives a type error:
 
-```ts
+```typescript
 const value = getValue(); // returns 'string | undefined'
 
 expect(value).toBeDefined();
@@ -35,7 +35,7 @@ const { length } = value;
 This library's helpers narrow types:
 
 <!-- prettier-ignore -->
-```ts
+```typescript
 // ./examples/expectToBeDefined.ts
 
 import { ok } from "node:assert/strict";
@@ -56,7 +56,7 @@ ok(length === 2);
 ```
 
 <!-- prettier-ignore -->
-```ts
+```typescript
 // ./examples/expectToBeLeft.ts
 
 import { ok } from "node:assert/strict";
@@ -81,7 +81,7 @@ ok(value.left === "Cannot divide by zero");
 ```
 
 <!-- prettier-ignore -->
-```ts
+```typescript
 // ./examples/expectToBeRight.ts
 
 import { ok } from "node:assert/strict";
@@ -106,7 +106,7 @@ ok(value.right === 5);
 ```
 
 <!-- prettier-ignore -->
-```ts
+```typescript
 // ./examples/expectToBeSafeParseError.ts
 
 import { ok } from "node:assert/strict";
@@ -129,7 +129,7 @@ ok(firstIssue.message === "Expected string, received number");
 ```
 
 <!-- prettier-ignore -->
-```ts
+```typescript
 // ./examples/expectToBeSafeParseSuccess.ts
 
 import { ok } from "node:assert/strict";

--- a/packages/util-ts/README.md
+++ b/packages/util-ts/README.md
@@ -27,7 +27,7 @@ See `./src/lib` for each utility.
 ### ServiceError
 
 <!-- prettier-ignore -->
-```ts
+```typescript
 // ./examples/serviceError.ts
 
 import { deepEqual, equal } from "node:assert/strict";
@@ -115,7 +115,7 @@ try {
 ### ServiceResult
 
 <!-- prettier-ignore -->
-```ts
+```typescript
 // ./examples/serviceResult.ts
 
 import { ok } from "node:assert/strict";
@@ -153,7 +153,7 @@ ok(E.isRight(validateUser({ email: "user@example.com", phone: "555-555-5555" }))
 #### `pipe`
 
 <!-- prettier-ignore -->
-```ts
+```typescript
 // ./examples/pipe.ts
 
 import { equal } from "node:assert/strict";
@@ -175,7 +175,7 @@ equal(result, "Hello World");
 #### `option`
 
 <!-- prettier-ignore -->
-```ts
+```typescript
 // ./examples/option.ts
 
 import { equal } from "node:assert/strict";
@@ -207,7 +207,7 @@ equal(result, "Result is 0.1");
 #### `either`
 
 <!-- prettier-ignore -->
-```ts
+```typescript
 // ./examples/either.ts
 
 import { equal } from "node:assert/strict";

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,6 +13,7 @@
       "@clipboard-health/config": ["packages/config/src/index.ts"],
       "@clipboard-health/contract-core": ["packages/contract-core/src/index.ts"],
       "@clipboard-health/eslint-config": ["packages/eslint-config/src/index.js"],
+      "@clipboard-health/example-embedder": ["packages/example-embedder/src/index.ts"],
       "@clipboard-health/execution-context": ["packages/execution-context/src/index.ts"],
       "@clipboard-health/json-api": ["packages/json-api/src/index.ts"],
       "@clipboard-health/json-api-nestjs": ["packages/json-api-nestjs/src/index.ts"],


### PR DESCRIPTION
Summary
===
Add `example-embedder`, a a CLI to embed example TypeScript code into TypeDoc comments and markdown files. It replaces https://github.com/zakhenry/embedme and https://github.com/ferdodo/typedoc-plugin-include-example while also allowing us to embed examples directly into TypeDoc comments so they show up in IDE "on-hover" and remain up-to-date and type checked.