### PR TITLE
fix(INV-2217): define money schema in contract-core over cbh-core/money

### DIFF
--- a/packages/contract-core/src/lib/schemas/index.ts
+++ b/packages/contract-core/src/lib/schemas/index.ts
@@ -1,5 +1,6 @@
 export * from "./apiError";
 export * from "./booleanString";
+export * from "./money";
 export * from "./nonEmptyString";
 export * from "./objectId";
 export * from "./uuid";

--- a/packages/contract-core/src/lib/schemas/money.spec.ts
+++ b/packages/contract-core/src/lib/schemas/money.spec.ts
@@ -1,0 +1,34 @@
+import { type ZodError } from "zod";
+
+import { money } from "./money";
+
+describe("money schema", () => {
+  it("validates the data", () => {
+    let issues: unknown = [];
+    try {
+      money.parse({
+        amount: 100,
+        currencyCode: "EUR",
+      });
+    } catch (error: unknown) {
+      const zodError = error as ZodError;
+      issues = zodError.errors;
+    }
+
+    expect(issues).toMatchObject([
+      {
+        path: ["amountInMinorUnits"],
+        code: "invalid_type",
+        message: "Required",
+        expected: "number",
+        received: "undefined",
+      },
+      {
+        path: ["currencyCode"],
+        code: "invalid_enum_value",
+        message: "Invalid enum value. Expected 'USD', received 'EUR'",
+        received: "EUR",
+      },
+    ]);
+  });
+});

--- a/packages/contract-core/src/lib/schemas/money.ts
+++ b/packages/contract-core/src/lib/schemas/money.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+/**
+ * Currency code that follows the ISO 4217 standard.
+ */
+export const currencyCode = z.enum(["USD"]);
+
+export const money = z.object({
+  amountInMinorUnits: z.number().int(),
+  currencyCode,
+});


### PR DESCRIPTION
Summary
===
<!--
- For expectations after PR approval and merge, see the CONTRIBUTING.md file
-->

Move `moneySchema` from `@clipboard-health/money` to `money` in `contract-core` to disentangle the pure zod schema from BigInt support

Changes
---
- Add money schema

Videos/screenshots
---

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Defines a pure Zod money schema in contract-core and exports it, removing the dependency on @clipboard-health/money’s BigInt-based implementation. Addresses INV-2217 by separating the schema from BigInt support.

- **New Features**
  - Added money schema with amountInMinorUnits (int number) and currencyCode (enum, currently USD only).
  - Exported the schema from the contract-core schemas index.
  - Added tests that confirm errors for missing amountInMinorUnits and unsupported currency codes.

<!-- End of auto-generated description by cubic. -->

