### PR TITLE
fix!: return 400 instead of 422 for backward compat

### DIFF
--- a/packages/util-ts/src/lib/errors/serviceError.spec.ts
+++ b/packages/util-ts/src/lib/errors/serviceError.spec.ts
@@ -29,20 +29,20 @@ describe("ServiceError", () => {
       expect(actual).toBeInstanceOf(ServiceError);
       expect(actual.issues).toEqual([
         {
-          code: ERROR_CODES.unprocessableEntity,
+          code: ERROR_CODES.badRequest,
           message: "Invalid email format",
           path: ["email"],
-          title: "Request failed validation",
+          title: "Invalid or malformed request",
         },
         {
-          code: ERROR_CODES.unprocessableEntity,
+          code: ERROR_CODES.badRequest,
           message: "Invalid phone number",
           path: ["phoneNumber"],
-          title: "Request failed validation",
+          title: "Invalid or malformed request",
         },
       ]);
       expect(actual.cause).toBe(input);
-      expect(actual.status).toBe(422);
+      expect(actual.status).toBe(400);
     });
   });
 
@@ -239,7 +239,7 @@ describe("ServiceError", () => {
     expect(jsonApi.errors).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          status: "400",
+          status: "422",
           source: expect.objectContaining({
             pointer: expect.stringMatching(/^\//),
           }),

--- a/packages/util-ts/src/lib/errors/serviceError.ts
+++ b/packages/util-ts/src/lib/errors/serviceError.ts
@@ -198,7 +198,7 @@ export class ServiceError extends Error {
 
 export function toZodIssue(issue: ZodIssue): ServiceIssue {
   return {
-    code: ERROR_CODES.unprocessableEntity,
+    code: ERROR_CODES.badRequest,
     message: issue.message,
     path: issue.path,
   };

--- a/packages/util-ts/src/lib/functional/serviceResult.spec.ts
+++ b/packages/util-ts/src/lib/functional/serviceResult.spec.ts
@@ -67,8 +67,8 @@ describe("ServiceResult", () => {
       expect(actual.left).toBeInstanceOf(ServiceError);
       expect(actual.left.issues).toEqual([
         {
-          code: ERROR_CODES.unprocessableEntity,
-          title: "Request failed validation",
+          code: ERROR_CODES.badRequest,
+          title: "Invalid or malformed request",
           message: "Expected string, received number",
           path: [],
         },


### PR DESCRIPTION
Summary
===
This started getting called by our HttpExceptionFilter in `cbh-core` in [this commit](https://github.com/ClipboardHealth/cbh-core/commit/894547763fd9d80c0d5bdc7584b802798ab8ebf7), which changed the status code from 400 to 422. This PR reverts that breaking change.

This is another breaking change, but the since the vast majority of services haven't updated yet, it's easier to revert.