### PR TITLE
feat: Include rules from `eslint-plugin` in `eslint-config`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ dist/
 node_modules/
 
 # Alphabetical files
+packages/eslint-config/src/index.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -20775,7 +20775,6 @@
       "version": "4.41.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
@@ -22414,16 +22413,16 @@
     },
     "packages/config": {
       "name": "@clipboard-health/config",
-      "version": "0.12.3",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
-        "@clipboard-health/util-ts": "3.3.3",
+        "@clipboard-health/util-ts": "3.4.0",
         "decamelize": "5.0.1",
         "dotenv": "16.5.0",
         "tslib": "2.8.1"
       },
       "devDependencies": {
-        "@clipboard-health/contract-core": "0.13.3",
+        "@clipboard-health/contract-core": "0.14.0",
         "zod": "3.25.30",
         "zod-validation-error": "3.4.0"
       },
@@ -22446,13 +22445,13 @@
     },
     "packages/contract-core": {
       "name": "@clipboard-health/contract-core",
-      "version": "0.13.3",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
       },
       "devDependencies": {
-        "@clipboard-health/testing-core": "0.13.3",
+        "@clipboard-health/testing-core": "0.14.0",
         "zod": "3.25.30"
       },
       "peerDependencies": {
@@ -22460,7 +22459,7 @@
       }
     },
     "packages/embedex": {
-      "version": "0.5.4",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "14.0.0",
@@ -22512,8 +22511,11 @@
     },
     "packages/eslint-config": {
       "name": "@clipboard-health/eslint-config",
-      "version": "5.3.1",
+      "version": "5.4.0",
       "license": "MIT",
+      "dependencies": {
+        "@clipboard-health/eslint-plugin": "^0.1.0"
+      },
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": "^7",
         "@typescript-eslint/parser": "^7",
@@ -22539,10 +22541,10 @@
     },
     "packages/eslint-plugin": {
       "name": "@clipboard-health/eslint-plugin",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/utils": "^8.33.0",
+        "@typescript-eslint/utils": "8.33.0",
         "tslib": "2.8.1"
       }
     },
@@ -22675,7 +22677,7 @@
       "name": "@clipboard-health/example-nestjs",
       "version": "0.0.10",
       "dependencies": {
-        "@clipboard-health/contract-core": "0.13.3",
+        "@clipboard-health/contract-core": "0.13.4",
         "@clipboard-health/json-api-nestjs": "0.17.3",
         "@nestjs/common": "11.1.2",
         "@nestjs/core": "11.1.2",
@@ -22694,11 +22696,36 @@
         "webpack-cli": "6.0.1"
       }
     },
+    "packages/example-nestjs/node_modules/@clipboard-health/contract-core": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@clipboard-health/contract-core/-/contract-core-0.13.4.tgz",
+      "integrity": "sha512-qNhF9ac5VVillG2YZlf3pocfwKppm3QPxGE8nWg+/CzpdZB9ceENcxiXUpYPNSIASx2pLwXXmL4/c8mzxvdcOw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "peerDependencies": {
+        "zod": "^3"
+      }
+    },
+    "packages/example-nestjs/node_modules/@clipboard-health/json-api-nestjs": {
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@clipboard-health/json-api-nestjs/-/json-api-nestjs-0.17.3.tgz",
+      "integrity": "sha512-559n6/9eWJXmXIbu/MhyEYKsuISBh3JbY2+9o7dwIz8wBMjj+2thPPXqzPYzTp+dF4EvBuSvesdxIkWoYYIhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@clipboard-health/contract-core": "0.13.3",
+        "tslib": "2.8.1"
+      },
+      "peerDependencies": {
+        "type-fest": "^4",
+        "zod": "^3"
+      }
+    },
     "packages/example-nestjs/node_modules/@clipboard-health/json-api-nestjs/node_modules/@clipboard-health/contract-core": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@clipboard-health/contract-core/-/contract-core-0.13.0.tgz",
