### PR TITLE
feat: add figma-to-code skill

### DIFF
--- a/plugins/core/skills/figma-to-code/SKILL.md
+++ b/plugins/core/skills/figma-to-code/SKILL.md
@@ -13,6 +13,7 @@ You are implementing a UI from a Figma design in the CBH Admin Frontend codebase
 Extract `fileKey` and `nodeId` from the Figma URL and call `mcp__claude_ai_Figma__get_design_context`.
 
 URL patterns:
+
 - `figma.com/design/:fileKey/:fileName?node-id=:nodeId` → convert `-` to `:` in nodeId
 - `figma.com/design/:fileKey/branch/:branchKey/:fileName` → use branchKey as fileKey
 
@@ -23,6 +24,7 @@ Always include `clientFrameworks: "react"` and `clientLanguages: "typescript"`.
 The Figma MCP returns React+Tailwind reference code. **NEVER use Tailwind.** This output is a reference only.
 
 Before writing any code:
+
 1. Read the screenshot returned by the MCP carefully
 2. **Ignore hidden elements** — Figma nodes with `visible: false` or `opacity: 0` are design-time helpers (e.g., bounding boxes, redline guides, hidden variants). Do NOT implement them.
 3. Read any `data-annotations` attributes — they contain implementation hints (e.g., menu items, behaviors)
@@ -36,31 +38,32 @@ Before writing any code:
 
 ### Component Mapping
 
-| Figma Element | Codebase Component | Import Path |
-|---|---|---|
-| Button (any variant) | `<Button>` | `redesign/components/Button` |
-| Icon-only button | `<IconButton>` | `redesign/components/IconButton` |
-| Icon | `<Icon>` | `redesign/components/Icon` |
-| Avatar / profile image | `<Avatar>` | `redesign/components/Avatar` |
-| Text / label | `<Text>` | `redesign/components/Text` |
-| Heading | `<Title>` | `redesign/components/Title` |
-| Chip / filter pill | `<Chip>` | `redesign/components/Chip` |
-| Tag / status badge | `<Tag>` | `redesign/components/Tag` |
-| Pill | `<Pill>` | `redesign/components/Pill` |
-| Input field | `<TextInput>` | `redesign/components/TextInput` |
-| Checkbox | `<Checkbox>` | `redesign/components/Checkbox` |
-| Tabs | `<Tabs>` + `<Tab>` | `redesign/components/Tabs` |
-| Modal/dialog (desktop) | `<Dialog>` | `redesign/components/Dialog` |
+| Figma Element             | Codebase Component   | Import Path                            |
+| ------------------------- | -------------------- | -------------------------------------- |
+| Button (any variant)      | `<Button>`           | `redesign/components/Button`           |
+| Icon-only button          | `<IconButton>`       | `redesign/components/IconButton`       |
+| Icon                      | `<Icon>`             | `redesign/components/Icon`             |
+| Avatar / profile image    | `<Avatar>`           | `redesign/components/Avatar`           |
+| Text / label              | `<Text>`             | `redesign/components/Text`             |
+| Heading                   | `<Title>`            | `redesign/components/Title`            |
+| Chip / filter pill        | `<Chip>`             | `redesign/components/Chip`             |
+| Tag / status badge        | `<Tag>`              | `redesign/components/Tag`              |
+| Pill                      | `<Pill>`             | `redesign/components/Pill`             |
+| Input field               | `<TextInput>`        | `redesign/components/TextInput`        |
+| Checkbox                  | `<Checkbox>`         | `redesign/components/Checkbox`         |
+| Tabs                      | `<Tabs>` + `<Tab>`   | `redesign/components/Tabs`             |
+| Modal/dialog (desktop)    | `<Dialog>`           | `redesign/components/Dialog`           |
 | Modal/dialog (responsive) | `<ResponsiveDialog>` | `redesign/components/ResponsiveDialog` |
-| Bottom sheet (mobile) | `<BottomSheet>` | `redesign/components/BottomSheet` |
-| Side panel | `<SidePanel>` | `redesign/components/SidePanel` |
-| Drawer (full-height) | `<Drawer>` | `redesign/components/Drawer` |
-| Divider line | `<Divider>` | `redesign/components/Divider` |
-| Loading spinner | `<Loader>` | `redesign/components/Loader` |
-| Notification dot | `<Badge>` | `redesign/components/Badge` |
-| Data table | `<DataGrid>` | `redesign/components/DataGrid` |
+| Bottom sheet (mobile)     | `<BottomSheet>`      | `redesign/components/BottomSheet`      |
+| Side panel                | `<SidePanel>`        | `redesign/components/SidePanel`        |
+| Drawer (full-height)      | `<Drawer>`           | `redesign/components/Drawer`           |
+| Divider line              | `<Divider>`          | `redesign/components/Divider`          |
+| Loading spinner           | `<Loader>`           | `redesign/components/Loader`           |
+| Notification dot          | `<Badge>`            | `redesign/components/Badge`            |
+| Data table                | `<DataGrid>`         | `redesign/components/DataGrid`         |
 
 ### Button Variants
