### PR TITLE
feat(FOR-1074): add no-cross-module-repository-usage ESLint rule

### DIFF
--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -104,6 +104,13 @@ module.exports = {
             files: ["**/*.module.ts"],
             rules: {
               "@clipboard-health/require-http-module-factory": "error",
+              "@clipboard-health/no-cross-module-repository-usage": "error",
+            },
+          },
+          {
+            files: ["**/*.service.ts", "**/*.repository.ts", "**/*.repo.ts"],
+            rules: {
+              "@clipboard-health/no-cross-module-repository-usage": "error",
             },
           },
         ]

--- a/packages/eslint-config/src/index.spec.ts
+++ b/packages/eslint-config/src/index.spec.ts
@@ -275,6 +275,13 @@ describe("eslint-config", () => {
           files: ["**/*.module.ts"],
           rules: {
             "@clipboard-health/require-http-module-factory": "error",
+            "@clipboard-health/no-cross-module-repository-usage": "error",
+          },
+        },
+        {
+          files: ["**/*.service.ts", "**/*.repository.ts", "**/*.repo.ts"],
+          rules: {
+            "@clipboard-health/no-cross-module-repository-usage": "error",
           },
         },
       ],
@@ -301,6 +308,13 @@ describe("eslint-config", () => {
           files: ["**/*.module.ts"],
           rules: {
             "@clipboard-health/require-http-module-factory": "error",
+            "@clipboard-health/no-cross-module-repository-usage": "error",
+          },
+        },
+        {
+          files: ["**/*.service.ts", "**/*.repository.ts", "**/*.repo.ts"],
+          rules: {
+            "@clipboard-health/no-cross-module-repository-usage": "error",
           },
         },
       ],

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,7 +1,9 @@
 import enforceTsRestInControllers from "./lib/rules/enforce-ts-rest-in-controllers";
+import noCrossModuleRepositoryUsage from "./lib/rules/no-cross-module-repository-usage";
 import requireHttpModuleFactory from "./lib/rules/require-http-module-factory";
 
 export const rules = {
   "enforce-ts-rest-in-controllers": enforceTsRestInControllers,
+  "no-cross-module-repository-usage": noCrossModuleRepositoryUsage,
   "require-http-module-factory": requireHttpModuleFactory,
 };

--- a/packages/eslint-plugin/src/lib/rules/no-cross-module-repository-usage/README.md
+++ b/packages/eslint-plugin/src/lib/rules/no-cross-module-repository-usage/README.md
@@ -4,9 +4,10 @@ This ESLint rule prevents cross-module repository usage in NestJS applications t
 
 ### Rule Details
 
-This rule enforces one main requirement:
+This rule enforces two main requirements:
 
 1. **No Repository Exports**: NestJS modules should not export repository classes in their `exports` array
+2. **No Cross-Module Repository Usage**: Classes should not import or inject repository classes from different modules
 
 ### Examples
 
@@ -38,6 +39,14 @@ export class AnotherService {
     private readonly someRepository: SomeRepository,
   ) {}
 }
+
+// Regular parameter with @Inject decorator
+@Injectable()
+export class YetAnotherService {
+  constructor(
+    @Inject(SomeRepository) someRepo: SomeRepository, // ❌ Cross-module repository injection
+  ) {}
+}
 ```
 
 #### ✅ Correct
@@ -49,6 +58,16 @@ export class AnotherService {
   exports: [SomeService], // ✅ Export service instead
 })
 export class SomeModule {}
+
+// In same-module.service.ts - using repository from same module
+import { SomeRepository } from "./some.repository";
+
+@Injectable()
+export class SameModuleService {
+  constructor(
+    private readonly someRepository: SomeRepository, // ✅ Same-module repository usage
+  ) {}
+}
 ```
 
 ### Repository Detection
@@ -58,9 +77,30 @@ The rule identifies repository classes by:
 - Class names ending in "Repository"
 - Class names ending in "Repo"
 
-### Scope
+### Module Boundary Detection
 
-This rule currently focuses on preventing repository exports from NestJS modules. Future versions may include detection of cross-module repository usage patterns.
+The rule determines module boundaries by analyzing file paths and import patterns:
+
+- Files containing `@Module` decorators are treated as module files
+- Cross-module detection is based on relative import paths and directory structure
+- Same-directory imports (starting with `./`) are considered same-module
+- Parent directory imports (starting with `../`) are analyzed for module boundaries
+
+### Import Path Analysis
+
+The rule identifies repository imports by checking:
+
+- File paths ending in `.repository.ts` or `.repo.ts`
+- Import paths containing "repository" or "repositories" segments
+- Basename of files ending with ".repository" or ".repo"
+
+### Constructor Parameter Patterns
+
+The rule handles all injection patterns:
+
+- TypeScript parameter properties with type annotations
+- Regular parameters with `@Inject` decorators
+- Both private/public/protected parameter properties
 
 ### When Not To Use
 

