### PR TITLE
fix: move internal deps to peers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Architecture
+
+This is an Nx monorepo containing TypeScript libraries and utilities for Clipboard Health. The codebase follows functional programming patterns with strict TypeScript and emphasizes type safety, immutability, and pure functions.
+
+### Key Libraries
+
+- **util-ts**: Core TypeScript utilities including `ServiceResult` (Either type), `ServiceError`, functional utilities (`pipe`, `option`, `either`)
+- **json-api**: TypeScript utilities for JSON:API specification compliance
+- **json-api-nestjs**: JSON:API utilities specifically for NestJS applications
+- **config**: Type-safe configuration management with Zod validation
+- **rules-engine**: Pure functional rules engine for business logic
+- **testing-core**: Testing utilities and helpers
+- **nx-plugin**: Custom Nx generators for project management
+
+### Code Conventions
+
+- Use `function` keyword instead of `const` for function declarations
+- Avoid the `any` type
+- Prefer interfaces over types
+- Avoid enums; use const maps instead
+- Use camelCase for files and directories
+- Favor `@clipboard-health/util-ts`'s `Either` type (`ServiceResult`) over try/catch for expected errors
+- Structure files: constants, types, exported functions, non-exported functions
+- Use descriptive variable names with auxiliary verbs (isLoading, hasError)
+
+## Commands
+
+### Development
+
+```bash
+# Install dependencies
+npm install
+
+# Build, lint, and test only changed files from main
+npm run affected
+
+# Build, lint, and test everything
+npm run all
+
+# Format code
+npm run format
+
+# Check formatting, spelling, and run embedex
+npm run ci:check
+```
+
+### Package-specific Commands
+
+```bash
+# Install dependency in specific package
+npm install --workspace packages/[PROJECT_NAME] [DEPENDENCY]
+
+# Run specific command against a package
+npx nx run [PROJECT_NAME]:[COMMAND]
+
+# Common targets: build, lint, test
+npx nx run json-api:build
+npx nx run util-ts:test
+
+# For test coverage, run with the "ci" configuration
+npx nx run util-ts:test:ci
+```
+
+### Testing
+
+- Tests use Jest configuration per package
+- Follow Arrange-Act-Assert convention with newlines between sections
+- Use `mockX`, `input`, `expected`, `actual` naming convention
+
+## Project Structure
+
+Each package in `packages/` has:
+
+- `project.json`: Nx project configuration with build/lint/test targets
+- `src/index.ts`: Main export file
+- `README.md`: Package-specific documentation with usage examples
+- Individual `tsconfig.lib.json`, `jest.config.ts`, etc.
+
+## Development Notes
+
+- The repo uses conventional commits with automated releases
+- All packages follow JSON:API specification where applicable
+- NestJS applications use three-tier architecture (controllers → services → repos)
+- ts-rest contracts define API schemas using Zod
+- Code must pass lint, typecheck, and tests before commits
+- Use `npm run affected` before opening PRs to verify changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -22915,10 +22915,12 @@
       "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
-        "@clipboard-health/phone-number": "0.2.1",
-        "@clipboard-health/util-ts": "3.12.1",
         "@segment/analytics-node": "2.3.0",
         "tslib": "2.8.1"
+      },
+      "peerDependencies": {
+        "@clipboard-health/phone-number": "^0.2.0",
+        "@clipboard-health/util-ts": "^3.0.0"
       }
     },
     "packages/config": {
@@ -22926,7 +22928,6 @@
       "version": "0.19.1",
       "license": "MIT",
       "dependencies": {
-        "@clipboard-health/util-ts": "3.12.1",
         "decamelize": "5.0.1",
         "dotenv": "17.2.2",
         "tslib": "2.8.1"
@@ -22936,6 +22937,7 @@
         "zod": "3.25.76"
       },
       "peerDependencies": {
+        "@clipboard-health/util-ts": "^3.0.0",
         "zod": "^3"
       }
     },
@@ -23317,7 +23319,6 @@
       "version": "0.24.1",
       "license": "MIT",
       "dependencies": {
-        "@clipboard-health/contract-core": "0.22.1",
         "tslib": "2.8.1"
       },
       "devDependencies": {
@@ -23326,6 +23327,7 @@
         "zod": "3.25.76"
       },
       "peerDependencies": {
+        "@clipboard-health/contract-core": "^0.22.0",
         "type-fest": "^4 || ^5.0.0",
         "zod": "^3"
       }