+
 - Figma solid blue button → `variant="primary"`
 - Figma dark/black button → `variant="secondary"`
 - Figma outlined button → `variant="outlined"`
@@ -70,15 +73,19 @@ Before writing any code:
 - Figma ghost/no-border button → `variant="muted"`
 
 ### Button Sizes
+
 - Figma small (24px height) → `size="small"`
 - Figma medium (38px height) → `size="medium"`
 - Figma large (54px height) → `size="large"`
 
 ### Button with icon
+
 Use `startIconType` or `endIconType` prop with the icon name from the Icon type registry.
 
 ### Icon Names
+
 Before using an icon, verify it exists in `src/appV2/redesign/components/Icon.types.tsx`. Search for the closest match. Common mappings:
+
 - Chain link / hyperlink icon → `"hyperlink"`
 - Key / credential icon → `"key-outline"`
 - Three dots horizontal → `"ellipsis"`
@@ -110,6 +117,7 @@ Before using an icon, verify it exists in `src/appV2/redesign/components/Icon.ty
 - Cogwheel / settings → `"cogwheel"`
 
 ### Text Variants
+
 - Figma 24px → `variant="h5"` (x-large)
 - Figma 18px → `variant="h6"` (large)
 - Figma 16px → `variant="body1"` (normal, default)
@@ -236,10 +244,10 @@ Before using an icon, verify it exists in `src/appV2/redesign/components/Icon.ty
 
 ## Step 7: Breakpoints
 
-| Name | Width | Hook |
-|---|---|---|
-| Mobile | < 640px (md) | `useIsMobile()` |
-| Tablet | < 1024px (lg) | `useIsTablet()` |
+| Name    | Width          | Hook             |
+| ------- | -------------- | ---------------- |
+| Mobile  | < 640px (md)   | `useIsMobile()`  |
+| Tablet  | < 1024px (lg)  | `useIsTablet()`  |
 | Desktop | >= 1024px (lg) | `useIsDesktop()` |
 
 Mobile renders BottomSheet for overlays. Desktop renders SidePanel/Dialog.
@@ -247,6 +255,7 @@ Mobile renders BottomSheet for overlays. Desktop renders SidePanel/Dialog.
 ## Step 8: Implementation Checklist
 
 Before writing code, confirm:
+
 - [ ] Fetched Figma design context with screenshot
 - [ ] Identified ALL existing components to reuse
 - [ ] Mapped ALL Figma tokens to theme tokens
@@ -255,6 +264,7 @@ Before writing code, confirm:
 - [ ] Identified responsive differences (mobile vs desktop)
 
 After writing code, verify:
+
 - [ ] No hardcoded colors (grep for `#`, `rgb`, `rgba` in new code)
 - [ ] No JSX local variables — only inline JSX or extracted components
 - [ ] No Tailwind classes

--- a/plugins/core/skills/figma-to-code/SKILL.md
+++ b/plugins/core/skills/figma-to-code/SKILL.md
@@ -1,122 +1,276 @@
 ---
 name: figma-to-code
-description: "Implement UI from a Figma design. Use when the user shares a Figma URL, asks to implement a design, or says things like 'build this from Figma', 'match this design', 'implement this Figma', or 'figma to code'."
+description: "Implement UI from a Figma design in the CBH Admin Frontend. Use when the user shares a Figma URL, asks to implement a design, or says things like 'build this from Figma', 'match this design', 'implement this Figma', or 'figma to code'."
 argument-hint: "<figma-url>"
 ---
 
-# Figma to Code
+# Figma to Code: CBH Admin Frontend
 
-Fetch a Figma design, map it to the project's existing components and theme tokens, and produce production-ready code that matches the design.
-
-## Arguments
-
-- `$ARGUMENTS` - Figma URL (e.g., `https://www.figma.com/design/:fileKey/:fileName?node-id=:nodeId`). Required.
+You are implementing a UI from a Figma design in the CBH Admin Frontend codebase. The user will provide a Figma URL (and optionally a screenshot). Your job is to fetch the design, map it to existing components and theme tokens, and produce production-ready code.
 
 ## Step 1: Fetch the Design
 
