### PR TITLE
feat(MX-3792): add `addToMetadataRecord` function in execution-context

### DIFF
--- a/packages/execution-context/src/lib/contextStore.spec.ts
+++ b/packages/execution-context/src/lib/contextStore.spec.ts
@@ -1,6 +1,7 @@
 import {
   addMetadataToLocalContext,
   addToMetadataList,
+  addToMetadataRecord,
   getExecutionContext,
   newExecutionContext,
   runWithExecutionContext,
@@ -13,6 +14,8 @@ const addMetadataIfContextIsPresent = () => {
   });
   addToMetadataList("list", { listKey: "listValue" });
   addToMetadataList("list", { listKey: "listValue" });
+  addToMetadataRecord("record", { recordKey1: "recordValue1" });
+  addToMetadataRecord("record", { recordKey2: "recordValue2" });
 };
 
 describe("Context Store", () => {
@@ -25,6 +28,7 @@ describe("Context Store", () => {
         key1: "value1",
         key2: "value2",
         list: [{ listKey: "listValue" }, { listKey: "listValue" }],
+        record: { recordKey1: "recordValue1", recordKey2: "recordValue2" },
       });
     });
   });

--- a/packages/execution-context/src/lib/util.ts
+++ b/packages/execution-context/src/lib/util.ts
@@ -1,0 +1,3 @@
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
Summary
===
Linear: https://linear.app/clipboardhealth/issue/MX-3792/bug-in-the-windowcreationjob-log-we-repeat-flag-definitions-multiple

Changes
---
- add `addToMetadataRecord` function in `execution-context` package that can be used to add records in a nested context record.
This makes it easy to contain relevant log data within a `key`

Videos/screenshots
---
