### PR TITLE
feat: disable `sonarjs/no-duplicate-string` for all files

### DIFF
--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -33,9 +33,6 @@ module.exports = {
       rules: {
         // Interferes with `jest`'s `expect.any`
         "@typescript-eslint/no-unsafe-assignment": "off",
-
-        // Duplication allows verbose test case setups and asserts
-        "sonarjs/no-duplicate-string": "off",
       },
     },
     /**
@@ -229,6 +226,9 @@ module.exports = {
       "error",
       { ignore: [/config/i, /params/i, /props/i, /ref/i] },
     ],
+
+    // There are cases where duplicating strings is ok (tests, contracts, etc...)
+    "sonarjs/no-duplicate-string": "off",
   },
   settings: { node: { version: ">=18.15.0" } },
 };

--- a/packages/eslint-config/src/index.spec.ts
+++ b/packages/eslint-config/src/index.spec.ts
@@ -37,9 +37,6 @@ describe("eslint-config", () => {
           rules: {
             // Interferes with `jest`'s `expect.any`
             "@typescript-eslint/no-unsafe-assignment": "off",
-
-            // Duplication allows verbose test case setups and asserts
-            "sonarjs/no-duplicate-string": "off",
           },
         },
         /**
@@ -233,6 +230,9 @@ describe("eslint-config", () => {
           "error",
           { ignore: [/config/i, /params/i, /props/i, /ref/i] },
         ],
+
+        // There are cases where duplicating strings is ok (tests, contracts, etc...)
+        "sonarjs/no-duplicate-string": "off",
       },
       settings: { node: { version: ">=18.15.0" } },
     });


### PR DESCRIPTION
Summary
===

There aren't many benefits of this rule, in some cases it makes code more difficult to maintain.
