### PR TITLE
feat: Add extractRelatedResourceByName helper

### DIFF
--- a/packages/json-api/src/lib/response/extractRelatedResourceByName.spec.ts
+++ b/packages/json-api/src/lib/response/extractRelatedResourceByName.spec.ts
@@ -1,0 +1,106 @@
+import { extractRelatedResourceByName } from "./jsonApiHelpers";
+
+describe("extractRelatedResourceByName", () => {
+  it("should return undefined if relationships are undefined", () => {
+    const apiResponse = {
+      data: {
+        type: "book",
+        id: "1",
+      },
+    };
+    const result = extractRelatedResourceByName(apiResponse.data, undefined, "author");
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined if included array is undefined", () => {
+    const apiResponse = {
+      data: {
+        type: "book",
+        id: "1",
+        relationships: {
+          author: { data: { type: "person", id: "1" } },
+          editor: { data: { type: "person", id: "2" } },
+        },
+      },
+    };
+    const result = extractRelatedResourceByName(apiResponse.data, undefined, "author");
+    expect(result).toBeUndefined();
+  });
+
+  it("should return the related resource when relationship data is a single object", () => {
+    const apiResponse = {
+      data: {
+        type: "book",
+        id: "1",
+        relationships: {
+          author: { data: { type: "person", id: "1" } },
+          editor: { data: { type: "person", id: "2" } },
+        },
+      },
+      included: [
+        { type: "person", id: "1", attributes: { name: "John Doe" } },
+        { type: "person", id: "2", attributes: { name: "Jane Doe 2" } },
+      ],
+    };
+    const result = extractRelatedResourceByName(apiResponse.data, apiResponse.included, "author");
+    expect(result).toEqual({ type: "person", id: "1", attributes: { name: "John Doe" } });
+
+    const result2 = extractRelatedResourceByName(apiResponse.data, apiResponse.included, "editor");
+    expect(result2).toEqual({ type: "person", id: "2", attributes: { name: "Jane Doe 2" } });
+  });
+
+  it("should return an array of related resources when relationship data is an array", () => {
+    const apiResponse = {
+      data: {
+        type: "post",
+        id: "1",
+        relationships: {
+          comments: {
+            data: [
+              { type: "comment", id: "1" },
+              { type: "comment", id: "2" },
+            ],
+          },
+        },
+      },
+      included: [
+        { type: "comment", id: "1", attributes: { text: "Great post!" } },
+        { type: "comment", id: "2", attributes: { text: "Thanks for sharing!" } },
+      ],
+    };
+    const result = extractRelatedResourceByName(apiResponse.data, apiResponse.included, "comments");
+    expect(result).toEqual([
+      { type: "comment", id: "1", attributes: { text: "Great post!" } },
+      { type: "comment", id: "2", attributes: { text: "Thanks for sharing!" } },
+    ]);
+  });
+
+  it("should return undefined if the relationship name does not exist", () => {
+    const apiResponse = {
+      data: {
+        type: "book",
+        id: "1",
+        relationships: {
+          author: { data: { type: "person", id: "1" } },
+        },
+      },
+      included: [{ type: "person", id: "1", attributes: { name: "John Doe" } }],
+    };
+    const result = extractRelatedResourceByName(apiResponse.data, apiResponse.included, "editor");
+    expect(result).toBeUndefined();
+  });
+
+  // Ideally this is server error and responsibility of the server to return the correct data, but it's good to have a test for it
+  it("should return undefined if no matching included resource is found", () => {
+    const apiResponse = {
+      data: {
+        type: "book",
+        id: "1",
+        relationships: { author: { data: { type: "person", id: "2" } } },
+      },
+      included: [{ type: "person", id: "1", attributes: { name: "John Doe" } }],
+    };
+    const result = extractRelatedResourceByName(apiResponse.data, apiResponse.included, "author");
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/json-api/src/lib/response/extractRelatedResourceByName.ts
+++ b/packages/json-api/src/lib/response/extractRelatedResourceByName.ts
@@ -1,0 +1,41 @@
+  import { JsonApiResource } from "../types";
+  /**
+   * Extracts a related resource from the included array of a JSON:API response
+   * based on the relationship name.
+   *
+   * @param resource - The main resource containing the relationships.
+   * @param included - The included array from a JSON:API response.
+   * @param relationshipName - The name of the relationship to extract.
+   * @returns The related resource if found, otherwise undefined.
+   */
+  export function extractRelatedResourceByName(
+    resource: JsonApiResource,
+    included: JsonApiResource[] | undefined,
+    relationshipName: string
+  ): JsonApiResource | JsonApiResource[] | undefined {
+    if (!resource.relationships || !included) {
+      return undefined;
+    }
+  
+    const relationship = resource.relationships[relationshipName];
+    if (!relationship?.data) {
+      return undefined;
+    }
+  
+    if (Array.isArray(relationship.data)) {
+      return relationship.data
+        .map((data) =>
+          included?.find(
+            (includedResource) =>
+              includedResource.type === data.type && includedResource.id === data.id
+          )
+        )
+        .filter((element) => !!element);
+    }
+  
+    const { type, id } = relationship.data;
+  
+    return included.find(
+      (includedResource) => includedResource.type === type && includedResource.id === id
+    );
+  }

--- a/packages/json-api/src/lib/types.ts
+++ b/packages/json-api/src/lib/types.ts
@@ -73,3 +73,13 @@ export interface JsonApiQuery<T extends JsonApiQueryTypes> {
 export type ClientJsonApiQuery = JsonApiQuery<ClientTypes>;
 
 export type ServerJsonApiQuery = JsonApiQuery<ServerTypes>;
+
+export interface JsonApiResource {
+  type: string;
+  id: string;
+  attributes?: Record<string, any>;
+  relationships?: Record<
+    string,
+    { data: { type: string; id: string } | Array<{ type: string; id: string }> }
+  >;
+}


### PR DESCRIPTION
Summary
===
<!--
- For expectations after PR approval and merge, see the CONTRIBUTING.md file
-->

This PR introduces the `extractRelatedResourceByName` function, which facilitates extracting relationship data from the `included` key of a `JSON:API` compliant API response using the relationship name.

Key Benefits:

- Simplified Data Access: By using the relationship name, this function retrieves the relationship's data, reducing the need for manual data traversal and lookup logic by the developer, thus saving time.
- Support for Multiple Relationships: Handles both single and multiple related resources.
- Missing Data Handling: Returns undefined when relationships or included resources are missing.
- Improved Code Readability: Encapsulates the logic for extracting related resources, leading to cleaner, less verbose code.

Changes
---
- Add helper extractRelatedResourceByName and related tests

Videos/screenshots
---
