### PR TITLE
feat: Add custom lint rule to prevent Object.assign return being used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3503,6 +3503,24 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/@jest/core/node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@jest/core/node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@jest/core/node_modules/jest-config": {
       "version": "30.0.5",
       "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.0.5.tgz",
@@ -3652,6 +3670,52 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@jest/core/node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jest/diff-sequences": {
@@ -4751,6 +4815,24 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/@nx/jest/node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@nx/jest/node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@nx/jest/node_modules/babel-jest": {
       "version": "30.1.2",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.1.2.tgz",
@@ -5085,6 +5167,52 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/@nx/jest/node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nx/js": {
@@ -6549,6 +6677,24 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "14.1.5",
@@ -9980,6 +10126,15 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -15301,6 +15456,24 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-cli/node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/jest-cli/node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/jest-cli/node_modules/jest-config": {
       "version": "30.0.5",
       "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.0.5.tgz",
@@ -15450,6 +15623,52 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jest-cli/node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
       }
     },
     "node_modules/jest-diff": {
@@ -24545,6 +24764,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -106,6 +106,12 @@ module.exports = {
               "@clipboard-health/require-http-module-factory": "error",
             },
           },
+          {
+            files: ["**/*.ts", "**/*.tsx"],
+            rules: {
+              "@clipboard-health/forbid-object-assign": "error",
+            },
+          },
         ]
       : []),
   ],

--- a/packages/eslint-config/src/index.spec.ts
+++ b/packages/eslint-config/src/index.spec.ts
@@ -277,6 +277,12 @@ describe("eslint-config", () => {
             "@clipboard-health/require-http-module-factory": "error",
           },
         },
+        {
+          files: ["**/*.ts", "**/*.tsx"],
+          rules: {
+            "@clipboard-health/forbid-object-assign": "error",
+          },
+        },
       ],
     });
   });
@@ -301,6 +307,12 @@ describe("eslint-config", () => {
           files: ["**/*.module.ts"],
           rules: {
             "@clipboard-health/require-http-module-factory": "error",
+          },
+        },
+        {
+          files: ["**/*.ts", "**/*.tsx"],
+          rules: {
+            "@clipboard-health/forbid-object-assign": "error",
           },
         },
       ],

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,7 +1,9 @@
 import enforceTsRestInControllers from "./lib/rules/enforce-ts-rest-in-controllers";
+import forbidObjectAssign from "./lib/rules/forbid-object-assign";
 import requireHttpModuleFactory from "./lib/rules/require-http-module-factory";
 
 export const rules = {
   "enforce-ts-rest-in-controllers": enforceTsRestInControllers,
   "require-http-module-factory": requireHttpModuleFactory,
+  "forbid-object-assign": forbidObjectAssign,
 };

--- a/packages/eslint-plugin/src/lib/rules/forbid-object-assign/README.md
+++ b/packages/eslint-plugin/src/lib/rules/forbid-object-assign/README.md
@@ -1,0 +1,47 @@
+## forbid-object-assign
+
+This ESLint rule is designed to disallow the use of `Object.assign` where the return value is used.
+
+An example of how this could be confusing:
+
+```ts
+const original = { name: "User", age: 20 };
+const copy = Object.assign(original, { name: "User2" });
+
+console.log(copy); // prints { name: 'User2', age: 20 }
+console.log(original); // prints { name: 'User2', age: 20 }
+console.log(copy === original); // prints true. copy and original both have the same reference.
+```
+
+It may be confusing or unclear that `original` has been modified. Another point of confusion is that `copy` is not a
+copy of the values of `original`, it's the same reference. So, even if you meant to mutate the original object, any
+further mutations to `copy` will continue to mutate `original.` This can lead to confusing behavior. To prevent all of
+that, this rule disallows `Object.assign` where its return is used.
+
+Specifically, this rule forbids usages of `Object.assign` such as:
+
+1. Direct return such as `return Object.assign(x, {a:2});`
+2. Variable declaration such as `const y = Object.assign(x, {a:2});`
+3. Variable assignment such as `let y; y = Object.assign(x, {a:2});`
+4. Member usage such as `Object.assign(x, {a:2}).b;`
+5. Usage in template literals such as `` `${Object.assign(x, {a:2})}` ``
+6. Usage in array literals such as `[Object.assign(x, {a:2})]`
+7. Usage in function arguments such as `console.log(Object.assign(x, {a:2}))`
+
+The recommendation for the above code example would be to use the spread operator instead:
+
+```ts
+const original = { name: "User", age: 20 };
+const copy = { ...original, name: "User2" };
+
+console.log(copy); // prints { name: 'User2', age: 20 }
+console.log(original); // prints { name: 'User', age: 20 } It is unmodified
+console.log(copy === original); // prints false, of course the references are different
+```
+
+You can still use `Object.assign` as a pure assignment operation. For now:
+
+```ts
+const original = { name: "User", age: 20 };
+Object.assign(original, { addThisProperty: "fun" }); // allowed by this rule, for now
+```

