### PR TITLE
chore: add the allIf runner to the rules engine

### DIFF
--- a/packages/rules-engine/README.md
+++ b/packages/rules-engine/README.md
@@ -25,6 +25,7 @@ import { deepEqual } from "node:assert/strict";
 
 import {
   all,
+  allIf,
   appendOutput,
   firstMatch,
   type Rule,
@@ -89,6 +90,17 @@ const firstMatchResult = firstMatch(
 ).run(exampleContext);
 
 deepEqual(firstMatchResult.output, [{ result: 7 }]);
+
+// Using allIf() applies all the rules that return true for `runIf` to the context when the predicate
+// (a function received as firs argument) returns true
+const allIfResult = allIf(
+  (input) => input.a === 2,
+  divideNumbersIfNegative,
+  addNumbersIfPositiveRule,
+  multiplyNumbersIfPositiveRule,
+).run(exampleContext);
+
+deepEqual(allIfResult.output, [{ result: 7 }, { result: 10 }]);
 ```
 
 </embedex>

--- a/packages/rules-engine/examples/rules.ts
+++ b/packages/rules-engine/examples/rules.ts
@@ -3,6 +3,7 @@ import { deepEqual } from "node:assert/strict";
 
 import {
   all,
+  allIf,
   appendOutput,
   firstMatch,
   type Rule,
@@ -67,3 +68,14 @@ const firstMatchResult = firstMatch(
 ).run(exampleContext);
 
 deepEqual(firstMatchResult.output, [{ result: 7 }]);
+
+// Using allIf() applies all the rules that return true for `runIf` to the context when the predicate
+// (a function received as firs argument) returns true
+const allIfResult = allIf(
+  (input) => input.a === 2,
+  divideNumbersIfNegative,
+  addNumbersIfPositiveRule,
+  multiplyNumbersIfPositiveRule,
+).run(exampleContext);
+
+deepEqual(allIfResult.output, [{ result: 7 }, { result: 10 }]);

--- a/packages/rules-engine/src/lib/runners/allIf.spec.ts
+++ b/packages/rules-engine/src/lib/runners/allIf.spec.ts
@@ -1,6 +1,6 @@
-import { type Rule, type RuleContext } from "../..";
 import { appendOutput } from "../appendOutput";
-import { allIfFirst } from "./allIfFirst";
+import { type Rule, type RuleContext } from "../rule";
+import { allIf } from "./allIf";
 
 interface Input {
   a: number;
@@ -38,31 +38,27 @@ const testRule4: TestRule = {
   run: (context) => appendOutput(context, 4),
 };
 
-describe("allIfFirst", () => {
+describe("allIf", () => {
   describe("if", () => {
-    it("returns true if the first rule is true", () => {
-      expect(allIfFirst(testRule2, testRule1).runIf(context.input)).toBe(true);
+    it("returns true if predicate returns true", () => {
+      expect(allIf(() => true, testRule2, testRule1).runIf(context.input)).toBe(true);
     });
 
-    it("returns false if the first rule is false", () => {
-      expect(allIfFirst(testRule1, testRule2).runIf(context.input)).toBe(false);
-    });
-
-    it("returns false if the array is empty", () => {
-      expect(allIfFirst().runIf(context.input)).toBe(false);
+    it("returns false if predicate returns false", () => {
+      expect(allIf(() => false, testRule2, testRule1).runIf(context.input)).toBe(false);
     });
   });
 
   describe("run", () => {
     it("runs all the matching rules", () => {
-      expect(allIfFirst(testRule2, testRule1, testRule3, testRule4).run(context)).toEqual({
+      expect(allIf(() => true, testRule2, testRule1, testRule3, testRule4).run(context)).toEqual({
         ...context,
         output: [2, 3],
       });
     });
 
     it("returns the received context if no rule can be run", () => {
-      expect(allIfFirst(testRule1, testRule4).run(context)).toEqual(context);
+      expect(allIf(() => true, testRule1, testRule4).run(context)).toEqual(context);
     });
   });
 });

--- a/packages/rules-engine/src/lib/runners/allIf.ts
+++ b/packages/rules-engine/src/lib/runners/allIf.ts
@@ -1,9 +1,18 @@
 import { type Rule, type RuleContext } from "../rule";
 
 /**
- * Run all rules that return true when `allIfPredicate` returns true.
+ * Run all rules that return true for their runIf condition, but only when the predicate function returns true.
  *
- * @param rules The rules to run.
+ * @param allIfPredicate - Function that determines if rules should be evaluated
+ * @param rules - Array of rules to evaluate when predicate is true
+ * @returns A Rule that combines the behavior of all matching rules
+ *
+ * @example
+ * const rule = allIf(
+ *   (input) => input.type === 'special',
+ *   rule1,
+ *   rule2
+ * );
  */
 export function allIf<TInput, TOutput, TContext extends RuleContext<TInput, TOutput>>(
   allIfPredicate: (input: RuleContext<TInput, TOutput>["input"]) => boolean,

--- a/packages/rules-engine/src/lib/runners/allIf.ts
+++ b/packages/rules-engine/src/lib/runners/allIf.ts
@@ -1,16 +1,17 @@
 import { type Rule, type RuleContext } from "../rule";
 
 /**
- * Run all rules that return true for `runIf` only if the first rule returns true.
+ * Run all rules that return true when `allIfPredicate` returns true.
  *
  * @param rules The rules to run.
  */
-export function allIfFirst<TInput, TOutput, TContext extends RuleContext<TInput, TOutput>>(
+export function allIf<TInput, TOutput, TContext extends RuleContext<TInput, TOutput>>(
+  allIfPredicate: (input: RuleContext<TInput, TOutput>["input"]) => boolean,
   ...rules: Array<Rule<TInput, TOutput, TContext>>
 ): Rule<TInput, TOutput, TContext> {
   return {
-    runIf: (input) => Boolean(rules[0]?.runIf(input)),
-    run: (context) =>
+    runIf: (input) => allIfPredicate(input),
+    run: (context: TContext) =>
       rules
         .filter((rule) => rule.runIf(context.input))
         .reduce((previousContext, rule) => rule.run(previousContext), context),

--- a/packages/rules-engine/src/lib/runners/index.ts
+++ b/packages/rules-engine/src/lib/runners/index.ts
@@ -1,2 +1,3 @@
 export * from "./all";
+export * from "./allIf";
 export * from "./firstMatch";


### PR DESCRIPTION
Summary
===
<!--
- For expectations after PR approval and merge, see the CONTRIBUTING.md file
-->

Changes
---
- We have been using this new runner for different scenarios in curated shifts when we want to reuse existing rules for a new vertical or specific flow. (examples [here](https://github.com/ClipboardHealth/open-shifts/blob/main/curated-shifts/src/modules/pricing/rules/fixed-rates-workplaces.ts#L16), [here](https://github.com/ClipboardHealth/open-shifts/blob/main/curated-shifts/src/modules/pricing/rules/workplace-types/education.ts#L20))
- This runner applies all the rules that match the runIf criteria **only** when the first argument (a function) returns true.
- This overrides the previous allIf, which we never exported and used.

Videos/screenshots
---