-Extract `fileKey` and `nodeId` from the Figma URL:
-- `figma.com/design/:fileKey/:fileName?node-id=:int1-:int2` → nodeId = `int1:int2` (convert `-` to `:`)
+Extract `fileKey` and `nodeId` from the Figma URL and call `mcp__claude_ai_Figma__get_design_context`.
+
+URL patterns:
+- `figma.com/design/:fileKey/:fileName?node-id=:nodeId` → convert `-` to `:` in nodeId
 - `figma.com/design/:fileKey/branch/:branchKey/:fileName` → use branchKey as fileKey
 
-Call `mcp__claude_ai_Figma__get_design_context` with:
-- `fileKey` and `nodeId` from the URL
-- `clientFrameworks`: detect from the project (e.g., "react", "vue", "angular")
-- `clientLanguages`: detect from the project (e.g., "typescript", "javascript")
+Always include `clientFrameworks: "react"` and `clientLanguages: "typescript"`.
 
 ## Step 2: Interpret the Design (DO NOT generate code yet)
 
-The Figma MCP returns **reference code** (typically React+Tailwind) plus a screenshot. This is a starting point, NOT final code.
+The Figma MCP returns React+Tailwind reference code. **NEVER use Tailwind.** This output is a reference only.
 
 Before writing any code:
+1. Read the screenshot returned by the MCP carefully
+2. **Ignore hidden elements** — Figma nodes with `visible: false` or `opacity: 0` are design-time helpers (e.g., bounding boxes, redline guides, hidden variants). Do NOT implement them.
+3. Read any `data-annotations` attributes — they contain implementation hints (e.g., menu items, behaviors)
+4. Identify which existing redesign components match each Figma element
+5. Map all Figma design tokens (`--berlin/*`) to MUI theme tokens
+6. If the user provided a screenshot, compare it with the Figma screenshot — only implement what's visually present
 
-1. **Study the screenshot** — this is the source of truth for what to build
-2. **Ignore hidden elements** — Figma nodes with `visible: false` or `opacity: 0` are design-time helpers (bounding boxes, redline guides, hidden variants). Do NOT implement them.
-3. **Read `data-annotations`** — these contain implementation hints from designers (e.g., which menu items to show, interaction behaviors, conditional states)
-4. **Identify existing components** — search the project's component library for matches before creating anything new. Use Grep/Glob to find component files.
-5. **Map design tokens** — identify the project's theme/token system and map Figma's CSS variables to it
-6. **Compare screenshots** — if the user provided a screenshot alongside the URL, compare it with the Figma screenshot to understand what's currently implemented vs what needs to change
+## Step 3: Map to Existing Components
 
-## Step 3: Discover the Project's Design System
+**ALWAYS search the codebase first** for existing components before creating new ones. The redesign component library is in `src/appV2/redesign/components/`.
 
-Before implementing, understand the project's existing patterns:
+### Component Mapping
 
-### 3a: Find the Component Library
+| Figma Element | Codebase Component | Import Path |
+|---|---|---|
+| Button (any variant) | `<Button>` | `redesign/components/Button` |
+| Icon-only button | `<IconButton>` | `redesign/components/IconButton` |
+| Icon | `<Icon>` | `redesign/components/Icon` |
+| Avatar / profile image | `<Avatar>` | `redesign/components/Avatar` |
+| Text / label | `<Text>` | `redesign/components/Text` |
+| Heading | `<Title>` | `redesign/components/Title` |
+| Chip / filter pill | `<Chip>` | `redesign/components/Chip` |
+| Tag / status badge | `<Tag>` | `redesign/components/Tag` |
+| Pill | `<Pill>` | `redesign/components/Pill` |
+| Input field | `<TextInput>` | `redesign/components/TextInput` |
+| Checkbox | `<Checkbox>` | `redesign/components/Checkbox` |
+| Tabs | `<Tabs>` + `<Tab>` | `redesign/components/Tabs` |
+| Modal/dialog (desktop) | `<Dialog>` | `redesign/components/Dialog` |
+| Modal/dialog (responsive) | `<ResponsiveDialog>` | `redesign/components/ResponsiveDialog` |
+| Bottom sheet (mobile) | `<BottomSheet>` | `redesign/components/BottomSheet` |
+| Side panel | `<SidePanel>` | `redesign/components/SidePanel` |
+| Drawer (full-height) | `<Drawer>` | `redesign/components/Drawer` |
+| Divider line | `<Divider>` | `redesign/components/Divider` |
+| Loading spinner | `<Loader>` | `redesign/components/Loader` |
+| Notification dot | `<Badge>` | `redesign/components/Badge` |
+| Data table | `<DataGrid>` | `redesign/components/DataGrid` |
 