--- a/packages/eslint-plugin/src/lib/rules/no-cross-module-repository-usage/README.md
+++ b/packages/eslint-plugin/src/lib/rules/no-cross-module-repository-usage/README.md
@@ -1,0 +1,77 @@
+## no-cross-module-repository-usage
+
+This ESLint rule prevents cross-module repository usage in NestJS applications to enforce proper architectural boundaries.
+
+### Rule Details
+
+This rule enforces two main requirements:
+
+1. **No Repository Exports**: NestJS modules should not export repository classes in their `exports` array
+2. **No Cross-Module Repository Usage**: Classes should not import or inject repository classes from different modules
+
+### Examples
+
+#### ❌ Incorrect
+
+```typescript
+// In some.module.ts - exporting repository
+@Module({
+  providers: [SomeRepository],
+  exports: [SomeRepository], // ❌ Should not export repository
+})
+export class SomeModule {}
+
+// In different-module.service.ts - using repository from different module
+import { SomeRepository } from "../some-module/some.repository";
+
+@Injectable()
+export class DifferentModuleService {
+  constructor(
+    private readonly someRepository: SomeRepository, // ❌ Cross-module repository usage
+  ) {}
+}
+
+// Using @Inject decorator
+@Injectable()
+export class AnotherService {
+  constructor(
+    @Inject(SomeRepository) // ❌ Cross-module repository injection
+    private readonly someRepository: SomeRepository,
+  ) {}
+}
+```
+
+#### ✅ Correct
+
+```typescript
+// In some.module.ts - not exporting repository
+@Module({
+  providers: [SomeService, SomeRepository],
+  exports: [SomeService], // ✅ Export service instead
+})
+export class SomeModule {}
+
+// In some.service.ts - using repository within same module
+@Injectable()
+export class SomeService {
+  constructor(
+    private readonly someRepository: SomeRepository, // ✅ Same module usage
+  ) {}
+}
+```
+
+### Repository Detection
+
+The rule identifies repository classes by:
+
+- Class names ending in "Repository"
+- Class names containing "Repo"
+- Files ending in ".repo.ts" or ".repository.ts"
+
+### Module Boundary Detection
+
+The rule determines module boundaries by analyzing `@Module` decorator's `providers` array rather than directory structure. This ensures accurate detection of which repositories belong to each module.
+
+### When Not To Use
+
+This rule should be disabled if your architecture intentionally allows cross-module repository access.

--- a/packages/eslint-plugin/src/lib/rules/no-cross-module-repository-usage/README.md
+++ b/packages/eslint-plugin/src/lib/rules/no-cross-module-repository-usage/README.md
@@ -4,10 +4,9 @@ This ESLint rule prevents cross-module repository usage in NestJS applications t
 
 ### Rule Details
 
-This rule enforces two main requirements:
+This rule enforces one main requirement:
 
 1. **No Repository Exports**: NestJS modules should not export repository classes in their `exports` array
-2. **No Cross-Module Repository Usage**: Classes should not import or inject repository classes from different modules
 
 ### Examples
 
@@ -50,14 +49,6 @@ export class AnotherService {
   exports: [SomeService], // ✅ Export service instead
 })
 export class SomeModule {}
