### PR TITLE
fix: disable unicorn/no-null, make no-await-in-loop a warn

### DIFF
--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -132,6 +132,9 @@ module.exports = {
     // Allow PascalCase for Decorators
     "new-cap": ["warn", { capIsNew: false, newIsCap: true }],
 
+    // Set to warn so LLMs to write worse code to get around it
+    "no-await-in-loop": "warn",
+
     // Disallow `.only` in tests to prevent it from making it into `main`.
     "no-only-tests/no-only-tests": "error",
 
@@ -209,6 +212,9 @@ module.exports = {
 
     // "Better readability" is subjective
     "unicorn/no-array-reduce": "off",
+
+    // React, MongoDB, and Prisma use `null`
+    "unicorn/no-null": "off",
 
     // Our libraries don't use ESM
     "unicorn/prefer-module": "off",

--- a/packages/eslint-config/src/index.spec.ts
+++ b/packages/eslint-config/src/index.spec.ts
@@ -136,6 +136,9 @@ describe("eslint-config", () => {
         // Allow PascalCase for Decorators
         "new-cap": ["warn", { capIsNew: false, newIsCap: true }],
 
+        // Set to warn so LLMs to write worse code to get around it
+        "no-await-in-loop": "warn",
+
         // Disallow `.only` in tests to prevent it from making it into `main`.
         "no-only-tests/no-only-tests": "error",
 
@@ -213,6 +216,9 @@ describe("eslint-config", () => {
 
         // "Better readability" is subjective
         "unicorn/no-array-reduce": "off",
+
+        // React, MongoDB, and Prisma use `null`
+        "unicorn/no-null": "off",
 
         // Our libraries don't use ESM
         "unicorn/prefer-module": "off",

--- a/packages/json-api-nestjs/src/lib/internal/queryFilterPreprocessor.ts
+++ b/packages/json-api-nestjs/src/lib/internal/queryFilterPreprocessor.ts
@@ -38,6 +38,5 @@ export function queryFilterPreprocessor(value: unknown): Record<string, string> 
 }
 
 function isObject(value: unknown): value is Record<string, unknown> {
-  // eslint-disable-next-line no-eq-null, unicorn/no-null
-  return value != null && typeof value === "object";
+  return value !== null && value !== undefined && typeof value === "object";
 }

--- a/packages/json-api/src/lib/query/stringifyQuery.spec.ts
+++ b/packages/json-api/src/lib/query/stringifyQuery.spec.ts
@@ -150,7 +150,6 @@ describe("stringifyQuery", () => {
     const actual = stringify({
       filter: {
         // @ts-expect-error Testing null filter value
-        // eslint-disable-next-line unicorn/no-null
         age: null,
         status: { eq: undefined },
       },

--- a/packages/testing-core/src/lib/expectToBeDefined.spec.ts
+++ b/packages/testing-core/src/lib/expectToBeDefined.spec.ts
@@ -48,7 +48,6 @@ describe("expectToBeDefined", () => {
     },
     {
       name: "throws for null",
-      // eslint-disable-next-line unicorn/no-null
       input: null,
     },
   ])("$name", ({ input }) => {

--- a/packages/util-ts/src/lib/deepFreeze.spec.ts
+++ b/packages/util-ts/src/lib/deepFreeze.spec.ts
@@ -43,7 +43,6 @@ describe("deepFreeze", () => {
   });
 
   it("returns non-object values as-is", () => {
-    // eslint-disable-next-line unicorn/no-null
     const inputs = [null, undefined, 42, "test", true, Symbol("test")] as const;
 
     inputs.forEach((input) => {

--- a/packages/util-ts/src/lib/errors/isError.spec.ts
+++ b/packages/util-ts/src/lib/errors/isError.spec.ts
@@ -10,7 +10,6 @@ describe("isError", () => {
     { input: true, expected: false },
     { input: {}, expected: false },
     { input: [], expected: false },
-    // eslint-disable-next-line unicorn/no-null
     { input: null, expected: false },
     { input: undefined, expected: false },
   ])("returns $expected for $input", ({ input, expected }) => {

--- a/packages/util-ts/src/lib/errors/toError.spec.ts
+++ b/packages/util-ts/src/lib/errors/toError.spec.ts
@@ -8,7 +8,6 @@ describe("toError", () => {
     { input: 123, expected: "123" },
     { input: BigInt(123), expected: '"123"' },
     { input: Symbol("test"), expected: "Symbol(test)" },
-    // eslint-disable-next-line unicorn/no-null
     { input: null, expected: "null" },
     { input: undefined, expected: "" },
     { input: "", expected: "" },

--- a/packages/util-ts/src/lib/errors/toErrorMessage.spec.ts
+++ b/packages/util-ts/src/lib/errors/toErrorMessage.spec.ts
@@ -8,7 +8,6 @@ describe("toErrorMessage", () => {
     { input: 123, expected: "123" },
     { input: BigInt(123), expected: '"123"' },
     { input: Symbol("test"), expected: "Symbol(test)" },
-    // eslint-disable-next-line unicorn/no-null
     { input: null, expected: "null" },
     { input: undefined, expected: "" },
     { input: "", expected: "" },

--- a/packages/util-ts/src/lib/functional/option.spec.ts
+++ b/packages/util-ts/src/lib/functional/option.spec.ts
@@ -89,7 +89,6 @@ describe("Option", () => {
     });
 
     it("should return None for null value", () => {
-      // eslint-disable-next-line unicorn/no-null
       const actual = O.fromNullable(null);
       expect(actual).toEqual(O.none);
     });

--- a/packages/util-ts/src/lib/nullish/isDefined.spec.ts
+++ b/packages/util-ts/src/lib/nullish/isDefined.spec.ts
@@ -2,7 +2,6 @@ import { isDefined } from "./isDefined";
 
 describe("isDefined", () => {
   it.each([
-    // eslint-disable-next-line unicorn/no-null
     { input: null, expected: false },
     { input: undefined, expected: false },
     { input: "", expected: true },

--- a/packages/util-ts/src/lib/nullish/isNil.spec.ts
+++ b/packages/util-ts/src/lib/nullish/isNil.spec.ts
@@ -2,7 +2,6 @@ import { isNil, isNullOrUndefined } from "./isNil";
 
 describe("isNil", () => {
   it.each([
-    // eslint-disable-next-line unicorn/no-null
     { input: null, expected: true },
     { input: undefined, expected: true },
     { input: "", expected: false },

--- a/packages/util-ts/src/lib/nullish/nullToUndefined.spec.ts
+++ b/packages/util-ts/src/lib/nullish/nullToUndefined.spec.ts
@@ -2,7 +2,6 @@ import { nullToUndefined } from "./nullToUndefined";
 
 describe("nullToUndefined", () => {
   it("returns undefined", async () => {
-    // eslint-disable-next-line unicorn/no-null
     expect(await nullToUndefined(Promise.resolve(null))).toBeUndefined();
   });
 

--- a/packages/util-ts/src/lib/strings/isString.spec.ts
+++ b/packages/util-ts/src/lib/strings/isString.spec.ts
@@ -14,7 +14,6 @@ describe("isString", () => {
     { input: true, expected: false },
     { input: {}, expected: false },
     { input: [], expected: false },
-    // eslint-disable-next-line unicorn/no-null
     { input: null, expected: false },
     { input: undefined, expected: false },
   ])("returns $expected for $input", ({ input, expected }) => {

--- a/packages/util-ts/src/lib/strings/stringify.spec.ts
+++ b/packages/util-ts/src/lib/strings/stringify.spec.ts
@@ -8,7 +8,6 @@ describe("stringify", () => {
     { input: { foo: "bar" }, expected: '{"foo":"bar"}' },
     { input: [1, 2, 3], expected: "[1,2,3]" },
     { input: BigInt(9_007_199_254_740_991), expected: '"9007199254740991"' },
-    // eslint-disable-next-line unicorn/no-null
     { input: null, expected: "null" },
     { input: undefined, expected: undefined },
     { input: { nested: { array: [1, { x: 2 }] } }, expected: '{"nested":{"array":[1,{"x":2}]}}' },


### PR DESCRIPTION
Summary
===
React, MongoDB, and Prisma use `null` and there's [lots of argument](https://github.com/sindresorhus/meta/discussions/7) over the `unicorn/no-null` rule; disable it. Also, make `no-await-in-loop` a warn so LLMs don't write worse code to get around it.