-```
-Search for: Button, IconButton, Icon, Avatar, Text, Dialog, Modal components
-Look in: src/**/components/, src/**/ui/, src/**/design-system/
-```
+### Button Variants
+- Figma solid blue button → `variant="primary"`
+- Figma dark/black button → `variant="secondary"`
+- Figma outlined button → `variant="outlined"`
+- Figma text button → `variant="link"`
+- Figma red button → `variant="danger"`
+- Figma orange button → `variant="warning"`
+- Figma ghost/no-border button → `variant="muted"`
 
-For each Figma element, find the matching project component. Prefer reusing existing components over creating new ones.
+### Button Sizes
+- Figma small (24px height) → `size="small"`
+- Figma medium (38px height) → `size="medium"`
+- Figma large (54px height) → `size="large"`
 
-### 3b: Find the Theme/Token System
+### Button with icon
+Use `startIconType` or `endIconType` prop with the icon name from the Icon type registry.
 
-```
-Search for: theme.ts, tokens.ts, variables.css, tailwind.config
-Look for: color palette, spacing scale, border radius, typography, shadows
-```
+### Icon Names
+Before using an icon, verify it exists in `src/appV2/redesign/components/Icon.types.tsx`. Search for the closest match. Common mappings:
+- Chain link / hyperlink icon → `"hyperlink"`
+- Key / credential icon → `"key-outline"`
+- Three dots horizontal → `"ellipsis"`
+- Three dots vertical → `"ellipsis-vertical"`
+- Chat bubble → `"message"`
+- File/document icon → `"documents"`
+- X / close → `"close"`
+- Star → `"star-five-sides"`
+- Block / stop → `"general-stop"`
+- Search → `"magnifying-glass"`
+- Plus → `"plus"`
+- Pencil / edit → `"pencil"`
+- Trash / delete → `"trash"`
+- Download → `"download"`
+- Arrow left → `"arrow-left"`
+- Arrow right → `"arrow-right"`
+- Chevron down → `"chevron-down"`
+- Chevron right → `"chevron-right"`
+- Calendar → `"calendar"`
+- Clock → `"clock"`
+- Filter → `"filter"`
+- Person → `"person-male"`
+- Building → `"building"`
+- Dollar → `"dollar"`
+- Information → `"information"`
+- Warning → `"warning"`
+- Bookmark → `"bookmark"`
+- Briefcase → `"briefcase"`
+- Cogwheel / settings → `"cogwheel"`
 
-Map every Figma design token (CSS variables like `--token-name`) to the project's equivalent.
+### Text Variants
+- Figma 24px → `variant="h5"` (x-large)
+- Figma 18px → `variant="h6"` (large)
+- Figma 16px → `variant="body1"` (normal, default)
+- Figma 14px → `variant="body2"` (small)
+- Figma 12px → `variant="caption"` (x-small)
+- Figma 11px → `variant="overline"` (2x-small)
+- Figma Medium weight (500) → `semibold` prop
+- Figma Bold weight (700) → `bold` prop
+- Figma Light weight (300) → `light` prop
+- Figma inline text (span) → `inline` prop
 
-### 3c: Find the Icon Registry
+## Step 4: Map Design Tokens to Theme
 
-```
-Search for: icon type definitions, icon name enums, SVG imports
-Verify each icon name exists before using it
-```
+### Berlin Token → MUI Theme Mapping
 
-### 3d: Identify the Styling Approach
+**Spacing** (custom scale, NOT default MUI 8px base):
+| Berlin Token | `theme.spacing()` | Pixels |
+|---|---|---|
+| `--berlin/padding/2x-small` | `spacing(0.5)` | 1px |
+| `--berlin/padding/x-small` | `spacing(1)` | 2px |
+| `--berlin/padding/small` | `spacing(2)` | 5px |
+| `--berlin/padding/normal` | `spacing(3)` | 10px |
+| `--berlin/padding/large` | `spacing(4)` | 15px |
+| `--berlin/padding/x-large` | `spacing(5)` | 20px |
+| `--berlin/padding/2x-large` | `spacing(6)` | 30px |
+| `--berlin/padding/3x-large` | `spacing(7)` | 40px |
+| `--berlin/padding/4x-large` | `spacing(8)` | 80px |
 
