### PR TITLE
feat: add eslint rule which blocks the use of date-fns-tz

### DIFF
--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -148,7 +148,8 @@ module.exports = {
           },
           {
             name: "date-fns-tz",
-            message: "date-fns-tz is not allowed. Use @clipboard-health/date-time, a recent version of date-fns, or moment-timezone instead",
+            message:
+              "date-fns-tz is not allowed. Use @clipboard-health/date-time, a recent version of date-fns, or moment-timezone instead",
           },
         ],
       },

--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -146,6 +146,10 @@ module.exports = {
               'Importing `ObjectId` from `mongodb` is not allowed. Use `import { Types } from "mongoose"` and then `Types.ObjectId` instead.',
             name: "mongodb",
           },
+          {
+            name: "date-fns-tz",
+            message: "date-fns-tz is not allowed. Use @clipboard-health/date-time, a recent version of date-fns, or moment-timezone instead. Read more about why here: https://www.notion.so/date-fns-tz-is-bad-let-s-block-it-1ed8643321f48095a67afe8509b92c82",
+          },
         ],
       },
     ],

--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -148,7 +148,7 @@ module.exports = {
           },
           {
             name: "date-fns-tz",
-            message: "date-fns-tz is not allowed. Use @clipboard-health/date-time, a recent version of date-fns, or moment-timezone instead. Read more about why here: https://www.notion.so/date-fns-tz-is-bad-let-s-block-it-1ed8643321f48095a67afe8509b92c82",
+            message: "date-fns-tz is not allowed. Use @clipboard-health/date-time, a recent version of date-fns, or moment-timezone instead",
           },
         ],
       },

--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -149,7 +149,7 @@ module.exports = {
           {
             name: "date-fns-tz",
             message:
-              "date-fns-tz is not allowed. Use @clipboard-health/date-time, a recent version of date-fns, or moment-timezone instead",
+              "date-fns-tz is not allowed. Use @clipboard-health/date-time instead. If it doesn't have what you need then please add it there and open a PR.",
           },
         ],
       },

--- a/packages/eslint-config/src/index.spec.ts
+++ b/packages/eslint-config/src/index.spec.ts
@@ -152,7 +152,7 @@ describe("eslint-config", () => {
               },
               {
                 name: "date-fns-tz",
-                message: "date-fns-tz is not allowed. Use @clipboard-health/date-time, a recent version of date-fns, or moment-timezone instead. Read more about why here: https://www.notion.so/date-fns-tz-is-bad-let-s-block-it-1ed8643321f48095a67afe8509b92c82",
+                message: "date-fns-tz is not allowed. Use @clipboard-health/date-time, a recent version of date-fns, or moment-timezone instead",
               },
             ],
           },

--- a/packages/eslint-config/src/index.spec.ts
+++ b/packages/eslint-config/src/index.spec.ts
@@ -150,6 +150,10 @@ describe("eslint-config", () => {
                   'Importing `ObjectId` from `mongodb` is not allowed. Use `import { Types } from "mongoose"` and then `Types.ObjectId` instead.',
                 name: "mongodb",
               },
+              {
+                name: "date-fns-tz",
+                message: "date-fns-tz is not allowed. Use @clipboard-health/date-time, a recent version of date-fns, or moment-timezone instead. Read more about why here: https://www.notion.so/date-fns-tz-is-bad-let-s-block-it-1ed8643321f48095a67afe8509b92c82",
+              },
             ],
           },
         ],

--- a/packages/eslint-config/src/index.spec.ts
+++ b/packages/eslint-config/src/index.spec.ts
@@ -152,7 +152,8 @@ describe("eslint-config", () => {
               },
               {
                 name: "date-fns-tz",
-                message: "date-fns-tz is not allowed. Use @clipboard-health/date-time, a recent version of date-fns, or moment-timezone instead",
+                message:
+                  "date-fns-tz is not allowed. Use @clipboard-health/date-time, a recent version of date-fns, or moment-timezone instead",
               },
             ],
           },

--- a/packages/eslint-config/src/index.spec.ts
+++ b/packages/eslint-config/src/index.spec.ts
@@ -153,7 +153,7 @@ describe("eslint-config", () => {
               {
                 name: "date-fns-tz",
                 message:
-                  "date-fns-tz is not allowed. Use @clipboard-health/date-time, a recent version of date-fns, or moment-timezone instead",
+                  "date-fns-tz is not allowed. Use @clipboard-health/date-time instead. If it doesn't have what you need then please add it there and open a PR.",
               },
             ],
           },


### PR DESCRIPTION
Summary
===
<!--
- For expectations after PR approval and merge, see the CONTRIBUTING.md file
-->

As I wrote about in https://www.notion.so/date-fns-tz-is-bad-let-s-block-it-1ed8643321f48095a67afe8509b92c82, `date-fns-tz` is problematic and we should block it from being used moving forward.

This PR adds an eslint rule whch blocks the use of date-fns-tz
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added an ESLint rule to block importing the date-fns-tz package and suggest alternatives.

<!-- End of auto-generated description by mrge. -->