--- a/packages/eslint-plugin/src/lib/rules/forbid-object-assign/index.spec.ts
+++ b/packages/eslint-plugin/src/lib/rules/forbid-object-assign/index.spec.ts
@@ -1,0 +1,204 @@
+import { TSESLint } from "@typescript-eslint/utils";
+
+import rule from "./index";
+
+// eslint-disable-next-line n/no-unpublished-require
+const parser = require.resolve("@typescript-eslint/parser");
+
+const ruleTester = new TSESLint.RuleTester({
+  parser,
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: "module",
+  },
+});
+
+ruleTester.run("forbid-object-assign", rule, {
+  valid: [
+    {
+      /* While we may want to eventually disallow ALL object.assign usages, this one is not as bad
+       * since we don't confusingly use the return value. We are only using this function for its
+       * ability to mutate the first argument.
+       */
+      name: "Object.assign used only to assign",
+      code: `Object.assign(env, mapToString(process.env));`,
+    },
+    {
+      name: "invoking a function called assign on a different object should not error",
+      code: `const x = MyObject.assign(y, {a: 2});
+         const z = object.assign(y, {a: 2});`,
+    },
+  ],
+  invalid: [
+    {
+      name: "Object.assign used in a variable declaration -- Example from production code",
+      code: `const forbiddenError = Object.assign(new Error("Forbidden"), { status: 403 });`,
+      errors: [
+        {
+          messageId: "objectAssignReturnValueUsed",
+          line: 1,
+          column: 24,
+        },
+      ],
+    },
+    {
+      name: "Object.assign used in a variable declaration simple",
+      code: `const x = Object.assign(y, {a: 2});`,
+      errors: [
+        {
+          messageId: "objectAssignReturnValueUsed",
+          line: 1,
+          column: 11,
+        },
+      ],
+    },
+    {
+      name: "Object.assign used in a variable declaration with casting",
+      code: `const x = Object.assign(y, { data: 5 }) as CoolType;`,
+      errors: [
+        {
+          messageId: "objectAssignReturnValueUsed",
+          line: 1,
+          column: 11,
+        },
+      ],
+    },
+    {
+      name: "Object.assign used in a variable reassignment",
+      code: `let x = {a: 1, b: 100};
+         let c;
+         c = Object.assign(x, {b:2}); // we want to forbid this because x is mutated as well`,
+      errors: [
+        {
+          messageId: "objectAssignReturnValueUsed",
+          line: 3,
+          column: 14,
+        },
+      ],
+    },
+    {
+      name: "Object.assign used in a variable reassignment with casting",
+      code: `let x = {a: 1, b: 100};
+         let c;
+         c = Object.assign(x, {b:2}) as SomeType; // we want to forbid this because x is mutated`,
+      errors: [
+        {
+          messageId: "objectAssignReturnValueUsed",
+          line: 3,
+          column: 14,
+        },
+      ],
+    },
+    {
+      name: "Object.assign used in function return statement -- Example from production code",
+      code: `return Object.assign({}, ...bansCount) as Record<PlacementCandidateBanAction, number>;`,
+      errors: [
+        {
+          messageId: "objectAssignReturnValueUsed",
+          line: 1,
+          column: 8,
+        },
+      ],
+    },
+    {
+      name: "Object.assign used in function return statement -- simple example",
+      code: `return Object.assign(x, {a:2});`,
+      errors: [
+        {
+          messageId: "objectAssignReturnValueUsed",
+          line: 1,
+          column: 8,
+        },
+      ],
+    },
+    {
+      name: "Object.assign used in the left side of a member expression",
+      code: `Object.assign(x, {a:2}).a;`,
+      errors: [
+        {
+          messageId: "objectAssignReturnValueUsed",
+          line: 1,
+          column: 1,
+        },
+      ],
+    },
+    {
+      name: "Object.assign used in the left side of a member expression with casting",
+      code: `(Object.assign(x, {a:2}) as R).a;`,
+      errors: [
+        {
+          messageId: "objectAssignReturnValueUsed",
+          line: 1,
+          column: 2,
+        },
+      ],
+    },
+    {
+      name: "Object.assign used in a variable declaration in parenthetical expression",
+      code: `const x = (Object.assign(y, {a: 2}));`,
+      errors: [
+        {
+          messageId: "objectAssignReturnValueUsed",
+          line: 1,
+          column: 12,
+        },
+      ],
+    },
+    {
+      name: "Object.assign used in a variable declaration in non null expression",
+      code: `const x = (Object.assign(y, {a: 2}))!;`,
+      errors: [
+        {
+          messageId: "objectAssignReturnValueUsed",
+          line: 1,
+          column: 12,
+        },
+      ],
+    },
+    {
+      name: "Object.assign used in template literal",
+      // eslint-disable-next-line no-template-curly-in-string
+      code: "`${Object.assign({}, {a:2})}`.length",
+      errors: [
+        {
+          messageId: "objectAssignReturnValueUsed",
+          line: 1,
+          column: 4,
+        },
+      ],
+    },
+    {
+      name: "Object.assign used in array",
+      code: "const x = [Object.assign({}, {a:2})]",
+      errors: [
+        {
+          messageId: "objectAssignReturnValueUsed",
+          line: 1,
+          column: 12,
+        },
+      ],
+    },
+    {
+      name: "Object.assign used in array spread operator",
+      code: "const x = [...Object.assign({}, {a:2})]",
+      errors: [
+        {
+          messageId: "objectAssignReturnValueUsed",
+          line: 1,
+          column: 15,
+        },
+      ],
+    },
+    {
+      name: "Object.assign used in function argument",
+      code: "func(1, Object.assign({}, {a:2}), 3)",
+      errors: [
+        {
+          messageId: "objectAssignReturnValueUsed",
+          line: 1,
+          column: 9,
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/lib/rules/forbid-object-assign/index.ts
+++ b/packages/eslint-plugin/src/lib/rules/forbid-object-assign/index.ts
@@ -1,0 +1,140 @@
+import type { TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { type RuleContext } from "@typescript-eslint/utils/dist/ts-eslint";
+
+import createRule from "../../createRule";
+import {
+  isIdentifierExpression,
+  isMemberExpression,
+  isNonNullAssertion,
+  isTypescriptTypedExpression,
+} from "../tsEsTreeTypeGuards";
+
+function reportViolationIfObjectAssignReturnValueUsed(
+  context: Readonly<RuleContext<"objectAssignReturnValueUsed", unknown[]>>,
+  expression: TSESTree.Expression,
+): void {
+  const unwrappedExpression = unwrapExpression(expression);
+  if (isObjectAssignCall(unwrappedExpression)) {
+    context.report({
+      node: unwrappedExpression,
+      messageId: "objectAssignReturnValueUsed",
+    });
+  }
+}
+
+// Returns true iff the expression is the invocation of `Object.assign`
+function isObjectAssignCall(expression: TSESTree.Expression): boolean {
+  // Verify that the passed in expression is a function call
+  if (expression.type !== AST_NODE_TYPES.CallExpression) {
+    return false;
+  }
+
+  // Verify that the expression is a member function on an object, e.g. x.call() or f().call()
+  const { callee } = expression;
+  if (!isMemberExpression(callee)) {
+    return false;
+  }
+
+  // Verify that the function call is on an object identity, e.g. X.call() (but not f().call())
+  const { object } = callee;
+  if (!isIdentifierExpression(object)) {
+    return false;
+  }
+
+  // Verify that the function call is on the identifier referring to Object, e.g. Object.call()
+  if (object.name !== "Object") {
+    return false;
+  }
+
+  // Verify that the function being called is "assign"
+  const { property } = callee;
+  return property.type === AST_NODE_TYPES.Identifier && property.name === "assign";
+}
+
+/*
+ * Unwraps some wrapped expressions to get to the base expression. For example,
+ * Unwraps "return x as Type" to "return x" and unwraps "(x)!" to "x"
+ * This is necessary so that our rule can lint the underlying expression for violations
+ *
+ * If you want to reuse this in a wider use case, you may have to expand this to specifically deal
+ * with parentheses and other cases.
+ */
+function unwrapExpression(expression: TSESTree.Expression): TSESTree.Expression {
+  if (isTypescriptTypedExpression(expression) || isNonNullAssertion(expression)) {
+    return unwrapExpression(expression.expression);
+  }
+
+  return expression;
+}
+
+const rule = createRule({
+  name: "forbid-object-assign",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Favor object spread operator {...obj} over Object.assign",
+    },
+    schema: [],
+    messages: {
+      objectAssignReturnValueUsed:
+        "Use the object spread operator. Object.assign mutates the first argument which is confusing. See https://www.notion.so/BP-TypeScript-Style-Guide-5d4c24aea08a4b9f9feb03550f2c5310?source=copy_link#2568643321f4805ba04ecce1082b2b38 for more information.",
+    },
+  },
+
+  create(context: Readonly<RuleContext<"objectAssignReturnValueUsed", unknown[]>>) {
+    return {
+      VariableDeclarator(node: TSESTree.VariableDeclarator) {
+        if (node.init === null) {
+          return;
+        }
+
+        reportViolationIfObjectAssignReturnValueUsed(context, node.init);
+      },
+      AssignmentExpression(node: TSESTree.AssignmentExpression) {
+        const rightHandSideOfAssignment = node.right;
+        reportViolationIfObjectAssignReturnValueUsed(context, rightHandSideOfAssignment);
+      },
+      ReturnStatement(node: TSESTree.ReturnStatement) {
+        if (node.argument === null) {
+          return;
+        }
+
+        reportViolationIfObjectAssignReturnValueUsed(context, node.argument);
+      },
+      MemberExpression(node: TSESTree.MemberExpression) {
+        reportViolationIfObjectAssignReturnValueUsed(context, node.object);
+      },
+      TemplateLiteral(node: TSESTree.TemplateLiteral) {
+        node.expressions.forEach((expression) => {
+          reportViolationIfObjectAssignReturnValueUsed(context, expression);
+        });
+      },
+      ArrayExpression(node: TSESTree.ArrayExpression) {
+        node.elements.forEach((expression) => {
+          if (expression === null) {
+            return;
+          }
+
+          if (expression.type === AST_NODE_TYPES.SpreadElement) {
+            reportViolationIfObjectAssignReturnValueUsed(context, expression.argument);
+          } else {
+            reportViolationIfObjectAssignReturnValueUsed(context, expression);
+          }
+        });
+      },
+      CallExpression(node: TSESTree.CallExpression) {
+        node.arguments.forEach((argument) => {
+          if (argument.type === AST_NODE_TYPES.SpreadElement) {
+            reportViolationIfObjectAssignReturnValueUsed(context, argument.argument);
+          } else {
+            reportViolationIfObjectAssignReturnValueUsed(context, argument);
+          }
+        });
+      },
+    };
+  },
+});
+
+export default rule;

--- a/packages/eslint-plugin/src/lib/rules/tsEsTreeTypeGuards.ts
+++ b/packages/eslint-plugin/src/lib/rules/tsEsTreeTypeGuards.ts
@@ -1,0 +1,29 @@
+import type { TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES } from "@typescript-eslint/utils";
+
+export function isMemberExpression(
+  expression: TSESTree.Expression | TSESTree.Super,
+): expression is TSESTree.MemberExpression {
+  return expression.type === AST_NODE_TYPES.MemberExpression;
+}
+
+export function isIdentifierExpression(
+  expression: TSESTree.Expression,
+): expression is TSESTree.Identifier {
+  return expression.type === AST_NODE_TYPES.Identifier;
+}
+
+export function isTypescriptTypedExpression(
+  expression: TSESTree.Expression,
+): expression is TSESTree.TSAsExpression | TSESTree.TSTypeAssertion {
+  return (
+    expression.type === AST_NODE_TYPES.TSAsExpression ||
+    expression.type === AST_NODE_TYPES.TSTypeAssertion
+  );
+}
+
+export function isNonNullAssertion(
+  expression: TSESTree.Expression,
+): expression is TSESTree.TSNonNullExpression {
+  return expression.type === AST_NODE_TYPES.TSNonNullExpression;
+}


### PR DESCRIPTION
Summary
===
This adds a new custom linting rule to forbid using the return value of `Object.assign`

An example of how this could be confusing:

```ts
const original = { name: "User", age: 20 };
const copy = Object.assign(original, { name: "User2" });

console.log(copy); // prints { name: 'User2', age: 20 }
console.log(original); // prints { name: 'User2', age: 20 }
console.log(copy === original); // prints true. copy and original both have the same reference.
```

It may be confusing or unclear that `original` has been modified. Another point of confusion is that `copy` is not a
copy of the values of `original`, it's the same reference. So, even if you meant to mutate the original object, any
further mutations to `copy` will continue to mutate `original.` This can lead to confusing behavior. To prevent all of
that, this rule disallows `Object.assign` where its return is used.

Specifically, this rule forbids usages of `Object.assign` such as:

1. Direct return such as `return Object.assign(x, {a:2});`
2. Variable declaration such as `const y = Object.assign(x, {a:2});`
3. Variable assignment such as `let y; y = Object.assign(x, {a:2});`
4. Member usage such as `Object.assign(x, {a:2}).b;`
5. Usage in template literals such as `` `${Object.assign(x, {a:2})}` ``
6. Usage in array literals such as `[Object.assign(x, {a:2})]`
7. Usage in function arguments such as `console.log(Object.assign(x, {a:2}))`


The recommendation for the above code example would be to use the spread operator instead:

```ts
const original = { name: "User", age: 20 };
const copy = { ...original, name: "User2" };

console.log(copy); // prints { name: 'User2', age: 20 }
console.log(original); // prints { name: 'User', age: 20 } It is unmodified
console.log(copy === original); // prints false, of course the references are different
```

You can still use `Object.assign` as a pure assignment operation. For now:

```ts
const original = { name: "User", age: 20 };
Object.assign(original, { addThisProperty: "fun" }); // allowed by this rule, for now
```