-Determine which styling system the project uses:
-- MUI `sx` prop
-- Tailwind CSS
-- CSS Modules
-- styled-components
-- Vanilla CSS/SCSS
+**Border Radius:**
+| Berlin Token | Theme Token | Pixels |
+|---|---|---|
+| `--berlin/border-radius/x-small` | `theme.borderRadius?.xSmall` | 3px |
+| `--berlin/border-radius/small` | `theme.borderRadius?.small` | 6px |
+| `--berlin/border-radius/medium` | `theme.borderRadius?.medium` | 8px |
+| `--berlin/border-radius/large` | `theme.borderRadius?.large` | 12px |
+| `--berlin/border-radius/x-large` | `theme.borderRadius?.xLarge` | 16px |
+| `--berlin/border-radius/2x-large` | `theme.borderRadius?.xxLarge` | 30px |
+| `--berlin/border-radius/3x-large` | `theme.borderRadius?.xxxLarge` | 40px |
 
-**Use whatever the project uses. Never mix approaches.**
+**Colors:**
+| Berlin Token | Theme Token |
+|---|---|
+| `--berlin/color/base` | `theme.palette.text.primary` or `theme.palette.base?.base` |
+| `--berlin/color/strong` | `theme.palette.base?.strong` |
+| `--berlin/color/muted` | `theme.palette.text.secondary` or `theme.palette.base?.muted` |
+| `--berlin/color/inactive` | `theme.palette.base?.inactive` |
+| `--berlin/color/primary` | `theme.palette.primary.main` or `theme.palette.base?.primary` |
+| `--berlin/color/danger` | `theme.palette.base?.danger` |
+| `--berlin/color/warning` | `theme.palette.statusChip?.warning.text` |
+| `--berlin/background-color/standout` | `theme.palette.background.standout` (white) |
+| `--berlin/background-color/base` | `theme.palette.background.base` |
+| `--berlin/background-color/medium` | `theme.palette.background.medium` |
+| `--berlin/background-color/muted` | `theme.palette.background.muted` |
+| `--berlin/background-color/primary` | `theme.palette.background.primary` |
+| `--berlin/background-color/warning` | `theme.palette.background.warning` |
+| `--berlin/background-color/error` | `theme.palette.background.error` |
+| `--berlin/border-color/base` | `theme.palette.border?.base` |
+| `--berlin/border-color/muted` | `theme.palette.border?.muted` |
+| `--berlin/border-color/strong` | `theme.palette.border?.strong` |
+| `--berlin/border-color/primary` | `theme.palette.border?.primary` |
+| `--berlin/buttons/styles/primary/*` | Use `variant="primary"` on Button |
+| `--berlin/buttons/styles/outline/*` | Use `variant="outlined"` on Button |
 
-## Step 4: Implementation Rules
+**Shadows:**
+| Purpose | Theme Token |
+|---|---|
+| Cards | `theme.shadow?.card` |
+| Modals | `theme.shadow?.modal` |
+| Drawers | `theme.shadow?.drawer` |
+| Bottom sheets | `theme.shadow?.bottomSheet` |
+| Floating nav | `theme.shadow?.floatingNavigation` |
 
-### Universal Rules (apply to ALL projects)
+**Border Width:**
+| Berlin Token | Theme Token | Pixels |
+|---|---|---|
+| `--berlin/border-width/regular` | `theme.borderWidth?.regular` | 1px |
+| `--berlin/border-width/thick` | `theme.borderWidth?.thick` | 2px |
 
-1. **Never hardcode colors** — always use theme tokens / CSS variables
-2. **Never hardcode spacing** — use the project's spacing scale
-3. **Never use Figma asset URLs in code** — they expire in 7 days. Download SVGs and register them as icons if new.
-4. **Respect existing patterns** — if the project extracts components to files, don't use inline JSX variables. If the project uses a Container/View pattern, follow it.
-5. **Check the rules** — read any `.rules/`, `AGENTS.md`, `CLAUDE.md`, or similar project instruction files for coding conventions
+**Font Sizes (Berlin → Typography variant):**
+| Berlin Token | MUI Variant | Pixels |
+|---|---|---|
+| `--berlin/font-size/2x-small` | `overline` | 11px |
+| `--berlin/font-size/x-small` | `caption` | 12px |
+| `--berlin/font-size/small` | `body2` | 14px |
+| `--berlin/font-size/normal` | `body1` | 16px |
+| `--berlin/font-size/large` | `h6` | 18px |
+| `--berlin/font-size/x-large` | `h5` | 24px |
 
-### React + MUI Projects (common at CBH)
+## Step 5: Styling Rules (MANDATORY)
 
