### PR TITLE
feat!: ban enums

### DIFF
--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -169,7 +169,7 @@ module.exports = {
       },
       {
         message:
-          "`with` is disallowed in strict mode because it makes code impossible to predict and optimize.",
+          "`with` is disallowed in strict mode because it makes code difficult to predict and optimize.",
         selector: "WithStatement",
       },
       {

--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -175,7 +175,7 @@ module.exports = {
       {
         selector: "TSEnumDeclaration",
         message:
-          "Enums are one of the few non-type-level extensions to JavaScript, have pitfalls, and require explicity mapping. Use const objects instead.",
+          "Enums are one of the few non-type-level extensions to JavaScript, have pitfalls, and require explicit mapping. Use const objects instead.",
       },
     ],
 

--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -153,11 +153,11 @@ module.exports = {
       },
     ],
 
-    // Adapter from Airbnb's config, but allows ForOfStatement.
-    // See https://github.com/airbnb/javascript/blob/0f3ca32323b8d5770de3301036e65511c6d18e00/packages/eslint-config-airbnb-base/rules/style.js#L340-L358
     "no-restricted-syntax": [
       "error",
       {
+        // Adapted from Airbnb's config, but allows ForOfStatement.
+        // See https://github.com/airbnb/javascript/blob/0f3ca32323b8d5770de3301036e65511c6d18e00/packages/eslint-config-airbnb-base/rules/style.js#L340-L358
         message:
           "for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.",
         selector: "ForInStatement",
@@ -171,6 +171,11 @@ module.exports = {
         message:
           "`with` is disallowed in strict mode because it makes code impossible to predict and optimize.",
         selector: "WithStatement",
+      },
+      {
+        selector: "TSEnumDeclaration",
+        message:
+          "Enums are one of the few non-type-level extensions to JavaScript, have pitfalls, and require explicity mapping. Use const objects instead.",
       },
     ],
 

--- a/packages/eslint-config/src/index.spec.ts
+++ b/packages/eslint-config/src/index.spec.ts
@@ -173,7 +173,7 @@ describe("eslint-config", () => {
           },
           {
             message:
-              "`with` is disallowed in strict mode because it makes code impossible to predict and optimize.",
+              "`with` is disallowed in strict mode because it makes code difficult to predict and optimize.",
             selector: "WithStatement",
           },
           {

--- a/packages/eslint-config/src/index.spec.ts
+++ b/packages/eslint-config/src/index.spec.ts
@@ -179,7 +179,7 @@ describe("eslint-config", () => {
           {
             selector: "TSEnumDeclaration",
             message:
-              "Enums are one of the few non-type-level extensions to JavaScript, have pitfalls, and require explicity mapping. Use const objects instead.",
+              "Enums are one of the few non-type-level extensions to JavaScript, have pitfalls, and require explicit mapping. Use const objects instead.",
           },
         ],
 

--- a/packages/eslint-config/src/index.spec.ts
+++ b/packages/eslint-config/src/index.spec.ts
@@ -157,10 +157,10 @@ describe("eslint-config", () => {
           },
         ],
 
-        // Adapter from Airbnb's config, but allows ForOfStatement.
-        // See https://github.com/airbnb/javascript/blob/0f3ca32323b8d5770de3301036e65511c6d18e00/packages/eslint-config-airbnb-base/rules/style.js#L340-L358
         "no-restricted-syntax": [
           "error",
+          // Adapted from Airbnb's config, but allows ForOfStatement.
+          // See https://github.com/airbnb/javascript/blob/0f3ca32323b8d5770de3301036e65511c6d18e00/packages/eslint-config-airbnb-base/rules/style.js#L340-L358
           {
             message:
               "for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.",
@@ -175,6 +175,11 @@ describe("eslint-config", () => {
             message:
               "`with` is disallowed in strict mode because it makes code impossible to predict and optimize.",
             selector: "WithStatement",
+          },
+          {
+            selector: "TSEnumDeclaration",
+            message:
+              "Enums are one of the few non-type-level extensions to JavaScript, have pitfalls, and require explicity mapping. Use const objects instead.",
           },
         ],
 


### PR DESCRIPTION
Summary
===
TypeScript articulated its current governing principle: TC39, the JavaScript governing body, defines the runtime, while TypeScript innovates solely in the type space. Enums predate this principle. From the [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/enums.html#const-enum-pitfalls):
> Enums are one of the few features TypeScript has which is not a type-level extension of JavaScript.

The same page [discuses enum pitfalls](https://www.typescriptlang.org/docs/handbook/enums.html#const-enum-pitfalls). Using these non-type-level extensions aren't supported by type strippers like the one built into NodeJS. Effective TypeScript recommends against them (I've [copied the relevant book section](https://www.notion.so/Effective-TypeScript-Avoid-Enums-1cb8643321f480cda6abd6824ccabe85) if you're interested).
Instead of enums:

```ts
enum Dog {
  LAB = "LAB"
}
```

Use const objects:

```ts
const DOG = {
  lab: "LAB"
} as const;
```

In addition to various foot guns enums introduce, we're starting to see them in API contracts, which require an explicit mapping step that const objects don't.

The ESLint config is from the [`typescript-eslint` docs](https://typescript-eslint.io/troubleshooting/faqs/general/#how-can-i-ban-specific-language-feature).