### PR TITLE
fix: correct eslint-config-xo version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21337,7 +21337,7 @@
         "eslint": "^8",
         "eslint-config-airbnb-base": "^15",
         "eslint-config-prettier": "^9",
-        "eslint-config-xo": "^0.45",
+        "eslint-config-xo": "^0.45.0",
         "eslint-config-xo-react": "^0.27",
         "eslint-config-xo-typescript": "^1",
         "eslint-plugin-eslint-comments": "^3",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -15,7 +15,7 @@
     "eslint": "^8",
     "eslint-config-airbnb-base": "^15",
     "eslint-config-prettier": "^9",
-    "eslint-config-xo": "^0.45",
+    "eslint-config-xo": "^0.45.0",
     "eslint-config-xo-react": "^0.27",
     "eslint-config-xo-typescript": "^1",
     "eslint-plugin-eslint-comments": "^3",


### PR DESCRIPTION
Summary
===
<!--
- For expectations after PR approval and merge, see the CONTRIBUTING.md file
-->

Changes
---
- Fix the version of eslint-config-xo package to `^0.45.0`, as just `^0.45` updates the minor version to a version that requires eslint v9 as a peer dependency

Videos/screenshots
---