-- Use `sx` prop for styling, never CSS/SCSS/styled()/makeStyles()
-- Use `(theme) => ({...})` callback for type-safe theme access
-- Use `isDefined()` from `@clipboard-health/util-ts` for null checks, not truthy checks
-- Never extract JSX into local variables — inline or extract to a separate component
-- Follow Container/View pattern: Container fetches data, View is pure presentation
+1. **ALWAYS use MUI `sx` prop** — never CSS/SCSS/styled()/makeStyles()/Tailwind
+2. **NEVER hardcode colors** — always use `theme.palette.*`
+3. **NEVER hardcode border radius** — use `theme.borderRadius?.{size}` or the component's built-in border radius
+4. **Use theme spacing** — `theme.spacing(n)` or shorthand numeric values in sx (`padding: 5` = `theme.spacing(5)` = 20px)
+5. **Use `(theme) =>` callback** for type-safe theme access:
+   ```typescript
+   sx={(theme) => ({
+     borderBottom: `1px solid ${theme.palette.border?.base}`,
+     padding: theme.spacing(5),
+   })}
+   ```
+6. **Borders**: Always use `theme.palette.border?.base` for color, `theme.borderWidth?.regular` (1px) or `thick` (2px) for width
+7. **Never extract JSX into local variables** — inline or extract to a separate component
 
-### Responsive Design
+## Step 6: Architecture Rules
 
-- Check if the Figma has mobile and desktop variants
-- Use the project's responsive hooks/breakpoints
-- Mobile typically uses bottom sheets / stacked layouts
-- Desktop typically uses side panels / horizontal layouts
+1. **New features go in `src/appV2/redesign/`**
+2. **Container/View pattern**: Container fetches data, View is pure presentation
+3. **Feature folder structure**:
+   ```
+   FeatureName/
+   ├── api/           # API hooks
+   ├── components/    # Presentational components
+   ├── hooks/         # Custom hooks
+   ├── utils/         # Pure functions
+   ├── Container.tsx  # Data fetching
+   ├── View.tsx       # Presentation
+   ├── types.ts       # Domain types
+   └── constants.ts   # Constants
+   ```
+4. **Responsive**: Use `useIsMobile()` from `redesign/AppLayout/useResponsive` (breakpoint: 640px)
+5. **Modal state**: Use `useModalState()` from `@clipboard-health/ui-react`
+6. **Null checks**: Use `isDefined()` from `@clipboard-health/util-ts`, never truthy checks for null/undefined
 
-## Step 5: Verify the Implementation
+## Step 7: Breakpoints
 
-After writing code:
+| Name | Width | Hook |
+|---|---|---|
+| Mobile | < 640px (md) | `useIsMobile()` |
+| Tablet | < 1024px (lg) | `useIsTablet()` |
+| Desktop | >= 1024px (lg) | `useIsDesktop()` |
 
-1. **Run typechecks** — ensure no type errors
-2. **Run tests** — ensure existing tests still pass
-3. **Grep for hardcoded values** — search new code for `#`, `rgb(`, `rgba(`, hardcoded pixel values that should use tokens
-4. **Compare with Figma screenshot** — visually verify the implementation matches the design element by element
-5. **Check for hidden Figma properties** — ensure no invisible/hidden elements were accidentally implemented
+Mobile renders BottomSheet for overlays. Desktop renders SidePanel/Dialog.
 
-## Common Figma-to-Code Pitfalls
+## Step 8: Implementation Checklist
 
