### PR TITLE
fix: add analytics error handling

### DIFF
--- a/packages/analytics/src/lib/analytics.spec.ts
+++ b/packages/analytics/src/lib/analytics.spec.ts
@@ -143,7 +143,7 @@ describe("Analytics", () => {
         destination: "segment.identify",
         traceName: "analytics.identify",
         userId: "user123",
-        ...error,
+        error,
       });
     });
   });
@@ -229,7 +229,7 @@ describe("Analytics", () => {
         destination: "segment.track",
         traceName: "analytics.track",
         userId: "user123",
-        ...error,
+        error,
       });
     });
   });

--- a/packages/analytics/src/lib/analytics.spec.ts
+++ b/packages/analytics/src/lib/analytics.spec.ts
@@ -63,7 +63,10 @@ describe("Analytics", () => {
       analytics.identify(request);
 
       expect(mockSegment.identify).not.toHaveBeenCalled();
-      expect(logger.info).toHaveBeenCalledWith("Analytics identify is disabled, skipping", {
+      expect(logger.info).toHaveBeenCalledWith("analytics.identify: disabled, skipping", {
+        destination: "segment.identify",
+        traceName: "analytics.identify",
+        userId: "user123",
         params: request,
       });
     });
@@ -119,6 +122,30 @@ describe("Analytics", () => {
         traits: { email: "test@example.com" },
       });
     });
+
+    it("should handle segment identify errors", () => {
+      const enabled: Enabled = { identify: true, track: true };
+      analytics = new Analytics({ apiKey: "test-key", logger, enabled });
+
+      const request: IdentifyRequest = {
+        userId: "user123",
+        traits: { email: "test@example.com" },
+      };
+
+      const error = new Error("Segment API error");
+      mockSegment.identify.mockImplementationOnce(() => {
+        throw error;
+      });
+
+      analytics.identify(request);
+
+      expect(logger.error).toHaveBeenCalledWith("analytics.identify", {
+        destination: "segment.identify",
+        traceName: "analytics.identify",
+        userId: "user123",
+        ...error,
+      });
+    });
   });
 
   describe("track", () => {
@@ -154,7 +181,10 @@ describe("Analytics", () => {
       analytics.track(request);
 
       expect(mockSegment.track).not.toHaveBeenCalled();
-      expect(logger.info).toHaveBeenCalledWith("Analytics tracking is disabled, skipping", {
+      expect(logger.info).toHaveBeenCalledWith("analytics.track: disabled, skipping", {
+        destination: "segment.track",
+        traceName: "analytics.track",
+        userId: "user123",
         params: request,
       });
     });
@@ -175,6 +205,31 @@ describe("Analytics", () => {
         userId: "456",
         event: "Page View",
         properties: { page: "home" },
+      });
+    });
+
+    it("should handle segment track errors", () => {
+      const enabled: Enabled = { identify: true, track: true };
+      analytics = new Analytics({ apiKey: "test-key", logger, enabled });
+
+      const request: TrackRequest = {
+        userId: "user123",
+        event: "Button Clicked",
+        traits: { buttonName: "Submit" },
+      };
+
+      const error = new Error("Segment track error");
+      mockSegment.track.mockImplementationOnce(() => {
+        throw error;
+      });
+
+      analytics.track(request);
+
+      expect(logger.error).toHaveBeenCalledWith("analytics.track", {
+        destination: "segment.track",
+        traceName: "analytics.track",
+        userId: "user123",
+        ...error,
       });
     });
   });

--- a/packages/analytics/src/lib/analytics.ts
+++ b/packages/analytics/src/lib/analytics.ts
@@ -91,7 +91,7 @@ export class Analytics {
       this.log({
         logParams,
         logFunction: this.logger.error,
-        metadata: toError(error),
+        metadata: { error: toError(error) },
       });
     }
   }
@@ -122,7 +122,7 @@ export class Analytics {
       this.log({
         logParams,
         logFunction: this.logger.error,
-        metadata: toError(error),
+        metadata: { error: toError(error) },
       });
     }
   }
@@ -159,7 +159,7 @@ export class Analytics {
     logFunction?: LogFunction;
     logParams: LogContext;
     message?: string;
-    metadata?: Record<string, unknown> | Error;
+    metadata?: Record<string, unknown>;
   }): void {
     const { logParams, logFunction = this.logger.info, message, metadata } = params;
 

--- a/packages/analytics/src/lib/analytics.ts
+++ b/packages/analytics/src/lib/analytics.ts
@@ -1,4 +1,10 @@
-import { either as E, type LogFunction, type Logger, toError } from "@clipboard-health/util-ts";
+import {
+  either as E,
+  isString,
+  type LogFunction,
+  type Logger,
+  toError,
+} from "@clipboard-health/util-ts";
 import { Analytics as SegmentAnalytics } from "@segment/analytics-node";
 
 import { formatPhoneAsE164 } from "./formatPhoneAsE164";
@@ -138,7 +144,7 @@ export class Analytics {
     const { logParams, traits } = params;
 
     const normalized = { ...traits };
-    if (traits.phone && typeof traits.phone === "string") {
+    if (traits.phone && isString(traits.phone)) {
       const result = formatPhoneAsE164({ phone: traits.phone });
 
       if (E.isLeft(result)) {

--- a/packages/analytics/src/lib/analytics.ts
+++ b/packages/analytics/src/lib/analytics.ts
@@ -146,6 +146,7 @@ export class Analytics {
           logParams,
           message: result.left.issues.map((issue) => issue.message).join(", "),
           logFunction: this.logger.error,
+          metadata: { traits },
         });
       } else {
         normalized.phone = result.right;

--- a/packages/analytics/src/lib/analytics.ts
+++ b/packages/analytics/src/lib/analytics.ts
@@ -116,7 +116,7 @@ export class Analytics {
       this.segment.track({
         userId: String(userId),
         event,
-        properties: traits,
+        properties: this.normalizeTraits({ logParams, traits }),
       });
     } catch (error) {
       this.log({


### PR DESCRIPTION
Summary
===
Add try/catch around segment calls and log errors.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added error handling to analytics calls by wrapping Segment identify and track methods in try/catch blocks and logging any errors.

- **Bug Fixes**
  - Prevents unhandled exceptions from analytics failures.
  - Logs errors with context for easier debugging.

<!-- End of auto-generated description by cubic. -->

