### PR TITLE
feat(TF-2180): custom error code in ServiceError

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22413,16 +22413,16 @@
     },
     "packages/config": {
       "name": "@clipboard-health/config",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
-        "@clipboard-health/util-ts": "3.4.0",
+        "@clipboard-health/util-ts": "3.5.0",
         "decamelize": "5.0.1",
         "dotenv": "16.5.0",
         "tslib": "2.8.1"
       },
       "devDependencies": {
-        "@clipboard-health/contract-core": "0.14.0",
+        "@clipboard-health/contract-core": "0.15.0",
         "zod": "3.25.30",
         "zod-validation-error": "3.4.0"
       },
@@ -22445,13 +22445,13 @@
     },
     "packages/contract-core": {
       "name": "@clipboard-health/contract-core",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
       },
       "devDependencies": {
-        "@clipboard-health/testing-core": "0.14.0",
+        "@clipboard-health/testing-core": "0.15.0",
         "zod": "3.25.30"
       },
       "peerDependencies": {
@@ -22459,7 +22459,7 @@
       }
     },
     "packages/embedex": {
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "14.0.0",
@@ -22511,10 +22511,10 @@
     },
     "packages/eslint-config": {
       "name": "@clipboard-health/eslint-config",
-      "version": "5.4.0",
+      "version": "5.5.0",
       "license": "MIT",
       "peerDependencies": {
-        "@clipboard-health/eslint-plugin": "^0.1",
+        "@clipboard-health/eslint-plugin": "^0.2.0",
         "@typescript-eslint/eslint-plugin": "^7",
         "@typescript-eslint/parser": "^7",
         "eslint": "^8",
@@ -22539,7 +22539,7 @@
     },
     "packages/eslint-plugin": {
       "name": "@clipboard-health/eslint-plugin",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": "8.33.0",
@@ -22694,6 +22694,18 @@
         "webpack-cli": "6.0.1"
       }
     },
+    "packages/example-nestjs/node_modules/@clipboard-health/contract-core": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@clipboard-health/contract-core/-/contract-core-0.14.0.tgz",
+      "integrity": "sha512-mJbE7Wh5JYIi5gIoAwoA3ijZJ72NHNmHt7W+X0csnx99DTlQEDVuz4ecDk4MAYZGx2N0tQg087BYvhsagR+pAg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "peerDependencies": {
+        "zod": "^3"
+      }
+    },
     "packages/example-nestjs/node_modules/@clipboard-health/json-api-nestjs": {
       "version": "0.17.3",
       "resolved": "https://registry.npmjs.org/@clipboard-health/json-api-nestjs/-/json-api-nestjs-0.17.3.tgz",
@@ -22753,7 +22765,7 @@
     },
     "packages/execution-context": {
       "name": "@clipboard-health/execution-context",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -22761,7 +22773,7 @@
     },
     "packages/json-api": {
       "name": "@clipboard-health/json-api",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -22775,14 +22787,14 @@
     },
     "packages/json-api-nestjs": {
       "name": "@clipboard-health/json-api-nestjs",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
-        "@clipboard-health/contract-core": "0.14.0",
+        "@clipboard-health/contract-core": "0.15.0",
         "tslib": "2.8.1"
       },
       "devDependencies": {
-        "@clipboard-health/testing-core": "0.14.0",
+        "@clipboard-health/testing-core": "0.15.0",
         "type-fest": "4.41.0",
         "zod": "3.25.30"
       },
@@ -22793,7 +22805,7 @@
     },
     "packages/nx-plugin": {
       "name": "@clipboard-health/nx-plugin",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -22805,7 +22817,7 @@
     },
     "packages/rules-engine": {
       "name": "@clipboard-health/rules-engine",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -22819,10 +22831,10 @@
     },
     "packages/testing-core": {
       "name": "@clipboard-health/testing-core",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "@clipboard-health/util-ts": "3.4.0",
+        "@clipboard-health/util-ts": "3.5.0",
         "tslib": "2.8.1"
       },
       "devDependencies": {
@@ -22834,7 +22846,7 @@
     },
     "packages/util-ts": {
       "name": "@clipboard-health/util-ts",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"

--- a/packages/example-nestjs/package.json
+++ b/packages/example-nestjs/package.json
@@ -3,7 +3,7 @@
   "description": "A NestJS application using our libraries, primarily for end-to-end testing.",
   "version": "0.0.10",
   "dependencies": {
-    "@clipboard-health/contract-core": "0.14.0",
+    "@clipboard-health/contract-core": "0.15.0",
     "@clipboard-health/json-api-nestjs": "0.17.3",
     "@nestjs/common": "11.1.2",
     "@nestjs/core": "11.1.2",


### PR DESCRIPTION
Summary
===

Ticket: https://linear.app/clipboardhealth/issue/TF-2180/core-remove-serviceerror-whitelist-to-enable-custom-error-codes

### Context
`ServiceError` exposed a hard-coded union (`ERROR_CODES`) that limited us to nine generic strings. Because callers couldn’t introduce new codes, multiple places work around by parsing the error message to infer behaviour. 

This PR removes that blocker and aligns our error shape with the JSON:API spec.

More details: https://www.notion.so/HLD-Error-Handling-with-JSON-API-Error-Objects-1f38643321f4801daf4dd24ce62b0ed1

Changes
---
- `ErrorCode` widened , now `built-ins | (string & {})`
- `ServiceIssue` extended
  - `code`: now accepts custom strings
  - `title?`:  optional short summary (errors.title)
  - `status?`: optional HTTP status (errors.status)