### PR TITLE
feat: add date parsing restriction

### DIFF
--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -169,6 +169,17 @@ module.exports = {
           "`with` is disallowed in strict mode because it makes code impossible to predict and optimize.",
         selector: "WithStatement",
       },
+      {
+        selector: "NewExpression[callee.name='Date'] > Literal",
+        message:
+          "Parsing of date strings using the Date constructor is discouraged due to browser inconsistencies. Use date-fns instead.",
+      },
+      {
+        selector:
+          "CallExpression[callee.object.name='Date'][callee.property.name='parse'] > Literal",
+        message:
+          "Parsing of date strings using Date.parse() is discouraged due to browser inconsistencies. Use date-fns instead.",
+      },
     ],
 
     // While continue can be misused, especially with nested loops and labels,
@@ -190,7 +201,7 @@ module.exports = {
     "no-use-before-define": ["error", { classes: false, functions: false }],
 
     /*
-     * Only enable for properties. Favor arrow functions, they don’t have a `this` reference,
+     * Only enable for properties. Favor arrow functions, they don't have a `this` reference,
      * preventing accidental usage.
      */
     "object-shorthand": ["error", "properties"],

--- a/packages/eslint-config/src/index.spec.ts
+++ b/packages/eslint-config/src/index.spec.ts
@@ -173,6 +173,17 @@ describe("eslint-config", () => {
               "`with` is disallowed in strict mode because it makes code impossible to predict and optimize.",
             selector: "WithStatement",
           },
+          {
+            selector: "NewExpression[callee.name='Date'] > Literal",
+            message:
+              "Parsing of date strings using the Date constructor is discouraged due to browser inconsistencies. Use date-fns instead.",
+          },
+          {
+            selector:
+              "CallExpression[callee.object.name='Date'][callee.property.name='parse'] > Literal",
+            message:
+              "Parsing of date strings using Date.parse() is discouraged due to browser inconsistencies. Use date-fns instead.",
+          },
         ],
 
         // While continue can be misused, especially with nested loops and labels,


### PR DESCRIPTION
Summary
===
<!--
- For expectations after PR approval and merge, see the CONTRIBUTING.md file
-->

Changes
---
- We have an eslint rule plugin in cbh-mobile app:
https://github.com/amzn/eslint-plugin-no-date-parsing/

That disables date parsing, as there could be timezone issues. This is critical to avoid flaky tests in timezones, but the plugin unfortunately doesn't support the latest versions of eslint plugins such as parser:

```
What’s Happening?
@typescript-eslint/parser Conflict

Our project requires @typescript-eslint/parser@7.x due to @clipboard-health/eslint-config@4.20.2.
However, eslint-plugin-no-date-parsing@1.0.1 requires @typescript-eslint/parser@^5.0.0, causing a version conflict.
NPM Resolution Fails

Since both eslint-plugin-no-date-parsing and @clipboard-health/eslint-config have conflicting peer dependencies, npm cannot resolve them.
```


So, instead of relying on this plugin, we just add it as a syntax rule in our config
