### PR TITLE
feat: allow providing custom properties for notification users

### DIFF
--- a/packages/notifications/src/lib/internal/toKnockBody.spec.ts
+++ b/packages/notifications/src/lib/internal/toKnockBody.spec.ts
@@ -42,13 +42,16 @@ describe("toKnockBody", () => {
 
   it("handles mixed recipient types", () => {
     const input: TriggerBody = {
-      recipients: ["user-1", { userId: "user-2", email: "test@example.com" }],
+      recipients: [
+        "user-1",
+        { userId: "user-2", email: "test@example.com", customProperties: { stage: "ENROLLED" } },
+      ],
     };
 
     const result = toKnockBody(input);
 
     expect(result).toEqual({
-      recipients: ["user-1", { id: "user-2", email: "test@example.com" }],
+      recipients: ["user-1", { id: "user-2", email: "test@example.com", stage: "ENROLLED" }],
     });
   });
 });

--- a/packages/notifications/src/lib/internal/toKnockBody.ts
+++ b/packages/notifications/src/lib/internal/toKnockBody.ts
@@ -26,9 +26,20 @@ function toKnockRecipient(recipient: RecipientRequest): Knock.Recipients.Recipie
 function toKnockInlineIdentifyUserRequest(
   recipient: InlineIdentifyUserRequest,
 ): Knock.Users.InlineIdentifyUserRequest {
-  const { channelData, createdAt, email, name, phoneNumber, timeZone, userId, ...rest } = recipient;
+  const {
+    channelData,
+    createdAt,
+    email,
+    name,
+    phoneNumber,
+    timeZone,
+    userId,
+    customProperties,
+    ...rest
+  } = recipient;
 
   return {
+    ...customProperties,
     id: userId,
     ...(channelData ? { channel_data: channelData } : {}),
     ...(createdAt ? { created_at: createdAt.toISOString() } : {}),

--- a/packages/notifications/src/lib/types.ts
+++ b/packages/notifications/src/lib/types.ts
@@ -98,6 +98,11 @@ export interface InlineIdentifyUserRequest {
    * scheduled notifications.
    */
   timeZone?: string | undefined;
+
+  /**
+   * Custom user properties.
+   */
+  customProperties?: Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
Summary
===
Allow providing custom properties for notification users.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Allow inline identify recipients to include custom user properties in notification triggers. This enables sending fields like stage to Knock for personalization.

- **New Features**
  - Added customProperties to InlineIdentifyUserRequest.
  - Mapped customProperties into the Knock InlineIdentifyUserRequest payload.
  - Updated tests to cover mixed recipients with custom properties.

<!-- End of auto-generated description by cubic. -->

