### PR TITLE
chore: remove zod-validation-error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3402,6 +3402,24 @@
         }
       }
     },
+    "node_modules/@jest/core/node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@jest/core/node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@jest/core/node_modules/jest-config": {
       "version": "30.0.5",
       "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.0.5.tgz",
@@ -3450,6 +3468,52 @@
           "optional": true
         },
         "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/core/node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
           "optional": true
         }
       }
@@ -4217,6 +4281,24 @@
         "yargs-parser": "21.1.1"
       }
     },
+    "node_modules/@nx/jest/node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@nx/jest/node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@nx/jest/node_modules/jest-config": {
       "version": "30.0.5",
       "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.0.5.tgz",
@@ -4265,6 +4347,52 @@
           "optional": true
         },
         "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nx/jest/node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
           "optional": true
         }
       }
@@ -5731,6 +5859,24 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "14.1.5",
@@ -9074,6 +9220,15 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -14254,6 +14409,24 @@
         }
       }
     },
+    "node_modules/jest-cli/node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/jest-cli/node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/jest-cli/node_modules/jest-config": {
       "version": "30.0.5",
       "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.0.5.tgz",
@@ -14302,6 +14475,52 @@
           "optional": true
         },
         "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-cli/node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
           "optional": true
         }
       }
@@ -22791,6 +23010,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -22867,6 +23098,18 @@
       },
       "peerDependencies": {
         "zod": "^3"
+      }
+    },
+    "packages/config/node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "packages/contract-core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22863,37 +22863,10 @@
       },
       "devDependencies": {
         "@clipboard-health/contract-core": "0.19.3",
-        "zod": "3.25.76",
-        "zod-validation-error": "3.5.1"
+        "zod": "3.25.76"
       },
       "peerDependencies": {
-        "zod": "^3",
-        "zod-validation-error": "^3"
-      }
-    },
-    "packages/config/node_modules/dotenv": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
-      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
-    "packages/config/node_modules/zod-validation-error": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.5.1.tgz",
-      "integrity": "sha512-ozT8jy2nHaeKjaRIEThwgRXBwm16hAy0BaTRx1I2IY1xrezPegmlFmYKb5tcvYqZDQm0sfZtDr2IR7CdCJzTGw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0"
+        "zod": "^3"
       }
     },
     "packages/contract-core": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -11,8 +11,7 @@
   },
   "devDependencies": {
     "@clipboard-health/contract-core": "0.19.3",
-    "zod": "3.25.76",
-    "zod-validation-error": "3.5.1"
+    "zod": "3.25.76"
   },
   "keywords": [
     "config",
@@ -22,8 +21,7 @@
   "license": "MIT",
   "main": "./src/index.js",
   "peerDependencies": {
-    "zod": "^3",
-    "zod-validation-error": "^3"
+    "zod": "^3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/config/src/lib/createConfig.ts
+++ b/packages/config/src/lib/createConfig.ts
@@ -126,12 +126,7 @@ export function createConfig<
 
   const result = schema.safeParse(resolve({ config, environment: current, path: [], schema }));
   if (!result.success) {
-    throw new Error(
-      `Configuration validation failed: ${ServiceError.fromZodError(result.error).message}`,
-      {
-        cause: result.error,
-      },
-    );
+    throw ServiceError.fromZodError(result.error);
   }
 
   return deepFreeze(result.data);

--- a/packages/config/src/lib/createConfig.ts
+++ b/packages/config/src/lib/createConfig.ts
@@ -1,6 +1,5 @@
-import { deepFreeze } from "@clipboard-health/util-ts";
+import { deepFreeze, ServiceError } from "@clipboard-health/util-ts";
 import dotenv from "dotenv";
-import { fromZodError } from "zod-validation-error";
 
 import { resolve } from "./internal/resolver";
 import { type ConfigParams } from "./types";
@@ -127,9 +126,12 @@ export function createConfig<
 
   const result = schema.safeParse(resolve({ config, environment: current, path: [], schema }));
   if (!result.success) {
-    throw new Error(`Configuration validation failed: ${fromZodError(result.error).toString()}`, {
-      cause: result.error,
-    });
+    throw new Error(
+      `Configuration validation failed: ${ServiceError.fromZodError(result.error).message}`,
+      {
+        cause: result.error,
+      },
+    );
   }
 
   return deepFreeze(result.data);

--- a/packages/util-ts/src/lib/errors/serviceError.spec.ts
+++ b/packages/util-ts/src/lib/errors/serviceError.spec.ts
@@ -139,7 +139,9 @@ describe("ServiceError", () => {
 
     const actual = new ServiceError(input);
 
-    expect(actual.message).toBe("[badRequest]: Invalid email; [badRequest]: Invalid phone");
+    expect(actual.message).toBe(
+      '[badRequest]: Invalid email at "data.attributes.email"; [badRequest]: Invalid phone at "data.attributes.phoneNumber"',
+    );
     expect(actual.issues).toHaveLength(2);
     expect(actual.issues).toEqual([
       {

--- a/packages/util-ts/src/lib/errors/serviceError.ts
+++ b/packages/util-ts/src/lib/errors/serviceError.ts
@@ -140,7 +140,7 @@ export class ServiceError extends Error {
   static fromZodError(error: ZodError, options?: { source?: ErrorSource }): ServiceError {
     return new ServiceError({
       cause: error,
-      issues: error.issues.map(toZodIssue),
+      issues: error.issues.map(fromZodIssue),
       source: options?.source,
     });
   }
@@ -275,7 +275,7 @@ export class ServiceError extends Error {
   }
 }
 
-export function toZodIssue(issue: ZodIssue): ServiceIssue {
+export function fromZodIssue(issue: ZodIssue): ServiceIssue {
   return {
     code: ERROR_CODES.badRequest,
     message: issue.message,
@@ -296,7 +296,8 @@ function createServiceErrorMessage(issues: readonly Issue[]): string {
   return issues
     .map((issue) => {
       const message = issue.message ? `: ${issue.message}` : "";
-      return `[${issue.code}]${message}`;
+      const path = issue.path && issue.path.length > 0 ? ` at "${issue.path.join(".")}"` : "";
+      return `[${issue.code}]${message}${path}`;
     })
     .join("; ");
 }


### PR DESCRIPTION
Summary
===
Remove `zod-validation-error` in favor of `ServiceError`.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced zod-validation-error with our ServiceError to standardize validation errors and drop an external dependency. Validation messages now include field paths for clearer debugging.

- **Dependencies**
  - Removed zod-validation-error from config dev/peer deps and lockfile.
  - Kept zod as the only peer dependency (^3).

- **Refactors**
  - createConfig now uses ServiceError.fromZodError(result.error).
  - Renamed issue mapper to fromZodIssue and included issue path in messages (e.g., at "data.attributes.email").
  - Updated tests to assert the new message format.

<!-- End of auto-generated description by cubic. -->

