### PR TITLE
feat: disable no-continue eslint rule

### DIFF
--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -171,6 +171,11 @@ module.exports = {
       },
     ],
 
+    // While continue can be misused, especially with nested loops and labels,
+    // it can be useful for preventing code nesting and the existence of the rule
+    // caused us to lose time debating its validity
+    "no-continue": "off",
+
     // Prefer debugging ease over an extra microtask by requiring `return await`.
     // `no-return-await` states "This can make debugging more difficult."
     "no-return-await": "off",

--- a/packages/eslint-config/src/index.spec.ts
+++ b/packages/eslint-config/src/index.spec.ts
@@ -175,6 +175,11 @@ describe("eslint-config", () => {
           },
         ],
 
+        // While continue can be misused, especially with nested loops and labels,
+        // it can be useful for preventing code nesting and the existence of the rule
+        // caused us to lose time debating its validity
+        "no-continue": "off",
+
         // Prefer debugging ease over an extra microtask by requiring `return await`.
         // `no-return-await` states "This can make debugging more difficult."
         "no-return-await": "off",


### PR DESCRIPTION
While `continue` can be misused, especially with nested loops and labels, it can be useful for preventing code nesting and the existence of the rule caused us to lose time debating its validity

See full slack discussion about it [here](https://clipboardhealth.slack.com/archives/C03GV3J181X/p1736877828918619)

