### PR TITLE
feat(AMA-118): implement fromJsonApi method in ServiceError for JSONAPI error conversion

### DIFF
--- a/packages/util-ts/src/lib/errors/serviceError.spec.ts
+++ b/packages/util-ts/src/lib/errors/serviceError.spec.ts
@@ -351,4 +351,145 @@ describe("ServiceError", () => {
       expect(actual.status).toBe(422);
     });
   });
+
+  describe("fromJsonApi", () => {
+    it("converts JSON:API error with all fields", () => {
+      const input = {
+        errors: [
+          {
+            id: "123",
+            status: "400",
+            code: ERROR_CODES.badRequest,
+            title: "Invalid request",
+            detail: "Invalid email format",
+            source: {
+              pointer: "/data/attributes/email",
+            },
+          },
+        ],
+      };
+
+      const actual = ServiceError.fromJsonApi(input);
+
+      expect(actual).toBeInstanceOf(ServiceError);
+      expect(actual.id).toBe("123");
+      expect(actual.issues).toEqual([
+        {
+          code: ERROR_CODES.badRequest,
+          message: "Invalid email format",
+          path: ["data", "attributes", "email"],
+          title: "Invalid or malformed request",
+        },
+      ]);
+      expect(actual.status).toBe(400);
+    });
+
+    it("converts JSON:API error with minimal fields", () => {
+      const input = {
+        errors: [
+          {
+            code: ERROR_CODES.notFound,
+          },
+        ],
+      };
+
+      const actual = ServiceError.fromJsonApi(input);
+
+      expect(actual).toBeInstanceOf(ServiceError);
+      expect(actual.issues).toEqual([
+        {
+          code: ERROR_CODES.notFound,
+          title: "Resource not found",
+        },
+      ]);
+      expect(actual.status).toBe(404);
+    });
+
+    it("converts multiple JSON:API errors", () => {
+      const input = {
+        errors: [
+          {
+            code: ERROR_CODES.badRequest,
+            detail: "Invalid email",
+            source: {
+              pointer: "/data/attributes/email",
+            },
+          },
+          {
+            code: ERROR_CODES.unprocessableEntity,
+            detail: "Invalid phone",
+            source: {
+              pointer: "/data/attributes/phone",
+            },
+          },
+        ],
+      };
+
+      const actual = ServiceError.fromJsonApi(input);
+
+      expect(actual).toBeInstanceOf(ServiceError);
+      expect(actual.issues).toEqual([
+        {
+          code: ERROR_CODES.badRequest,
+          message: "Invalid email",
+          path: ["data", "attributes", "email"],
+          title: "Invalid or malformed request",
+        },
+        {
+          code: ERROR_CODES.unprocessableEntity,
+          message: "Invalid phone",
+          path: ["data", "attributes", "phone"],
+          title: "Request failed validation",
+        },
+      ]);
+      expect(actual.status).toBe(422);
+    });
+
+    it("handles different source types", () => {
+      const input = {
+        errors: [
+          {
+            code: ERROR_CODES.badRequest,
+            detail: "Invalid header",
+            source: {
+              header: "/authorization",
+            },
+          },
+        ],
+      };
+
+      const actual = ServiceError.fromJsonApi(input);
+
+      expect(actual).toBeInstanceOf(ServiceError);
+      expect(actual.issues).toEqual([
+        {
+          code: ERROR_CODES.badRequest,
+          message: "Invalid header",
+          path: ["authorization"],
+          title: "Invalid or malformed request",
+        },
+      ]);
+    });
+    it("converts to and from JSON:API format without data loss", () => {
+      const input = {
+        errors: [
+          {
+            id: "test-id",
+            status: "400",
+            code: ERROR_CODES.badRequest,
+            title: "Invalid or malformed request",
+            detail: "Invalid input",
+            source: {
+              pointer: "/data/attributes/name",
+            },
+          },
+        ],
+      };
+
+      const error = ServiceError.fromJsonApi(input);
+      const actual = error.toJsonApi();
+
+      expect(actual).toEqual(input);
+    });
+  });
 });

--- a/packages/util-ts/src/lib/errors/serviceError.ts
+++ b/packages/util-ts/src/lib/errors/serviceError.ts
@@ -130,6 +130,38 @@ export class ServiceError extends Error {
     });
   }
 
+  /**
+   * Creates a ServiceError from a JSON:API error object
+   * @see {@link https://jsonapi.org/format/#error-objects}
+   * @param jsonApiError - JSON:API error object
+   * @returns New ServiceError instance
+   */
+  static fromJsonApi(jsonApiError: {
+    errors: Array<{
+      id?: string;
+      status?: string;
+      code?: ErrorCode;
+      title?: string;
+      detail?: string;
+      source?: Record<string, string>;
+    }>;
+  }): ServiceError {
+    const issues = jsonApiError.errors.map((error) =>
+      toIssue({
+        code: error.code ?? ERROR_CODES.internal,
+        message: error.detail,
+        ...(error.source && {
+          path: Object.values(error.source)[0]?.split("/").filter(Boolean) ?? [],
+        }),
+      }),
+    );
+
+    return new ServiceError({
+      id: jsonApiError.errors[0]?.id ?? "",
+      issues,
+    });
+  }
+
   readonly id: string;
   readonly issues: readonly Issue[];
   readonly status: Status;

--- a/packages/util-ts/src/lib/errors/serviceError.ts
+++ b/packages/util-ts/src/lib/errors/serviceError.ts
@@ -146,15 +146,17 @@ export class ServiceError extends Error {
       source?: Record<string, string>;
     }>;
   }): ServiceError {
-    const issues = jsonApiError.errors.map((error) =>
-      toIssue({
+    const issues = jsonApiError.errors.map((error) => {
+      const path = Object.values(error.source ?? {})?.[0]
+        ?.split("/")
+        .filter(Boolean);
+
+      return toIssue({
         code: error.code ?? ERROR_CODES.internal,
         message: error.detail,
-        ...(error.source && {
-          path: Object.values(error.source)[0]?.split("/").filter(Boolean) ?? [],
-        }),
-      }),
-    );
+        ...(path && path.length > 0 && { path }),
+      });
+    });
 
     return new ServiceError({
       id: jsonApiError.errors[0]?.id ?? "",


### PR DESCRIPTION
Summary
===
<!--
- For expectations after PR approval and merge, see the CONTRIBUTING.md file
-->
https://linear.app/clipboardhealth/issue/AMA-118/implement-fromjsonapi-into-serviceerror-in-clipboard-healthutil-ts

Changes
---

- Added fromJsonApi method to ServiceError class to convert JSON:API error objects into ServiceError instances.
- Implemented tests for various scenarios including full, minimal, and multiple JSON:API errors, as well as handling different source types.
- Ensured that conversion to and from JSON:API format maintains data integrity without loss.

Videos/screenshots
---