-1. **Custom spacing scales** — many projects use non-standard spacing (not 8px base). Check `theme.spacing` before converting.
-2. **Figma returns Tailwind** — the reference code uses Tailwind classes. Convert every class to the project's styling system.
-3. **Figma returns `<img>` for icons** — replace with the project's Icon component.
-4. **Asset URLs expire** — `figma.com/api/mcp/asset/*` URLs expire in 7 days. Never use in production.
-5. **Annotations are instructions** — `data-annotations="documents, chat, download badge"` means the menu should contain those items. Don't render the annotation text.
-6. **Design tokens as CSS variables** — `var(--berlin/padding/small, 5px)` means use the project's equivalent of 5px spacing, not literally `5px`.
-7. **Multiple Figma variants** — a single node may represent different states (hover, active, disabled). Check for variant props in the reference code.
+Before writing code, confirm:
+- [ ] Fetched Figma design context with screenshot
+- [ ] Identified ALL existing components to reuse
+- [ ] Mapped ALL Figma tokens to theme tokens
+- [ ] Checked data-annotations for behavioral hints
+- [ ] Verified icon names exist in Icon.types.tsx
+- [ ] Identified responsive differences (mobile vs desktop)
+
+After writing code, verify:
+- [ ] No hardcoded colors (grep for `#`, `rgb`, `rgba` in new code)
+- [ ] No JSX local variables — only inline JSX or extracted components
+- [ ] No Tailwind classes
+- [ ] All `isDefined()` for null checks, not truthy
+- [ ] sx prop uses `(theme) =>` callback where theme tokens are needed
+- [ ] Tests pass (`npm run test:v2` and `npm run typecheck:v2`)
+
+## Common Pitfalls from Past Sessions
+
+1. **Theme spacing is NOT 8px base** — this project uses a custom scale (spacing(1)=2px, spacing(2)=5px, etc.). Never convert px to spacing by dividing by 8.
+2. **Figma returns Tailwind classes** — NEVER use them. Convert every class to MUI sx prop equivalent.
+3. **Figma returns `<img>` tags for icons** — Replace with `<Icon type="..." />` component.
+4. **Figma asset URLs expire in 7 days** — Never use them in production code. Download SVGs and register as icons if new.
+5. **The `hyperlink` icon** exists but is being replaced by `key-outline` for credential actions.
+6. **Desktop rows** use a single rounded container with internal dividers, NOT individual bordered cards. Mobile cards DO use individual bordered cards.
+7. **Status badges** have different rendering per viewport: plain colored text on desktop, Tags on mobile for "In progress"/"Starts in X hrs".
+8. **Figma hidden properties** — nodes with `visible: false` or `opacity: 0` are design helpers. Do not implement them.
+9. **CircularXX font in Figma** — maps to the "Circular" font family in the codebase theme. Do not add font-family overrides.
+10. **Figma `flex-[1_0_0]`** — means `flex: 1` in sx prop. Figma uses Tailwind shorthand for flex properties.

