### PR TITLE
chore(eslint-config): disable max-params rule

### DIFF
--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -241,6 +241,11 @@ module.exports = {
     // `no-return-await` states "This can make debugging more difficult."
     "no-return-await": "off",
 
+    // While a good recommendation, this is frequently disabled in constructors due to
+    // NestJS dependency injection. Since we can't disable it specifically for constructors,
+    // it causes more friction than value.
+    "max-params": "off",
+
     // False positive on `enum`s
     "no-shadow": "off",
 

--- a/packages/eslint-config/src/index.spec.ts
+++ b/packages/eslint-config/src/index.spec.ts
@@ -199,6 +199,11 @@ const duplicatedConfig = {
     // `no-return-await` states "This can make debugging more difficult."
     "no-return-await": "off",
 
+    // While a good recommendation, this is frequently disabled in constructors due to
+    // NestJS dependency injection. Since we can't disable it specifically for constructors,
+    // it causes more friction than value.
+    "max-params": "off",
+
     // False positive on `enum`s
     "no-shadow": "off",
 


### PR DESCRIPTION
## Summary

Disable the `max-params` ESLint rule to reduce friction with NestJS dependency injection patterns.

## Why

- The `max-params` rule is frequently violated in NestJS constructors due to dependency injection patterns
- ESLint cannot selectively disable rules for constructors only
- Teams end up adding many `eslint-disable` comments, which creates more friction than the rule provides value
- While generally a good recommendation, the inability to target specific contexts makes it impractical for NestJS codebases

## What

- Disable `max-params` rule in shared ESLint configuration
- Add inline comment explaining the reasoning for disabling this rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)