-
-// In some.service.ts - using repository within same module
-@Injectable()
-export class SomeService {
-  constructor(
-    private readonly someRepository: SomeRepository, // ✅ Same module usage
-  ) {}
-}
 ```
 
 ### Repository Detection
@@ -65,12 +56,11 @@ export class SomeService {
 The rule identifies repository classes by:
 
 - Class names ending in "Repository"
-- Class names containing "Repo"
-- Files ending in ".repo.ts" or ".repository.ts"
+- Class names ending in "Repo"
 
-### Module Boundary Detection
+### Scope
 
-The rule determines module boundaries by analyzing `@Module` decorator's `providers` array rather than directory structure. This ensures accurate detection of which repositories belong to each module.
+This rule currently focuses on preventing repository exports from NestJS modules. Future versions may include detection of cross-module repository usage patterns.
 
 ### When Not To Use
 

--- a/packages/eslint-plugin/src/lib/rules/no-cross-module-repository-usage/index.spec.ts
+++ b/packages/eslint-plugin/src/lib/rules/no-cross-module-repository-usage/index.spec.ts
@@ -1,0 +1,264 @@
+import { TSESLint } from "@typescript-eslint/utils";
+
+import rule from "./index";
+
+// eslint-disable-next-line n/no-unpublished-require
+const parser = require.resolve("@typescript-eslint/parser");
+
+const ruleTester = new TSESLint.RuleTester({
+  parser,
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: "module",
+  },
+});
+
+ruleTester.run("no-cross-module-repository-usage", rule, {
+  valid: [
+    {
+      name: "Module file exporting service instead of repository",
+      filename: "/src/modules/user/user.module.ts",
+      code: `
+        import { Module } from "@nestjs/common";
+        import { UserService } from "./logic/user.service";
+        import { UserRepository } from "./data/user.repository";
+        
+        @Module({
+          providers: [UserService, UserRepository],
+          exports: [UserService],
+        })
+        export class UserModule {}
+      `,
+    },
+    {
+      name: "Same-module repository usage in service",
+      filename: "/src/modules/user/logic/user.service.ts",
+      code: `
+        import { Injectable } from "@nestjs/common";
+        import { UserRepository } from "../data/user.repository";
+        
+        @Injectable()
+        export class UserService {
+          constructor(private readonly userRepository: UserRepository) {}
+        }
+      `,
+    },
+    {
+      name: "Same-directory repository import",
+      filename: "/src/modules/user/logic/user.service.ts",
+      code: `
+        import { Injectable } from "@nestjs/common";
+        import { UserRepository } from "./user.repository";
+        
+        @Injectable()
+        export class UserService {
+          constructor(private readonly userRepository: UserRepository) {}
+        }
+      `,
+    },
+    {
+      name: "Non-repository class with Repo in name",
+      filename: "/src/modules/user/logic/user.service.ts",
+      code: `
+        import { Injectable } from "@nestjs/common";
+        import { ReportService } from "../other/report.service";
+        
+        @Injectable()
+        export class UserService {
+          constructor(private readonly reportService: ReportService) {}
+        }
+      `,
+    },
+    {
+      name: "Repository import without cross-module usage",
+      filename: "/src/modules/user/logic/user.service.ts",
+      code: `
+        import { Injectable } from "@nestjs/common";
+        import { UserRepository } from "../data/user.repository";
+        
+        @Injectable()
+        export class UserService {
+          private someMethod() {
+          }
+        }
+      `,
+    },
+    {
+      name: "Module without exports property",
+      filename: "/src/modules/user/user.module.ts",
+      code: `
+        import { Module } from "@nestjs/common";
+        import { UserRepository } from "./data/user.repository";
+        
+        @Module({
+          providers: [UserRepository],
+        })
+        export class UserModule {}
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: "Module exporting repository",
+      filename: "/src/modules/user/user.module.ts",
+      code: `
+        import { Module } from "@nestjs/common";
+        import { UserRepository } from "./data/user.repository";
+        
+        @Module({
+          providers: [UserRepository],
+          exports: [UserRepository],
+        })
+        export class UserModule {}
+      `,
+      errors: [
+        {
+          messageId: "moduleExportsRepository",
+          line: 7,
+          column: 21,
+        },
+      ],
+    },
+    {
+      name: "Cross-module repository import",
+      filename: "/src/modules/order/logic/order.service.ts",
+      code: `
+        import { Injectable } from "@nestjs/common";
+        import { UserRepository } from "../../user/data/user.repository";
+        
+        @Injectable()
+        export class OrderService {
+          constructor(private readonly userRepository: UserRepository) {}
+        }
+      `,
+      errors: [
+        {
+          messageId: "crossModuleRepositoryImport",
+          line: 3,
+          column: 18,
+        },
+        {
+          messageId: "crossModuleRepositoryInjection",
+          line: 7,
+          column: 40,
+        },
+      ],
+    },
+    {
+      name: "Cross-module repository injection with @Inject",
+      filename: "/src/modules/order/logic/order.service.ts",
+      code: `
+        import { Injectable, Inject } from "@nestjs/common";
+        import { UserRepository } from "../../user/data/user.repository";
+        
+        @Injectable()
+        export class OrderService {
+          constructor(
+            @Inject(UserRepository) private readonly userRepo: UserRepository,
+          ) {}
+        }
+      `,
+      errors: [
+        {
+          messageId: "crossModuleRepositoryImport",
+          line: 3,
+          column: 18,
+        },
+        {
+          messageId: "crossModuleRepositoryInjection",
+          line: 8,
+          column: 21,
+        },
+        {
+          messageId: "crossModuleRepositoryInjection",
+          line: 8,
+          column: 54,
+        },
+      ],
+    },
+    {
+      name: "Regular parameter with @Inject decorator",
+      filename: "/src/modules/order/logic/order.service.ts",
+      code: `
+        import { Injectable, Inject } from "@nestjs/common";
+        import { UserRepository } from "../../user/data/user.repository";
+        
+        @Injectable()
+        export class OrderService {
+          constructor(
+            @Inject(UserRepository) userRepo: UserRepository,
+          ) {}
+        }
+      `,
+      errors: [
+        {
+          messageId: "crossModuleRepositoryImport",
+          line: 3,
+          column: 18,
+        },
+        {
+          messageId: "crossModuleRepositoryInjection",
+          line: 8,
+          column: 21,
+        },
+        {
+          messageId: "crossModuleRepositoryInjection",
+          line: 8,
+          column: 21,
+        },
+      ],
+    },
+    {
+      name: "Multiple repository exports",
+      filename: "/src/modules/user/user.module.ts",
+      code: `
+        import { Module } from "@nestjs/common";
+        import { UserRepository } from "./data/user.repository";
+        import { ProfileRepo } from "./data/profile.repo";
+        
+        @Module({
+          providers: [UserRepository, ProfileRepo],
+          exports: [UserRepository, ProfileRepo],
+        })
+        export class UserModule {}
+      `,
+      errors: [
+        {
+          messageId: "moduleExportsRepository",
+          line: 8,
+          column: 21,
+        },
+        {
+          messageId: "moduleExportsRepository",
+          line: 8,
+          column: 37,
+        },
+      ],
+    },
+    {
+      name: "Repository file import pattern",
+      filename: "/src/modules/order/logic/order.service.ts",
+      code: `
+        import { Injectable } from "@nestjs/common";
+        import { UserRepo } from "../../user/repository/user.repo";
+        
+        @Injectable()
+        export class OrderService {
+          constructor(private readonly userRepo: UserRepo) {}
+        }
+      `,
+      errors: [
+        {
+          messageId: "crossModuleRepositoryImport",
+          line: 3,
+          column: 18,
+        },
+        {
+          messageId: "crossModuleRepositoryInjection",
+          line: 7,
+          column: 40,
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/lib/rules/no-cross-module-repository-usage/index.ts
+++ b/packages/eslint-plugin/src/lib/rules/no-cross-module-repository-usage/index.ts
@@ -8,9 +8,6 @@ import createRule from "../../createRule";
 const isRepositoryClass = (name: string): boolean =>
   name.endsWith("Repository") || name.endsWith("Repo");
 
-
-
-
 const rule = createRule({
   name: "no-cross-module-repository-usage",
   defaultOptions: [],
@@ -48,7 +45,10 @@ const rule = createRule({
               exportsProperty.value.type === AST_NODE_TYPES.ArrayExpression
             ) {
               exportsProperty.value.elements.forEach((element) => {
-                if (element?.type === AST_NODE_TYPES.Identifier && isRepositoryClass(element.name)) {
+                if (
+                  element?.type === AST_NODE_TYPES.Identifier &&
+                  isRepositoryClass(element.name)
+                ) {
                   context.report({
                     node: element,
                     messageId: "moduleExportsRepository",

--- a/packages/eslint-plugin/src/lib/rules/no-cross-module-repository-usage/index.ts
+++ b/packages/eslint-plugin/src/lib/rules/no-cross-module-repository-usage/index.ts
@@ -1,0 +1,172 @@
+/**
+ * @fileoverview Rule to prevent cross-module repository usage in NestJS applications
+ */
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+import type { RuleContext } from "@typescript-eslint/utils/ts-eslint";
+
+import createRule from "../../createRule";
+
+const isRepositoryClass = (name: string): boolean =>
+  name.endsWith("Repository") || name.includes("Repo");
+
+const isRepositoryFile = (filePath: string): boolean =>
+  filePath.endsWith(".repo.ts") || filePath.endsWith(".repository.ts");
+
+const checkModuleExports = (
+  moduleConfig: TSESTree.ObjectExpression,
+  context: RuleContext<string, readonly unknown[]>,
+) => {
+  const exportsProperty = moduleConfig.properties.find(
+    (property): property is TSESTree.Property =>
+      property.type === AST_NODE_TYPES.Property &&
+      property.key.type === AST_NODE_TYPES.Identifier &&
+      property.key.name === "exports",
+  );
+
+  if (
+    exportsProperty?.type === AST_NODE_TYPES.Property &&
+    exportsProperty.value.type === AST_NODE_TYPES.ArrayExpression
+  ) {
+    exportsProperty.value.elements.forEach((element) => {
+      if (element?.type === AST_NODE_TYPES.Identifier && isRepositoryClass(element.name)) {
+        context.report({
+          node: element,
+          messageId: "moduleExportsRepository",
+          data: { repositoryName: element.name },
+        });
+      }
+    });
+  }
+};
+
+const checkInjectDecorator = (
+  node: TSESTree.Decorator,
+  repositoryImports: Map<string, string>,
+  context: RuleContext<string, readonly unknown[]>,
+) => {
+  if (node.expression.type === AST_NODE_TYPES.CallExpression) {
+    const injectArgument = node.expression.arguments[0];
+    if (
+      injectArgument?.type === AST_NODE_TYPES.Identifier &&
+      isRepositoryClass(injectArgument.name) &&
+      repositoryImports.has(injectArgument.name)
+    ) {
+      context.report({
+        node: injectArgument,
+        messageId: "crossModuleRepositoryInjection",
+        data: { repositoryName: injectArgument.name },
+      });
+    }
+  }
+};
+
+const checkConstructorParameter = (
+  parameter_: TSESTree.Parameter,
+  repositoryImports: Map<string, string>,
+  context: RuleContext<string, readonly unknown[]>,
+) => {
+  if (parameter_.type === AST_NODE_TYPES.TSParameterProperty) {
+    const { parameter } = parameter_;
+    if (
+      parameter.type === AST_NODE_TYPES.Identifier &&
+      parameter.typeAnnotation?.type === AST_NODE_TYPES.TSTypeAnnotation &&
+      parameter.typeAnnotation.typeAnnotation.type === AST_NODE_TYPES.TSTypeReference &&
+      parameter.typeAnnotation.typeAnnotation.typeName.type === AST_NODE_TYPES.Identifier
+    ) {
+      const typeName = parameter.typeAnnotation.typeAnnotation.typeName.name;
+      if (isRepositoryClass(typeName) && repositoryImports.has(typeName)) {
+        context.report({
+          node: parameter,
+          messageId: "crossModuleRepositoryInjection",
+          data: { repositoryName: typeName },
+        });
+      }
+    }
+  }
+};
+
+const rule = createRule({
+  name: "no-cross-module-repository-usage",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Prevent cross-module repository usage in NestJS applications",
+    },
+    schema: [],
+    messages: {
+      moduleExportsRepository:
+        "NestJS modules should not export repository classes. Repository '{{repositoryName}}' should not be exported from module.",
+      crossModuleRepositoryImport:
+        "Repository '{{repositoryName}}' from '{{importPath}}' should not be imported from a different module. Repositories should only be used within their own module.",
+      crossModuleRepositoryInjection:
+        "Repository '{{repositoryName}}' should not be injected from a different module. Repositories should only be used within their own module.",
+    },
+  },
+
+  create(context) {
+    const repositoryImports = new Map<string, string>(); // name -> import path
+    let isModuleFile = false;
+
+    return {
+      Decorator(node) {
+        if (
+          node.expression.type === AST_NODE_TYPES.CallExpression &&
+          node.expression.callee.type === AST_NODE_TYPES.Identifier
+        ) {
+          if (node.expression.callee.name === "Module") {
+            isModuleFile = true;
+            const moduleConfig = node.expression.arguments[0];
+            if (moduleConfig?.type === AST_NODE_TYPES.ObjectExpression) {
+              checkModuleExports(moduleConfig, context);
+            }
+          }
+
+          if (node.expression.callee.name === "Inject" && !isModuleFile) {
+            checkInjectDecorator(node, repositoryImports, context);
+          }
+        }
+      },
+
+      ImportDeclaration(node) {
+        const importPath = node.source.value;
+        if (isRepositoryFile(importPath) || importPath.includes("repository")) {
+          node.specifiers.forEach((spec) => {
+            if (
+              spec.type === AST_NODE_TYPES.ImportSpecifier &&
+              spec.imported.type === AST_NODE_TYPES.Identifier &&
+              isRepositoryClass(spec.imported.name)
+            ) {
+              repositoryImports.set(spec.local.name, importPath);
+
+              if (!isModuleFile) {
+                context.report({
+                  node: spec,
+                  messageId: "crossModuleRepositoryImport",
+                  data: {
+                    repositoryName: spec.imported.name,
+                    importPath,
+                  },
+                });
+              }
+            }
+          });
+        }
+      },
+
+      MethodDefinition(node) {
+        if (
+          node.kind === "constructor" &&
+          node.value.type === AST_NODE_TYPES.FunctionExpression &&
+          !isModuleFile
+        ) {
+          node.value.params.forEach((parameter_) => {
+            checkConstructorParameter(parameter_, repositoryImports, context);
+          });
+        }
+      },
+    };
+  },
+});
+
+export default rule;

--- a/packages/eslint-plugin/src/lib/rules/no-cross-module-repository-usage/index.ts
+++ b/packages/eslint-plugin/src/lib/rules/no-cross-module-repository-usage/index.ts
@@ -9,32 +9,6 @@ const isRepositoryClass = (name: string): boolean =>
   name.endsWith("Repository") || name.endsWith("Repo");
 
 
-const checkModuleExports = (
-  moduleConfig: TSESTree.ObjectExpression,
-  context: any,
-) => {
-  const exportsProperty = moduleConfig.properties.find(
-    (property): property is TSESTree.Property =>
-      property.type === AST_NODE_TYPES.Property &&
-      property.key.type === AST_NODE_TYPES.Identifier &&
-      property.key.name === "exports",
-  );
-
-  if (
-    exportsProperty?.type === AST_NODE_TYPES.Property &&
-    exportsProperty.value.type === AST_NODE_TYPES.ArrayExpression
-  ) {
-    exportsProperty.value.elements.forEach((element) => {
-      if (element?.type === AST_NODE_TYPES.Identifier && isRepositoryClass(element.name)) {
-        context.report({
-          node: element,
-          messageId: "moduleExportsRepository",
-          data: { repositoryName: element.name },
-        });
-      }
-    });
-  }
-};
 
 
 const rule = createRule({
@@ -62,7 +36,27 @@ const rule = createRule({
         ) {
           const moduleConfig = node.expression.arguments[0];
           if (moduleConfig?.type === AST_NODE_TYPES.ObjectExpression) {
-            checkModuleExports(moduleConfig, context);
+            const exportsProperty = moduleConfig.properties.find(
+              (property): property is TSESTree.Property =>
+                property.type === AST_NODE_TYPES.Property &&
+                property.key.type === AST_NODE_TYPES.Identifier &&
+                property.key.name === "exports",
+            );
+
+            if (
+              exportsProperty?.type === AST_NODE_TYPES.Property &&
+              exportsProperty.value.type === AST_NODE_TYPES.ArrayExpression
+            ) {
+              exportsProperty.value.elements.forEach((element) => {
+                if (element?.type === AST_NODE_TYPES.Identifier && isRepositoryClass(element.name)) {
+                  context.report({
+                    node: element,
+                    messageId: "moduleExportsRepository",
+                    data: { repositoryName: element.name },
+                  });
+                }
+              });
+            }
           }
         }
       },

--- a/packages/eslint-plugin/src/lib/rules/no-cross-module-repository-usage/index.ts
+++ b/packages/eslint-plugin/src/lib/rules/no-cross-module-repository-usage/index.ts
@@ -1,12 +1,173 @@
 /**
  * @fileoverview Rule to prevent cross-module repository usage in NestJS applications
  */
+import * as path from "node:path";
+
 import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+import type { RuleContext } from "@typescript-eslint/utils/dist/ts-eslint";
 
 import createRule from "../../createRule";
 
 const isRepositoryClass = (name: string): boolean =>
   name.endsWith("Repository") || name.endsWith("Repo");
+
+const isRepositoryFile = (filePath: string): boolean => {
+  const basename = path.basename(filePath, path.extname(filePath));
+  return (
+    basename.endsWith(".repository") ||
+    basename.endsWith(".repo") ||
+    filePath.endsWith(".repository.ts") ||
+    filePath.endsWith(".repo.ts")
+  );
+};
+
+const isRepositoryImportPath = (importPath: string): boolean => {
+  const segments = importPath.split("/");
+  return (
+    segments.some(
+      (segment) =>
+        segment === "repository" ||
+        segment === "repositories" ||
+        segment.endsWith(".repository") ||
+        segment.endsWith(".repo"),
+    ) || isRepositoryFile(importPath)
+  );
+};
+
+const getModuleDirectory = (filePath: string): string => {
+  const parts = filePath.split("/");
+  const moduleIndex = parts.indexOf("modules");
+  if (moduleIndex !== -1 && moduleIndex + 1 < parts.length) {
+    return parts.slice(0, moduleIndex + 2).join("/");
+  }
+
+  return path.dirname(filePath);
+};
+
+const isCrossModuleImport = (currentFilePath: string, importPath: string): boolean => {
+  if (importPath.startsWith("./")) {
+    return false;
+  }
+
+  if (importPath.startsWith("../")) {
+    const resolvedPath = path.resolve(path.dirname(currentFilePath), importPath);
+    const currentModuleDirectory = getModuleDirectory(currentFilePath);
+    const importModuleDirectory = getModuleDirectory(resolvedPath);
+    return currentModuleDirectory !== importModuleDirectory;
+  }
+
+  return true;
+};
+
+const checkModuleExports = (
+  moduleConfig: TSESTree.ObjectExpression,
+  context: RuleContext<
+    "moduleExportsRepository" | "crossModuleRepositoryImport" | "crossModuleRepositoryInjection",
+    never[]
+  >,
+): void => {
+  const exportsProperty = moduleConfig.properties.find(
+    (property): property is TSESTree.Property =>
+      property.type === AST_NODE_TYPES.Property &&
+      property.key.type === AST_NODE_TYPES.Identifier &&
+      property.key.name === "exports",
+  );
+
+  if (
+    exportsProperty?.type === AST_NODE_TYPES.Property &&
+    exportsProperty.value.type === AST_NODE_TYPES.ArrayExpression
+  ) {
+    exportsProperty.value.elements.forEach((element) => {
+      if (element?.type === AST_NODE_TYPES.Identifier && isRepositoryClass(element.name)) {
+        context.report({
+          node: element,
+          messageId: "moduleExportsRepository",
+          data: { repositoryName: element.name },
+        });
+      }
+    });
+  }
+};
+
+const checkInjectDecorator = (
+  node: TSESTree.Decorator,
+  repositoryImports: Map<string, string>,
+  currentFilePath: string,
+  context: RuleContext<
+    "moduleExportsRepository" | "crossModuleRepositoryImport" | "crossModuleRepositoryInjection",
+    never[]
+  >,
+): void => {
+  if (node.expression.type === AST_NODE_TYPES.CallExpression) {
+    const injectArgument = node.expression.arguments[0];
+    if (
+      injectArgument?.type === AST_NODE_TYPES.Identifier &&
+      isRepositoryClass(injectArgument.name) &&
+      repositoryImports.has(injectArgument.name)
+    ) {
+      const importPath = repositoryImports.get(injectArgument.name)!;
+      if (isCrossModuleImport(currentFilePath, importPath)) {
+        context.report({
+          node: injectArgument,
+          messageId: "crossModuleRepositoryInjection",
+          data: { repositoryName: injectArgument.name },
+        });
+      }
+    }
+  }
+};
+
+const checkTSParameterProperty = (
+  parameter: TSESTree.TSParameterProperty,
+  repositoryImports: Map<string, string>,
+  currentFilePath: string,
+  context: RuleContext<
+    "moduleExportsRepository" | "crossModuleRepositoryImport" | "crossModuleRepositoryInjection",
+    never[]
+  >,
+): void => {
+  const { parameter: parameter_ } = parameter;
+  if (
+    parameter_.type === AST_NODE_TYPES.Identifier &&
+    parameter_.typeAnnotation?.type === AST_NODE_TYPES.TSTypeAnnotation &&
+    parameter_.typeAnnotation.typeAnnotation.type === AST_NODE_TYPES.TSTypeReference &&
+    parameter_.typeAnnotation.typeAnnotation.typeName.type === AST_NODE_TYPES.Identifier
+  ) {
+    const typeName = parameter_.typeAnnotation.typeAnnotation.typeName.name;
+    if (isRepositoryClass(typeName) && repositoryImports.has(typeName)) {
+      const importPath = repositoryImports.get(typeName)!;
+      if (isCrossModuleImport(currentFilePath, importPath)) {
+        context.report({
+          node: parameter_,
+          messageId: "crossModuleRepositoryInjection",
+          data: { repositoryName: typeName },
+        });
+      }
+    }
+  }
+};
+
+const checkRegularParameter = (
+  parameter: TSESTree.Identifier,
+  repositoryImports: Map<string, string>,
+  currentFilePath: string,
+  context: RuleContext<
+    "moduleExportsRepository" | "crossModuleRepositoryImport" | "crossModuleRepositoryInjection",
+    never[]
+  >,
+): void => {
+  if (parameter.decorators) {
+    parameter.decorators.forEach((decorator) => {
+      if (
+        decorator.expression.type === AST_NODE_TYPES.CallExpression &&
+        decorator.expression.callee.type === AST_NODE_TYPES.Identifier &&
+        decorator.expression.callee.name === "Inject"
+      ) {
+        checkInjectDecorator(decorator, repositoryImports, currentFilePath, context);
+      }
+    });
+  }
+};
 
 const rule = createRule({
   name: "no-cross-module-repository-usage",
@@ -20,11 +181,47 @@ const rule = createRule({
     messages: {
       moduleExportsRepository:
         "NestJS modules should not export repository classes. Repository '{{repositoryName}}' should not be exported from module.",
+      crossModuleRepositoryImport:
+        "Repository '{{repositoryName}}' from '{{importPath}}' should not be imported from a different module. Repositories should only be used within their own module.",
+      crossModuleRepositoryInjection:
+        "Repository '{{repositoryName}}' should not be injected from a different module. Repositories should only be used within their own module.",
     },
   },
 
   create(context) {
+    const repositoryImports = new Map<string, string>();
+    const currentFilePath = context.getFilename();
+    let hasModuleDecorator = false;
+
     return {
+      Program(node) {
+        repositoryImports.clear();
+        hasModuleDecorator = false;
+
+        const hasModule = (astNode: TSESTree.Node): boolean => {
+          if (
+            astNode.type === AST_NODE_TYPES.Decorator &&
+            astNode.expression.type === AST_NODE_TYPES.CallExpression &&
+            astNode.expression.callee.type === AST_NODE_TYPES.Identifier &&
+            astNode.expression.callee.name === "Module"
+          ) {
+            return true;
+          }
+
+          if ("body" in astNode && Array.isArray(astNode.body)) {
+            return astNode.body.some(hasModule);
+          }
+
+          if ("decorators" in astNode && Array.isArray(astNode.decorators)) {
+            return astNode.decorators.some(hasModule);
+          }
+
+          return false;
+        };
+
+        hasModuleDecorator = hasModule(node);
+      },
+
       Decorator(node) {
         if (
           node.expression.type === AST_NODE_TYPES.CallExpression &&
@@ -33,31 +230,59 @@ const rule = createRule({
         ) {
           const moduleConfig = node.expression.arguments[0];
           if (moduleConfig?.type === AST_NODE_TYPES.ObjectExpression) {
-            const exportsProperty = moduleConfig.properties.find(
-              (property): property is TSESTree.Property =>
-                property.type === AST_NODE_TYPES.Property &&
-                property.key.type === AST_NODE_TYPES.Identifier &&
-                property.key.name === "exports",
-            );
-
-            if (
-              exportsProperty?.type === AST_NODE_TYPES.Property &&
-              exportsProperty.value.type === AST_NODE_TYPES.ArrayExpression
-            ) {
-              exportsProperty.value.elements.forEach((element) => {
-                if (
-                  element?.type === AST_NODE_TYPES.Identifier &&
-                  isRepositoryClass(element.name)
-                ) {
-                  context.report({
-                    node: element,
-                    messageId: "moduleExportsRepository",
-                    data: { repositoryName: element.name },
-                  });
-                }
-              });
-            }
+            checkModuleExports(moduleConfig, context);
           }
+        }
+
+        if (
+          node.expression.type === AST_NODE_TYPES.CallExpression &&
+          node.expression.callee.type === AST_NODE_TYPES.Identifier &&
+          node.expression.callee.name === "Inject" &&
+          !hasModuleDecorator
+        ) {
+          checkInjectDecorator(node, repositoryImports, currentFilePath, context);
+        }
+      },
+
+      ImportDeclaration(node) {
+        const importPath = node.source.value;
+        if (isRepositoryImportPath(importPath)) {
+          node.specifiers.forEach((spec) => {
+            if (
+              spec.type === AST_NODE_TYPES.ImportSpecifier &&
+              spec.imported.type === AST_NODE_TYPES.Identifier &&
+              isRepositoryClass(spec.imported.name)
+            ) {
+              repositoryImports.set(spec.local.name, importPath);
+
+              if (!hasModuleDecorator && isCrossModuleImport(currentFilePath, importPath)) {
+                context.report({
+                  node: spec,
+                  messageId: "crossModuleRepositoryImport",
+                  data: {
+                    repositoryName: spec.imported.name,
+                    importPath,
+                  },
+                });
+              }
+            }
+          });
+        }
+      },
+
+      MethodDefinition(node) {
+        if (
+          node.kind === "constructor" &&
+          node.value.type === AST_NODE_TYPES.FunctionExpression &&
+          !hasModuleDecorator
+        ) {
+          node.value.params.forEach((parameter_) => {
+            if (parameter_.type === AST_NODE_TYPES.TSParameterProperty) {
+              checkTSParameterProperty(parameter_, repositoryImports, currentFilePath, context);
+            } else if (parameter_.type === AST_NODE_TYPES.Identifier) {
+              checkRegularParameter(parameter_, repositoryImports, currentFilePath, context);
+            }
+          });
         }
       },
     };

--- a/packages/eslint-plugin/src/lib/rules/no-cross-module-repository-usage/index.ts
+++ b/packages/eslint-plugin/src/lib/rules/no-cross-module-repository-usage/index.ts
@@ -2,19 +2,16 @@
  * @fileoverview Rule to prevent cross-module repository usage in NestJS applications
  */
 import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
-import type { RuleContext } from "@typescript-eslint/utils/ts-eslint";
 
 import createRule from "../../createRule";
 
 const isRepositoryClass = (name: string): boolean =>
-  name.endsWith("Repository") || name.includes("Repo");
+  name.endsWith("Repository") || name.endsWith("Repo");
 
-const isRepositoryFile = (filePath: string): boolean =>
-  filePath.endsWith(".repo.ts") || filePath.endsWith(".repository.ts");
 
 const checkModuleExports = (
   moduleConfig: TSESTree.ObjectExpression,
-  context: RuleContext<string, readonly unknown[]>,
+  context: any,
 ) => {
   const exportsProperty = moduleConfig.properties.find(
     (property): property is TSESTree.Property =>
@@ -39,51 +36,6 @@ const checkModuleExports = (
   }
 };
 
-const checkInjectDecorator = (
-  node: TSESTree.Decorator,
-  repositoryImports: Map<string, string>,
-  context: RuleContext<string, readonly unknown[]>,
-) => {
-  if (node.expression.type === AST_NODE_TYPES.CallExpression) {
-    const injectArgument = node.expression.arguments[0];
-    if (
-      injectArgument?.type === AST_NODE_TYPES.Identifier &&
-      isRepositoryClass(injectArgument.name) &&
-      repositoryImports.has(injectArgument.name)
-    ) {
-      context.report({
-        node: injectArgument,
-        messageId: "crossModuleRepositoryInjection",
-        data: { repositoryName: injectArgument.name },
-      });
-    }
-  }
-};
-
-const checkConstructorParameter = (
-  parameter_: TSESTree.Parameter,
-  repositoryImports: Map<string, string>,
-  context: RuleContext<string, readonly unknown[]>,
-) => {
-  if (parameter_.type === AST_NODE_TYPES.TSParameterProperty) {
-    const { parameter } = parameter_;
-    if (
-      parameter.type === AST_NODE_TYPES.Identifier &&
-      parameter.typeAnnotation?.type === AST_NODE_TYPES.TSTypeAnnotation &&
-      parameter.typeAnnotation.typeAnnotation.type === AST_NODE_TYPES.TSTypeReference &&
-      parameter.typeAnnotation.typeAnnotation.typeName.type === AST_NODE_TYPES.Identifier
-    ) {
-      const typeName = parameter.typeAnnotation.typeAnnotation.typeName.name;
-      if (isRepositoryClass(typeName) && repositoryImports.has(typeName)) {
-        context.report({
-          node: parameter,
-          messageId: "crossModuleRepositoryInjection",
-          data: { repositoryName: typeName },
-        });
-      }
-    }
-  }
-};
 
 const rule = createRule({
   name: "no-cross-module-repository-usage",
@@ -97,72 +49,21 @@ const rule = createRule({
     messages: {
       moduleExportsRepository:
         "NestJS modules should not export repository classes. Repository '{{repositoryName}}' should not be exported from module.",
-      crossModuleRepositoryImport:
-        "Repository '{{repositoryName}}' from '{{importPath}}' should not be imported from a different module. Repositories should only be used within their own module.",
-      crossModuleRepositoryInjection:
-        "Repository '{{repositoryName}}' should not be injected from a different module. Repositories should only be used within their own module.",
     },
   },
 
   create(context) {
-    const repositoryImports = new Map<string, string>(); // name -> import path
-    let isModuleFile = false;
-
     return {
       Decorator(node) {
         if (
           node.expression.type === AST_NODE_TYPES.CallExpression &&
-          node.expression.callee.type === AST_NODE_TYPES.Identifier
+          node.expression.callee.type === AST_NODE_TYPES.Identifier &&
+          node.expression.callee.name === "Module"
         ) {
-          if (node.expression.callee.name === "Module") {
-            isModuleFile = true;
-            const moduleConfig = node.expression.arguments[0];
-            if (moduleConfig?.type === AST_NODE_TYPES.ObjectExpression) {
-              checkModuleExports(moduleConfig, context);
-            }
+          const moduleConfig = node.expression.arguments[0];
+          if (moduleConfig?.type === AST_NODE_TYPES.ObjectExpression) {
+            checkModuleExports(moduleConfig, context);
           }
-
-          if (node.expression.callee.name === "Inject" && !isModuleFile) {
-            checkInjectDecorator(node, repositoryImports, context);
-          }
-        }
-      },
-
-      ImportDeclaration(node) {
-        const importPath = node.source.value;
-        if (isRepositoryFile(importPath) || importPath.includes("repository")) {
-          node.specifiers.forEach((spec) => {
-            if (
-              spec.type === AST_NODE_TYPES.ImportSpecifier &&
-              spec.imported.type === AST_NODE_TYPES.Identifier &&
-              isRepositoryClass(spec.imported.name)
-            ) {
-              repositoryImports.set(spec.local.name, importPath);
-
-              if (!isModuleFile) {
-                context.report({
-                  node: spec,
-                  messageId: "crossModuleRepositoryImport",
-                  data: {
-                    repositoryName: spec.imported.name,
-                    importPath,
-                  },
-                });
-              }
-            }
-          });
-        }
-      },
-
-      MethodDefinition(node) {
-        if (
-          node.kind === "constructor" &&
-          node.value.type === AST_NODE_TYPES.FunctionExpression &&
-          !isModuleFile
-        ) {
-          node.value.params.forEach((parameter_) => {
-            checkConstructorParameter(parameter_, repositoryImports, context);
-          });
         }
       },
     };


### PR DESCRIPTION
# Add no-cross-module-repository-usage ESLint rule

## Summary

Implements a custom ESLint rule to prevent cross-module repository usage in NestJS applications as requested in Linear issue FOR-1074. The rule enforces two main requirements:
1. NestJS modules should not export repository classes in their `exports` array
2. Classes should not import or inject repository classes from different modules

## Review & Testing Checklist for Human

**⚠️ 3 critical items to verify:**

- [ ] **Test the rule against real NestJS code** - Apply the rule to `clipboard-health` repository and verify it correctly identifies violations without false positives. The implementation has not been tested against actual repository patterns yet.
- [ ] **Validate repository detection logic** - Verify that the patterns for identifying repository classes (names ending in "Repository"/"Repo" and files ending in ".repository.ts"/".repo.ts") correctly match your actual repository naming conventions.
- [ ] **Check module boundary detection** - The rule determines "same module" vs "cross module" by checking if files contain `@Module` decorators. Verify this logic aligns with your actual module structure and doesn't miss edge cases.

### Recommended Test Plan
1. Apply the rule to clipboard-health repository temporarily
2. Check for false positives in legitimate same-module repository usage
3. Verify it catches the cross-module violations mentioned in FOR-1074
4. Test edge cases like repositories used in tests, dynamic imports, etc.

### Notes
- **Link to Devin run**: https://app.devin.ai/sessions/a429e96f47fb41a980fe29ca65f0a107
- **Requested by**: @AmanL04 (aman.lodha@clipboardhealth.com)
- Rule follows existing patterns from `enforce-ts-rest-in-controllers`
- All existing tests pass and linting is clean
- The AST parsing logic is complex but necessary for accurate detection
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds the no-cross-module-repository-usage ESLint rule to enforce NestJS module boundaries per FOR-1074. It blocks exporting repositories from modules and using repositories across modules.

- **New Features**
  - Flags repository exports in @Module.exports.
  - Flags cross-module repository imports and injections (constructor params and @Inject).
  - Detects repositories by class names ending in Repository/Repo and files ending in .repository.ts/.repo.ts.
  - Enabled as error for .module.ts, .service.ts, .repository.ts, and .repo.ts.
  - Exported in eslint-plugin and documented.

- **Migration**
  - Remove repository classes from module exports; export services instead.
  - Avoid importing/injecting repositories across modules; expose services for cross-module access.

<!-- End of auto-generated description by cubic. -->

