### PR TITLE
fix: wrong version of contract-core on example-nest

### DIFF
--- a/packages/example-nestjs/package.json
+++ b/packages/example-nestjs/package.json
@@ -3,7 +3,7 @@
   "description": "A NestJS application using our libraries, primarily for end-to-end testing.",
   "version": "0.0.10",
   "dependencies": {
-    "@clipboard-health/contract-core": "0.16.0",
+    "@clipboard-health/contract-core": "0.17.0",
     "@clipboard-health/json-api-nestjs": "0.19.2",
     "@nestjs/common": "11.1.3",
     "@nestjs/core": "11.1.3",


### PR DESCRIPTION
Summary
===
<!--
- For expectations after PR approval and merge, see the CONTRIBUTING.md file
-->

Changes
---
- After recenty modification of contract-core package, the [CI action failed because example-nestjs had invalid not the latest versions set](https://github.com/ClipboardHealth/core-utils/actions/runs/15764635188/job/44439027501). This is an attempt to fix it

Ran `npx syncpack fix-mismatches`

```
= Nx isn't ready for eslint 9 upgrade yet. =====================================
     7 - 7 ignored
= Allow for flexible peer dependency versions. =================================
    30 ✓ already valid
= Default Version Group ========================================================
    73 ✓ already valid
     1 ✓ fixed
- package.json
- packages/config/package.json
- packages/contract-core/package.json
- packages/embedex/package.json
- packages/eslint-config/package.json
- packages/eslint-plugin/package.json
✓ packages/example-nestjs/package.json
- packages/execution-context/package.json
- packages/json-api/package.json
- packages/json-api-nestjs/package.json
- packages/nx-plugin/package.json
- packages/rules-engine/package.json
- packages/testing-core/package.json
- packages/util-ts/package.json
```
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated example-nestjs to use the latest version of @clipboard-health/contract-core to fix dependency issues.

<!-- End of auto-generated description by cubic. -->