--- a/plugins/core/skills/figma-to-code/SKILL.md
+++ b/plugins/core/skills/figma-to-code/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: figma-to-code
+description: "Implement UI from a Figma design. Use when the user shares a Figma URL, asks to implement a design, or says things like 'build this from Figma', 'match this design', 'implement this Figma', or 'figma to code'."
+argument-hint: "<figma-url>"
+---
+
+# Figma to Code
+
+Fetch a Figma design, map it to the project's existing components and theme tokens, and produce production-ready code that matches the design.
+
+## Arguments
+
+- `$ARGUMENTS` - Figma URL (e.g., `https://www.figma.com/design/:fileKey/:fileName?node-id=:nodeId`). Required.
+
+## Step 1: Fetch the Design
+
+Extract `fileKey` and `nodeId` from the Figma URL:
+- `figma.com/design/:fileKey/:fileName?node-id=:int1-:int2` → nodeId = `int1:int2` (convert `-` to `:`)
+- `figma.com/design/:fileKey/branch/:branchKey/:fileName` → use branchKey as fileKey
+
+Call `mcp__claude_ai_Figma__get_design_context` with:
+- `fileKey` and `nodeId` from the URL
+- `clientFrameworks`: detect from the project (e.g., "react", "vue", "angular")
+- `clientLanguages`: detect from the project (e.g., "typescript", "javascript")
+
+## Step 2: Interpret the Design (DO NOT generate code yet)
+
+The Figma MCP returns **reference code** (typically React+Tailwind) plus a screenshot. This is a starting point, NOT final code.
+
+Before writing any code:
+
+1. **Study the screenshot** — this is the source of truth for what to build
+2. **Ignore hidden elements** — Figma nodes with `visible: false` or `opacity: 0` are design-time helpers (bounding boxes, redline guides, hidden variants). Do NOT implement them.
+3. **Read `data-annotations`** — these contain implementation hints from designers (e.g., which menu items to show, interaction behaviors, conditional states)
+4. **Identify existing components** — search the project's component library for matches before creating anything new. Use Grep/Glob to find component files.
+5. **Map design tokens** — identify the project's theme/token system and map Figma's CSS variables to it
+6. **Compare screenshots** — if the user provided a screenshot alongside the URL, compare it with the Figma screenshot to understand what's currently implemented vs what needs to change
+
+## Step 3: Discover the Project's Design System
+
+Before implementing, understand the project's existing patterns:
+
+### 3a: Find the Component Library
+
+```
+Search for: Button, IconButton, Icon, Avatar, Text, Dialog, Modal components
+Look in: src/**/components/, src/**/ui/, src/**/design-system/
+```
+
+For each Figma element, find the matching project component. Prefer reusing existing components over creating new ones.
+
+### 3b: Find the Theme/Token System
+
+```
+Search for: theme.ts, tokens.ts, variables.css, tailwind.config
+Look for: color palette, spacing scale, border radius, typography, shadows
+```
+
+Map every Figma design token (CSS variables like `--token-name`) to the project's equivalent.
+
+### 3c: Find the Icon Registry
+
+```
+Search for: icon type definitions, icon name enums, SVG imports
+Verify each icon name exists before using it
+```
+
+### 3d: Identify the Styling Approach
+
+Determine which styling system the project uses:
+- MUI `sx` prop
+- Tailwind CSS
+- CSS Modules
+- styled-components
+- Vanilla CSS/SCSS
+
+**Use whatever the project uses. Never mix approaches.**
+
+## Step 4: Implementation Rules
+
+### Universal Rules (apply to ALL projects)
+
+1. **Never hardcode colors** — always use theme tokens / CSS variables
+2. **Never hardcode spacing** — use the project's spacing scale
+3. **Never use Figma asset URLs in code** — they expire in 7 days. Download SVGs and register them as icons if new.
+4. **Respect existing patterns** — if the project extracts components to files, don't use inline JSX variables. If the project uses a Container/View pattern, follow it.
+5. **Check the rules** — read any `.rules/`, `AGENTS.md`, `CLAUDE.md`, or similar project instruction files for coding conventions
+
+### React + MUI Projects (common at CBH)
+
+- Use `sx` prop for styling, never CSS/SCSS/styled()/makeStyles()
+- Use `(theme) => ({...})` callback for type-safe theme access
+- Use `isDefined()` from `@clipboard-health/util-ts` for null checks, not truthy checks
+- Never extract JSX into local variables — inline or extract to a separate component
+- Follow Container/View pattern: Container fetches data, View is pure presentation
+
+### Responsive Design
+
+- Check if the Figma has mobile and desktop variants
+- Use the project's responsive hooks/breakpoints
+- Mobile typically uses bottom sheets / stacked layouts
+- Desktop typically uses side panels / horizontal layouts
+
+## Step 5: Verify the Implementation
+
+After writing code:
+
+1. **Run typechecks** — ensure no type errors
+2. **Run tests** — ensure existing tests still pass
+3. **Grep for hardcoded values** — search new code for `#`, `rgb(`, `rgba(`, hardcoded pixel values that should use tokens
+4. **Compare with Figma screenshot** — visually verify the implementation matches the design element by element
+5. **Check for hidden Figma properties** — ensure no invisible/hidden elements were accidentally implemented
+
+## Common Figma-to-Code Pitfalls
+
+1. **Custom spacing scales** — many projects use non-standard spacing (not 8px base). Check `theme.spacing` before converting.
+2. **Figma returns Tailwind** — the reference code uses Tailwind classes. Convert every class to the project's styling system.
+3. **Figma returns `<img>` for icons** — replace with the project's Icon component.
+4. **Asset URLs expire** — `figma.com/api/mcp/asset/*` URLs expire in 7 days. Never use in production.
+5. **Annotations are instructions** — `data-annotations="documents, chat, download badge"` means the menu should contain those items. Don't render the annotation text.
+6. **Design tokens as CSS variables** — `var(--berlin/padding/small, 5px)` means use the project's equivalent of 5px spacing, not literally `5px`.
+7. **Multiple Figma variants** — a single node may represent different states (hover, active, disabled). Check for variant props in the reference code.


### PR DESCRIPTION
## Summary
Adds a `figma-to-code` skill to the core plugin that guides Figma-to-code implementation workflows.

**What it does:**
- Fetches Figma designs via MCP (`get_design_context`)
- Maps Figma elements to existing project components (searches codebase first)
- Maps design tokens (CSS variables) to project theme tokens
- Handles hidden elements, annotations, responsive variants
- Enforces project styling conventions (no hardcoded colors, use theme tokens)
- Lists common pitfalls from real Figma sessions (expired assets, custom spacing scales, Tailwind conversion, etc.)

**How to use:**
```
/figma-to-code https://www.figma.com/design/...?node-id=...
```

**Design decisions:**
- Generic enough for any frontend project (React/Vue/Angular, MUI/Tailwind/CSS Modules)
- Step 3 ("Discover the Project's Design System") makes it search the project before assuming anything
- React + MUI section is explicit since most CBH frontend projects use that stack
- Pitfalls section based on patterns from 25+ real Figma implementation sessions

Open to feedback on what to trim or add for team-wide usability.

## Test plan
- [ ] Install plugin and trigger `/figma-to-code` with a Figma URL
- [ ] Verify it fetches the design and maps to project components correctly
- [ ] Verify it respects project styling conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/clipboardhealth/core-utils/pull/470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