-      "integrity": "sha512-slc7C5962BKYr22bwvVUrQq1J0JtfTw2Kt8RrqydGzysAXs0XgghkImSQgioDCIf7wEcgmo0vvVWia07M1YyQA==",
-      "extraneous": true,
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@clipboard-health/contract-core/-/contract-core-0.13.3.tgz",
+      "integrity": "sha512-tTASqKptryvFtr8qChjZKfq39L0uiAgyFnSQaYWLNM2jBXkxYzXBoDqAlgmhTkhrOYSccAWiW1wygPsuHTEfGg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -22740,7 +22767,7 @@
     },
     "packages/execution-context": {
       "name": "@clipboard-health/execution-context",
-      "version": "0.9.3",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -22748,7 +22775,7 @@
     },
     "packages/json-api": {
       "name": "@clipboard-health/json-api",
-      "version": "0.19.3",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -22762,14 +22789,14 @@
     },
     "packages/json-api-nestjs": {
       "name": "@clipboard-health/json-api-nestjs",
-      "version": "0.17.3",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
-        "@clipboard-health/contract-core": "0.13.3",
+        "@clipboard-health/contract-core": "0.14.0",
         "tslib": "2.8.1"
       },
       "devDependencies": {
-        "@clipboard-health/testing-core": "0.13.3",
+        "@clipboard-health/testing-core": "0.14.0",
         "type-fest": "4.41.0",
         "zod": "3.25.30"
       },