@@ -23367,13 +23369,15 @@
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@clipboard-health/phone-number": "0.2.1",
-        "@clipboard-health/util-ts": "3.12.1",
         "@knocklabs/node": "1.16.0",
         "tslib": "2.8.1"
       },
       "devDependencies": {
         "@clipboard-health/testing-core": "0.21.1"
+      },
+      "peerDependencies": {
+        "@clipboard-health/phone-number": "^0.2.0",
+        "@clipboard-health/util-ts": "^3.0.0"
       }
     },
     "packages/nx-plugin": {
@@ -23393,7 +23397,6 @@
       "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "@clipboard-health/util-ts": "3.12.1",
         "tslib": "2.8.1"
       },
       "devDependencies": {
@@ -23401,6 +23404,7 @@
         "libphonenumber-js": "1.12.17"
       },
       "peerDependencies": {
+        "@clipboard-health/util-ts": "^3.0.0",
         "libphonenumber-js": "^1.12"
       }
     },
@@ -23439,13 +23443,13 @@
       "version": "0.21.1",
       "license": "MIT",
       "dependencies": {
-        "@clipboard-health/util-ts": "3.12.1",
         "tslib": "2.8.1"
       },
       "devDependencies": {
         "zod": "3.25.76"
       },
       "peerDependencies": {
+        "@clipboard-health/util-ts": "^3.0.0",
         "zod": "^3"
       }
     },

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -4,14 +4,16 @@
   "version": "0.4.1",
   "bugs": "https://github.com/ClipboardHealth/core-utils/issues",
   "dependencies": {
-    "@clipboard-health/phone-number": "0.2.1",
-    "@clipboard-health/util-ts": "3.12.1",
     "@segment/analytics-node": "2.3.0",
     "tslib": "2.8.1"
   },
   "keywords": [],
   "license": "MIT",
   "main": "./src/index.js",
+  "peerDependencies": {
+    "@clipboard-health/phone-number": "^0.2.0",
+    "@clipboard-health/util-ts": "^3.0.0"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -4,7 +4,6 @@
   "version": "0.19.1",
   "bugs": "https://github.com/ClipboardHealth/core-utils/issues",
   "dependencies": {
-    "@clipboard-health/util-ts": "3.12.1",
     "decamelize": "5.0.1",
     "dotenv": "17.2.2",
     "tslib": "2.8.1"
@@ -21,6 +20,7 @@
   "license": "MIT",
   "main": "./src/index.js",
   "peerDependencies": {
+    "@clipboard-health/util-ts": "^3.0.0",
     "zod": "^3"
   },
   "publishConfig": {

--- a/packages/json-api-nestjs/package.json
+++ b/packages/json-api-nestjs/package.json
@@ -4,7 +4,6 @@
   "version": "0.24.1",
   "bugs": "https://github.com/ClipboardHealth/core-utils/issues",
   "dependencies": {
-    "@clipboard-health/contract-core": "0.22.1",
     "tslib": "2.8.1"
   },
   "devDependencies": {
@@ -24,6 +23,7 @@
   "license": "MIT",
   "main": "./src/index.js",
   "peerDependencies": {
+    "@clipboard-health/contract-core": "^0.22.0",
     "type-fest": "^4 || ^5.0.0",
     "zod": "^3"
   },

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -4,8 +4,6 @@
   "version": "0.2.0",
   "bugs": "https://github.com/ClipboardHealth/core-utils/issues",
   "dependencies": {
-    "@clipboard-health/phone-number": "0.2.1",
-    "@clipboard-health/util-ts": "3.12.1",
     "@knocklabs/node": "1.16.0",
     "tslib": "2.8.1"
   },
@@ -15,6 +13,10 @@
   "keywords": [],
   "license": "MIT",
   "main": "./src/index.js",
+  "peerDependencies": {
+    "@clipboard-health/phone-number": "^0.2.0",
+    "@clipboard-health/util-ts": "^3.0.0"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/phone-number/package.json
+++ b/packages/phone-number/package.json
@@ -4,7 +4,6 @@
   "version": "0.2.1",
   "bugs": "https://github.com/ClipboardHealth/core-utils/issues",
   "dependencies": {
-    "@clipboard-health/util-ts": "3.12.1",
     "tslib": "2.8.1"
   },
   "devDependencies": {
@@ -15,6 +14,7 @@
   "license": "MIT",
   "main": "./src/index.js",
   "peerDependencies": {
+    "@clipboard-health/util-ts": "^3.0.0",
     "libphonenumber-js": "^1.12"
   },
   "publishConfig": {

--- a/packages/testing-core/package.json
+++ b/packages/testing-core/package.json
@@ -4,7 +4,6 @@
   "version": "0.21.1",
   "bugs": "https://github.com/ClipboardHealth/core-utils/issues",
   "dependencies": {
-    "@clipboard-health/util-ts": "3.12.1",
     "tslib": "2.8.1"
   },
   "devDependencies": {
@@ -18,6 +17,7 @@
   "license": "MIT",
   "main": "./src/index.js",
   "peerDependencies": {
+    "@clipboard-health/util-ts": "^3.0.0",
     "zod": "^3"
   },
   "publishConfig": {


### PR DESCRIPTION
Summary
===
Move `@clipboard-health/*` dependencies to `peerDependencies` to avoid microservices from having to update multiple packages so all of the versions match.