@@ -22780,7 +22807,7 @@
     },
     "packages/nx-plugin": {
       "name": "@clipboard-health/nx-plugin",
-      "version": "0.19.3",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -22792,7 +22819,7 @@
     },
     "packages/rules-engine": {
       "name": "@clipboard-health/rules-engine",
-      "version": "1.18.3",
+      "version": "1.19.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -22806,10 +22833,10 @@
     },
     "packages/testing-core": {
       "name": "@clipboard-health/testing-core",
-      "version": "0.13.3",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
-        "@clipboard-health/util-ts": "3.3.3",
+        "@clipboard-health/util-ts": "3.4.0",
         "tslib": "2.8.1"
       },
       "devDependencies": {
@@ -22821,7 +22848,7 @@
     },
     "packages/util-ts": {
       "name": "@clipboard-health/util-ts",
-      "version": "3.3.3",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -22513,10 +22513,8 @@
       "name": "@clipboard-health/eslint-config",
       "version": "5.4.0",
       "license": "MIT",
-      "dependencies": {
-        "@clipboard-health/eslint-plugin": "^0.1.0"
-      },
       "peerDependencies": {
+        "@clipboard-health/eslint-plugin": "^0.1",
         "@typescript-eslint/eslint-plugin": "^7",
         "@typescript-eslint/parser": "^7",
         "eslint": "^8",
@@ -22677,7 +22675,7 @@
       "name": "@clipboard-health/example-nestjs",
       "version": "0.0.10",
       "dependencies": {
-        "@clipboard-health/contract-core": "0.13.4",
+        "@clipboard-health/contract-core": "0.14.0",
         "@clipboard-health/json-api-nestjs": "0.17.3",
         "@nestjs/common": "11.1.2",
         "@nestjs/core": "11.1.2",
@@ -22694,18 +22692,6 @@
         "@types/supertest": "6.0.3",
         "supertest": "7.1.1",
         "webpack-cli": "6.0.1"
-      }
-    },
-    "packages/example-nestjs/node_modules/@clipboard-health/contract-core": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/@clipboard-health/contract-core/-/contract-core-0.13.4.tgz",
-      "integrity": "sha512-qNhF9ac5VVillG2YZlf3pocfwKppm3QPxGE8nWg+/CzpdZB9ceENcxiXUpYPNSIASx2pLwXXmL4/c8mzxvdcOw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "zod": "^3"
       }
     },
     "packages/example-nestjs/node_modules/@clipboard-health/json-api-nestjs": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "main": "./src/index.js",
   "peerDependencies": {
+    "@clipboard-health/eslint-plugin": "^0.1",
     "@typescript-eslint/eslint-plugin": "^7",
     "@typescript-eslint/parser": "^7",
     "eslint": "^8",

--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -1,6 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
 const path = require("node:path");
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
 const fs = require("node:fs");
 
 /*
@@ -18,7 +16,6 @@ const fs = require("node:fs");
 const isOutsideCoreUtilsMonorepo = (() => {
   try {
     const packageJsonPath = path.resolve(process.cwd(), "package.json");
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
     return packageJson.name !== "@clipboard-health/core-utils";
   } catch {
@@ -35,7 +32,7 @@ const plugins = [
   "@typescript-eslint",
 ];
 
-// Only add @clipboard-health plugin if we're outside the monorepo
+// Only add `@clipboard-health/eslint-plugin` if we're outside the core-utils monorepo
 if (isOutsideCoreUtilsMonorepo) {
   plugins.push("@clipboard-health");
 }

--- a/packages/eslint-config/src/index.spec.ts
+++ b/packages/eslint-config/src/index.spec.ts
@@ -1,245 +1,297 @@
-import config from ".";
+const readFileSyncMock = jest.fn<string, [string, string]>();
+jest.mock("node:fs", () => ({
+  readFileSync: (path: string, encoding: string) => readFileSyncMock(path, encoding),
+}));
+jest.mock("node:path", () => ({
+  resolve: jest.fn(),
+}));
 
-describe("eslint-config", () => {
-  it("matches", () => {
-    expect(config).toEqual({
-      extends: [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/eslint-recommended",
-        "plugin:@typescript-eslint/recommended",
-        "airbnb-base",
-        "plugin:eslint-comments/recommended",
-        "plugin:expect-type/recommended",
-        "plugin:jest/recommended",
-        "plugin:jest/style",
-        "plugin:import/recommended",
-        "plugin:n/recommended",
-        "plugin:no-use-extend-native/recommended",
-        "plugin:security/recommended",
-        "plugin:sonarjs/recommended",
-        "plugin:unicorn/recommended",
-        "xo",
-        "xo-typescript/space",
-        "prettier",
-      ],
-      overrides: [
-        {
-          files: [
-            "*.spec.ts",
-            "*.spec.tsx",
-            "*.spec.js",
-            "*.spec.jsx",
-            "*.test.ts",
-            "*.test.tsx",
-            "*.test.js",
-            "*.test.jsx",
-          ],
-          rules: {
-            // Interferes with `jest`'s `expect.any`
-            "@typescript-eslint/no-unsafe-assignment": "off",
-          },
-        },
-        /**
-         * Exclude *.dto.ts, null is needed for PATCH endpoints to differentiate empty from optional fields
-         * Exclude *.repository.ts, null is needed for our ORMs (prisma and mongoose)
-         */
-        {
-          files: ["**/*.dto.ts", "**/*.repository.ts", "**/*.repo.ts"],
-          rules: {
-            "@typescript-eslint/ban-types": [
-              "error",
-              {
-                extendDefaults: true,
-                types: {
-                  null: false,
-                },
-              },
-            ],
-          },
-        },
-      ],
-      parser: "@typescript-eslint/parser",
-      parserOptions: {
-        project: ["tsconfig.json"],
-        tsconfigRootDir: __dirname,
-      },
-      plugins: [
-        "expect-type",
-        "jest",
-        "no-only-tests",
-        "simple-import-sort",
-        "sonarjs",
-        "@typescript-eslint",
+const duplicatedConfig = {
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
+    "airbnb-base",
+    "plugin:eslint-comments/recommended",
+    "plugin:expect-type/recommended",
+    "plugin:jest/recommended",
+    "plugin:jest/style",
+    "plugin:import/recommended",
+    "plugin:n/recommended",
+    "plugin:no-use-extend-native/recommended",
+    "plugin:security/recommended",
+    "plugin:sonarjs/recommended",
+    "plugin:unicorn/recommended",
+    "xo",
+    "xo-typescript/space",
+    "prettier",
+  ],
+  overrides: [
+    {
+      files: [
+        "*.spec.ts",
+        "*.spec.tsx",
+        "*.spec.js",
+        "*.spec.jsx",
+        "*.test.ts",
+        "*.test.tsx",
+        "*.test.js",
+        "*.test.jsx",
       ],
       rules: {
-        // See https://github.com/microsoft/TypeScript/wiki/Performance#preferring-interfaces-over-intersections
-        "@typescript-eslint/consistent-type-definitions": ["error", "interface"],
-
-        // Too many false positives
-        "@typescript-eslint/naming-convention": "off",
-
-        // Makes functional programming difficult
-        "@typescript-eslint/no-unsafe-call": "off",
-
-        // Prefer an escape hatch instead of an outright ban
-        "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
-        "@typescript-eslint/return-await": ["error", "always"],
-
-        // Breaks code when temporarily commented, adding more friction than the value provided.
-        "capitalized-comments": "off",
-
-        // Recommends using static fields instead of moving to a function
-        "class-methods-use-this": "off",
-
-        // Prevent bugs
-        curly: ["error", "all"],
-
-        // Our libraries don't use ESM
-        "import/extensions": "off",
-
-        "import/no-cycle": ["error", { ignoreExternal: true, maxDepth: 16 }],
-
-        // Rely on `"n/no-extraneous-import"` instead
-        "import/no-extraneous-dependencies": "off",
-
-        // Doesn't play well with NX/monorepos
-        "import/no-unresolved": "off",
-
-        // Prefer named exports
-        "import/prefer-default-export": "off",
-        "jest/expect-expect": [
-          "error",
-          {
-            assertFunctionNames: [
-              "expect",
-              "expectToBeDefined",
-              "expectToBeLeft",
-              "expectToBeNone",
-              "expectToBeRight",
-              "expectToBeSafeParseError",
-              "expectToBeSafeParseSuccess",
-              "expectToBeSome",
-              "expectTypeOf",
-            ],
-          },
-        ],
-
-        // Our libraries don't use ESM
-        "n/no-missing-import": "off",
-
-        // Our libraries don't use ESM
-        "n/no-unpublished-import": "off",
-
-        // Allow PascalCase for Decorators
-        "new-cap": ["warn", { capIsNew: false, newIsCap: true }],
-
-        // Set to warn so LLMs to write worse code to get around it
-        "no-await-in-loop": "warn",
-
-        // Disallow `.only` in tests to prevent it from making it into `main`.
-        "no-only-tests/no-only-tests": "error",
-
-        "no-restricted-imports": [
-          "error",
-          {
-            paths: [
-              // We want `ObjectId` to be imported from `mongoose` only
-              {
-                importNames: ["ObjectId", "ObjectID"],
-                message:
-                  'Importing `ObjectId` from `mongodb` is not allowed. Use `import { Types } from "mongoose"` and then `Types.ObjectId` instead.',
-                name: "mongodb",
-              },
-              {
-                name: "date-fns-tz",
-                message:
-                  "date-fns-tz is not allowed. Use @clipboard-health/date-time instead. If it doesn't have what you need then please add it there and open a PR.",
-              },
-            ],
-          },
-        ],
-
-        "no-restricted-syntax": [
-          "error",
-          // Adapted from Airbnb's config, but allows ForOfStatement.
-          // See https://github.com/airbnb/javascript/blob/0f3ca32323b8d5770de3301036e65511c6d18e00/packages/eslint-config-airbnb-base/rules/style.js#L340-L358
-          {
-            message:
-              "for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.",
-            selector: "ForInStatement",
-          },
-          {
-            message:
-              "Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.",
-            selector: "LabeledStatement",
-          },
-          {
-            message:
-              "`with` is disallowed in strict mode because it makes code difficult to predict and optimize.",
-            selector: "WithStatement",
-          },
-          {
-            selector: "TSEnumDeclaration",
-            message:
-              "Enums are one of the few non-type-level extensions to JavaScript, have pitfalls, and require explicit mapping. Use const objects instead.",
-          },
-        ],
-
-        // While continue can be misused, especially with nested loops and labels,
-        // it can be useful for preventing code nesting and the existence of the rule
-        // caused us to lose time debating its validity
-        "no-continue": "off",
-
-        // Prefer debugging ease over an extra microtask by requiring `return await`.
-        // `no-return-await` states "This can make debugging more difficult."
-        "no-return-await": "off",
-
-        // False positive on `enum`s
-        "no-shadow": "off",
-
-        // Polarizing naming convention that isn't followed by us
-        "no-underscore-dangle": "off",
-
-        // We use TypeScript where these are caught by the compiler
-        "no-use-before-define": ["error", { classes: false, functions: false }],
-
-        /*
-         * Only enable for properties. Favor arrow functions, they don’t have a `this` reference,
-         * preventing accidental usage.
-         */
-        "object-shorthand": ["error", "properties"],
-        "security/detect-object-injection": "off",
-
-        "simple-import-sort/exports": "warn",
-
-        // Sort imports and exports
-        "simple-import-sort/imports": "warn",
-
-        // Makes functional programming difficult
-        "unicorn/no-array-callback-reference": "off",
-
-        // "Better readability" is subjective
-        "unicorn/no-array-for-each": "off",
-
-        // "Better readability" is subjective
-        "unicorn/no-array-reduce": "off",
-
-        // React, MongoDB, and Prisma use `null`
-        "unicorn/no-null": "off",
-
-        // Our libraries don't use ESM
-        "unicorn/prefer-module": "off",
-
-        // Allow common, well understood abbreviations
-        "unicorn/prevent-abbreviations": [
-          "error",
-          { ignore: [/config/i, /params/i, /props/i, /ref/i] },
-        ],
-
-        // There are cases where duplicating strings is ok (tests, contracts, etc...)
-        "sonarjs/no-duplicate-string": "off",
+        // Interferes with `jest`'s `expect.any`
+        "@typescript-eslint/no-unsafe-assignment": "off",
       },
-      settings: { node: { version: ">=18.15.0" } },
+    },
+    /**
+     * Exclude *.dto.ts, null is needed for PATCH endpoints to differentiate empty from optional fields
+     * Exclude *.repository.ts, null is needed for our ORMs (prisma and mongoose)
+     */
+    {
+      files: ["**/*.dto.ts", "**/*.repository.ts", "**/*.repo.ts"],
+      rules: {
+        "@typescript-eslint/ban-types": [
+          "error",
+          {
+            extendDefaults: true,
+            types: {
+              null: false,
+            },
+          },
+        ],
+      },
+    },
+  ],
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    project: ["tsconfig.json"],
+    tsconfigRootDir: __dirname,
+  },
+  plugins: [
+    "expect-type",
+    "jest",
+    "no-only-tests",
+    "simple-import-sort",
+    "sonarjs",
+    "@typescript-eslint",
+  ],
+  rules: {
+    // See https://github.com/microsoft/TypeScript/wiki/Performance#preferring-interfaces-over-intersections
+    "@typescript-eslint/consistent-type-definitions": ["error", "interface"],
+
+    // Too many false positives
+    "@typescript-eslint/naming-convention": "off",
+
+    // Makes functional programming difficult
+    "@typescript-eslint/no-unsafe-call": "off",
+
+    // Prefer an escape hatch instead of an outright ban
+    "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
+    "@typescript-eslint/return-await": ["error", "always"],
+
+    // Breaks code when temporarily commented, adding more friction than the value provided.
+    "capitalized-comments": "off",
+
+    // Recommends using static fields instead of moving to a function
+    "class-methods-use-this": "off",
+
+    // Prevent bugs
+    curly: ["error", "all"],
+
+    // Our libraries don't use ESM
+    "import/extensions": "off",
+
+    "import/no-cycle": ["error", { ignoreExternal: true, maxDepth: 16 }],
+
+    // Rely on `"n/no-extraneous-import"` instead
+    "import/no-extraneous-dependencies": "off",
+
+    // Doesn't play well with NX/monorepos
+    "import/no-unresolved": "off",
+
+    // Prefer named exports
+    "import/prefer-default-export": "off",
+    "jest/expect-expect": [
+      "error",
+      {
+        assertFunctionNames: [
+          "expect",
+          "expectToBeDefined",
+          "expectToBeLeft",
+          "expectToBeNone",
+          "expectToBeRight",
+          "expectToBeSafeParseError",
+          "expectToBeSafeParseSuccess",
+          "expectToBeSome",
+          "expectTypeOf",
+        ],
+      },
+    ],
+
+    // Our libraries don't use ESM
+    "n/no-missing-import": "off",
+
+    // Our libraries don't use ESM
+    "n/no-unpublished-import": "off",
+
+    // Allow PascalCase for Decorators
+    "new-cap": ["warn", { capIsNew: false, newIsCap: true }],
+
+    // Set to warn so LLMs to write worse code to get around it
+    "no-await-in-loop": "warn",
+
+    // Disallow `.only` in tests to prevent it from making it into `main`.
+    "no-only-tests/no-only-tests": "error",
+
+    "no-restricted-imports": [
+      "error",
+      {
+        paths: [
+          // We want `ObjectId` to be imported from `mongoose` only
+          {
+            importNames: ["ObjectId", "ObjectID"],
+            message:
+              'Importing `ObjectId` from `mongodb` is not allowed. Use `import { Types } from "mongoose"` and then `Types.ObjectId` instead.',
+            name: "mongodb",
+          },
+          {
+            name: "date-fns-tz",
+            message:
+              "date-fns-tz is not allowed. Use @clipboard-health/date-time instead. If it doesn't have what you need then please add it there and open a PR.",
+          },
+        ],
+      },
+    ],
+
+    "no-restricted-syntax": [
+      "error",
+      // Adapted from Airbnb's config, but allows ForOfStatement.
+      // See https://github.com/airbnb/javascript/blob/0f3ca32323b8d5770de3301036e65511c6d18e00/packages/eslint-config-airbnb-base/rules/style.js#L340-L358
+      {
+        message:
+          "for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.",
+        selector: "ForInStatement",
+      },
+      {
+        message:
+          "Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.",
+        selector: "LabeledStatement",
+      },
+      {
+        message:
+          "`with` is disallowed in strict mode because it makes code difficult to predict and optimize.",
+        selector: "WithStatement",
+      },
+      {
+        selector: "TSEnumDeclaration",
+        message:
+          "Enums are one of the few non-type-level extensions to JavaScript, have pitfalls, and require explicit mapping. Use const objects instead.",
+      },
+    ],
+
+    // While continue can be misused, especially with nested loops and labels,
+    // it can be useful for preventing code nesting and the existence of the rule
+    // caused us to lose time debating its validity
+    "no-continue": "off",
+
+    // Prefer debugging ease over an extra microtask by requiring `return await`.
+    // `no-return-await` states "This can make debugging more difficult."
+    "no-return-await": "off",
+
+    // False positive on `enum`s
+    "no-shadow": "off",
+
+    // Polarizing naming convention that isn't followed by us
+    "no-underscore-dangle": "off",
+
+    // We use TypeScript where these are caught by the compiler
+    "no-use-before-define": ["error", { classes: false, functions: false }],
+
+    /*
+     * Only enable for properties. Favor arrow functions, they don’t have a `this` reference,
+     * preventing accidental usage.
+     */
+    "object-shorthand": ["error", "properties"],
+    "security/detect-object-injection": "off",
+
+    "simple-import-sort/exports": "warn",
+
+    // Sort imports and exports
+    "simple-import-sort/imports": "warn",
+
+    // Makes functional programming difficult
+    "unicorn/no-array-callback-reference": "off",
+
+    // "Better readability" is subjective
+    "unicorn/no-array-for-each": "off",
+
+    // "Better readability" is subjective
+    "unicorn/no-array-reduce": "off",
+
+    // React, MongoDB, and Prisma use `null`
+    "unicorn/no-null": "off",
+
+    // Our libraries don't use ESM
+    "unicorn/prefer-module": "off",
+
+    // Allow common, well understood abbreviations
+    "unicorn/prevent-abbreviations": [
+      "error",
+      { ignore: [/config/i, /params/i, /props/i, /ref/i] },
+    ],
+
+    // There are cases where duplicating strings is ok (tests, contracts, etc...)
+    "sonarjs/no-duplicate-string": "off",
+  },
+  settings: { node: { version: ">=18.15.0" } },
+};
+
+describe("eslint-config", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it("matches config without `@clipboard-health/eslint-plugin` when used in core-utils", async () => {
+    readFileSyncMock.mockReturnValue(`{"name": "@clipboard-health/core-utils"}`);
+    const config = await import("./index");
+    expect(config.default).toEqual(duplicatedConfig);
+  });
+
+  it("includes `@clipboard-health/eslint-plugin` when used outside core-utils", async () => {
+    readFileSyncMock.mockReturnValue(`{"name": "test-project"}`);
+    const config = await import("./index");
+    expect(config.default).toEqual({
+      ...duplicatedConfig,
+      plugins: [...duplicatedConfig.plugins, "@clipboard-health"],
+      overrides: [
+        ...duplicatedConfig.overrides,
+        {
+          files: ["**/*.controller.ts", "**/*.controllers.ts"],
+          rules: {
+            "@clipboard-health/enforce-ts-rest-in-controllers": "error",
+          },
+        },
+      ],
+    });
+  });
+
+  it("includes `@clipboard-health/eslint-plugin` when host project cannot be determined", async () => {
+    readFileSyncMock.mockImplementation(() => {
+      throw new Error("Error");
+    });
+    const config = await import("./index");
+    expect(config.default).toEqual({
+      ...duplicatedConfig,
+      plugins: [...duplicatedConfig.plugins, "@clipboard-health"],
+      overrides: [
+        ...duplicatedConfig.overrides,
+        {
+          files: ["**/*.controller.ts", "**/*.controllers.ts"],
+          rules: {
+            "@clipboard-health/enforce-ts-rest-in-controllers": "error",
+          },
+        },
+      ],
     });
   });
 });

--- a/packages/example-nestjs/package.json
+++ b/packages/example-nestjs/package.json
@@ -3,7 +3,7 @@
   "description": "A NestJS application using our libraries, primarily for end-to-end testing.",
   "version": "0.0.10",
   "dependencies": {
-    "@clipboard-health/contract-core": "0.13.4",
+    "@clipboard-health/contract-core": "0.14.0",
     "@clipboard-health/json-api-nestjs": "0.17.3",
     "@nestjs/common": "11.1.2",
     "@nestjs/core": "11.1.2",


### PR DESCRIPTION
## [AMA-279](https://linear.app/clipboardhealth/issue/AMA-279/write-an-eslint-rule-for-checking-that-new-endpoints-in-backend-main)

Changes
---
- This is a follow-up to #131 where a new `eslint-plugin` package was introduced containing definitions for custom ESLint rules.
- This PR incorporates that plugin into the config exported by `@clipboard-health/eslint-config` so that using the config results in the rules in the plugin being automatically enabled. Consuming project do not need to directly install the `eslint-plugin` package.
- The PR also skips running the linter on the linter config itself since the linter errors are not very useful and cause unavoidable typing issues to appear on a .js file.

