### PR TITLE
feat(contract-core)!: replace user-supplied fallback with ENUM_FALLBACK sentinel

### DIFF
--- a/packages/ai-rules/rules/backend/restApiDesign.md
+++ b/packages/ai-rules/rules/backend/restApiDesign.md
@@ -96,7 +96,7 @@ GET /shifts?filter[verified]=true&sort=startDate,-urgency&page[cursor]=abc&page[
 Use helpers from `@clipboard-health/contract-core` instead of raw Zod methods in contract packages:
 
 - Use `dateTimeSchema()` for date fields — not `z.coerce.date()` (too permissive), `z.string().datetime()` (gives string, not Date), or `z.date()` (won't parse JSON strings)
-- Use `requiredEnumWithFallback`/`optionalEnumWithFallback` for enums — not bare `z.enum()` (breaks old mobile clients when new values are added) or `z.enum().catch()` (doesn't compose with `.optional()`)
+- Use `requiredEnumWithFallback`/`optionalEnumWithFallback` for enums — not bare `z.enum()` (breaks old mobile clients when new values are added) or `z.enum().catch()` (doesn't compose with `.optional()`). These helpers automatically append `ENUM_FALLBACK` (`"UNRECOGNIZED_"`) to the output type — do not pass a fallback value
 - Do not use `.default()` in contracts — client and server can drift on defaults. Set defaults in the service layer.
 - Name schemas with a `Schema` suffix: `ShiftAttributeSchema`, not `shiftAttribute`
 - Export at the DTO boundary (request/response schemas), not every intermediate schema

--- a/packages/contract-core/README.md
+++ b/packages/contract-core/README.md
@@ -29,8 +29,8 @@ This package provides four enum validation helpers to cover different use cases:
 
 **Fallback validation (with coalescing):**
 
-- `requiredEnumWithFallback(values, fallback)` - Invalid values are coerced to the fallback value. `undefined` fails validation.
-- `optionalEnumWithFallback(values, fallback)` - Invalid values are coerced to the fallback value. `undefined` passes through as `undefined`.
+- `requiredEnumWithFallback(values)` - Invalid values are coerced to `ENUM_FALLBACK` (`"UNRECOGNIZED_"`), a business-context-neutral sentinel automatically appended to the enum type. `undefined` fails validation.
+- `optionalEnumWithFallback(values)` - Invalid values are coerced to `ENUM_FALLBACK` (`"UNRECOGNIZED_"`). `undefined` passes through as `undefined`.
 
 **Strict validation (no fallback):**
 
@@ -44,6 +44,7 @@ import {
   apiErrors,
   booleanString,
   dateTimeSchema,
+  ENUM_FALLBACK,
   nonEmptyString,
   optionalEnum,
   optionalEnumWithFallback,
@@ -134,12 +135,13 @@ const someDate = schema.parse("2026-03-15T10:30:00.000Z");
 console.log(someDate);
 
 // Enum with fallback examples
+// ENUM_FALLBACK is a neutral sentinel ("UNRECOGNIZED_") automatically appended
+// to the enum type. Consumers cannot choose their own fallback value, preventing
+// misuse where a business-meaningful value is treated as a default.
+
 /* -- required -- */
-const requiredStatusEnumSchema = requiredEnumWithFallback(
-  ["unspecified", "pending", "completed", "failed"],
-  "unspecified",
-);
-// type RequiredStatusEnum = "unspecified" | "pending" | "completed" | "failed"
+const requiredStatusEnumSchema = requiredEnumWithFallback(["pending", "completed", "failed"]);
+// type RequiredStatusEnum = "pending" | "completed" | "failed" | "UNRECOGNIZED_"
 type RequiredStatusEnum = z.infer<typeof requiredStatusEnumSchema>;
 
 const completedStatus: RequiredStatusEnum = requiredStatusEnumSchema.parse("completed");
@@ -147,8 +149,9 @@ const completedStatus: RequiredStatusEnum = requiredStatusEnumSchema.parse("comp
 console.log(completedStatus);
 
 const additionalStatus = requiredStatusEnumSchema.parse("additional");
-// => "unspecified"
+// => "UNRECOGNIZED_" (ENUM_FALLBACK)
 console.log(additionalStatus);
+console.log(additionalStatus === ENUM_FALLBACK); // true
 
 try {
   // eslint-disable-next-line unicorn/no-useless-undefined
@@ -159,11 +162,8 @@ try {
 }
 
 /* -- optional -- */
-const optionalStatusEnumSchema = optionalEnumWithFallback(
-  ["unspecified", "pending", "completed", "failed"],
-  "unspecified",
-);
-// type OptionalStatusEnum = "unspecified" | "pending" | "completed" | "failed" | undefined
+const optionalStatusEnumSchema = optionalEnumWithFallback(["pending", "completed", "failed"]);
+// type OptionalStatusEnum = "pending" | "completed" | "failed" | "UNRECOGNIZED_" | undefined
 type OptionalStatusEnum = z.infer<typeof optionalStatusEnumSchema>;
 
 const failedStatus: OptionalStatusEnum = optionalStatusEnumSchema.parse("failed");
@@ -171,7 +171,7 @@ const failedStatus: OptionalStatusEnum = optionalStatusEnumSchema.parse("failed"
 console.log(failedStatus);
 
 const extraStatus = optionalStatusEnumSchema.parse("extra");
-// => "unspecified"
+// => "UNRECOGNIZED_" (ENUM_FALLBACK)
 console.log(extraStatus);
 
 // eslint-disable-next-line unicorn/no-useless-undefined

--- a/packages/contract-core/examples/schemas.ts
+++ b/packages/contract-core/examples/schemas.ts
@@ -3,6 +3,7 @@ import {
   apiErrors,
   booleanString,
   dateTimeSchema,
+  ENUM_FALLBACK,
   nonEmptyString,
   optionalEnum,
   optionalEnumWithFallback,
@@ -93,12 +94,13 @@ const someDate = schema.parse("2026-03-15T10:30:00.000Z");
 console.log(someDate);
 
 // Enum with fallback examples
+// ENUM_FALLBACK is a neutral sentinel ("UNRECOGNIZED_") automatically appended
+// to the enum type. Consumers cannot choose their own fallback value, preventing
+// misuse where a business-meaningful value is treated as a default.
+
 /* -- required -- */
-const requiredStatusEnumSchema = requiredEnumWithFallback(
-  ["unspecified", "pending", "completed", "failed"],
-  "unspecified",
-);
-// type RequiredStatusEnum = "unspecified" | "pending" | "completed" | "failed"
+const requiredStatusEnumSchema = requiredEnumWithFallback(["pending", "completed", "failed"]);
+// type RequiredStatusEnum = "pending" | "completed" | "failed" | "UNRECOGNIZED_"
 type RequiredStatusEnum = z.infer<typeof requiredStatusEnumSchema>;
 
 const completedStatus: RequiredStatusEnum = requiredStatusEnumSchema.parse("completed");
@@ -106,8 +108,9 @@ const completedStatus: RequiredStatusEnum = requiredStatusEnumSchema.parse("comp
 console.log(completedStatus);
 
 const additionalStatus = requiredStatusEnumSchema.parse("additional");
-// => "unspecified"
+// => "UNRECOGNIZED_" (ENUM_FALLBACK)
 console.log(additionalStatus);
+console.log(additionalStatus === ENUM_FALLBACK); // true
 
 try {
   // eslint-disable-next-line unicorn/no-useless-undefined
@@ -118,11 +121,8 @@ try {
 }
 
 /* -- optional -- */
-const optionalStatusEnumSchema = optionalEnumWithFallback(
-  ["unspecified", "pending", "completed", "failed"],
-  "unspecified",
-);
-// type OptionalStatusEnum = "unspecified" | "pending" | "completed" | "failed" | undefined
+const optionalStatusEnumSchema = optionalEnumWithFallback(["pending", "completed", "failed"]);
+// type OptionalStatusEnum = "pending" | "completed" | "failed" | "UNRECOGNIZED_" | undefined
 type OptionalStatusEnum = z.infer<typeof optionalStatusEnumSchema>;
 
 const failedStatus: OptionalStatusEnum = optionalStatusEnumSchema.parse("failed");
@@ -130,7 +130,7 @@ const failedStatus: OptionalStatusEnum = optionalStatusEnumSchema.parse("failed"
 console.log(failedStatus);
 
 const extraStatus = optionalStatusEnumSchema.parse("extra");
-// => "unspecified"
+// => "UNRECOGNIZED_" (ENUM_FALLBACK)
 console.log(extraStatus);
 
 // eslint-disable-next-line unicorn/no-useless-undefined

--- a/packages/contract-core/src/lib/schemas/enum.spec.ts
+++ b/packages/contract-core/src/lib/schemas/enum.spec.ts
@@ -4,6 +4,7 @@ import {
 } from "@clipboard-health/testing-core";
 
 import {
+  ENUM_FALLBACK,
   enumWithFallback,
   optionalEnum,
   optionalEnumWithFallback,
@@ -12,10 +13,9 @@ import {
 } from "./enum";
 
 const VALUES = ["a", "b", "c"] as const;
-const FALLBACK = "a";
 
 describe("requiredEnumWithFallback", () => {
-  const schema = requiredEnumWithFallback([...VALUES], FALLBACK);
+  const schema = requiredEnumWithFallback([...VALUES]);
 
   describe("success cases", () => {
     it.each<{ expected: string; input: unknown; name: string }>([
@@ -25,15 +25,15 @@ describe("requiredEnumWithFallback", () => {
       {
         name: "falls back for invalid string",
         input: "invalid",
-        expected: FALLBACK,
+        expected: ENUM_FALLBACK,
       },
       {
         name: "falls back for non-string input",
         input: 123,
-        expected: FALLBACK,
+        expected: ENUM_FALLBACK,
       },
-      { name: "falls back for null", input: null, expected: FALLBACK },
-      { name: "falls back for object", input: {}, expected: FALLBACK },
+      { name: "falls back for null", input: null, expected: ENUM_FALLBACK },
+      { name: "falls back for object", input: {}, expected: ENUM_FALLBACK },
     ])("$name", ({ input, expected }) => {
       const actual = schema.safeParse(input);
 
@@ -54,7 +54,7 @@ describe("requiredEnumWithFallback", () => {
 });
 
 describe("optionalEnumWithFallback", () => {
-  const schema = optionalEnumWithFallback([...VALUES], FALLBACK);
+  const schema = optionalEnumWithFallback([...VALUES]);
 
   describe("success cases", () => {
     it.each<{ expected: string | undefined; input: unknown; name: string }>([
@@ -65,15 +65,15 @@ describe("optionalEnumWithFallback", () => {
       {
         name: "falls back for invalid string",
         input: "invalid",
-        expected: FALLBACK,
+        expected: ENUM_FALLBACK,
       },
       {
         name: "falls back for non-string input",
         input: 123,
-        expected: FALLBACK,
+        expected: ENUM_FALLBACK,
       },
-      { name: "falls back for null", input: null, expected: FALLBACK },
-      { name: "falls back for object", input: {}, expected: FALLBACK },
+      { name: "falls back for null", input: null, expected: ENUM_FALLBACK },
+      { name: "falls back for object", input: {}, expected: ENUM_FALLBACK },
     ])("$name", ({ input, expected }) => {
       const actual = schema.safeParse(input);
 
@@ -84,8 +84,14 @@ describe("optionalEnumWithFallback", () => {
 });
 
 describe("enumWithFallback", () => {
+  it("throws if values include ENUM_FALLBACK", () => {
+    expect(() => enumWithFallback(["a", ENUM_FALLBACK])).toThrow(
+      `Enum values must not include "${ENUM_FALLBACK}"`,
+    );
+  });
+
   describe("with { optional: true }", () => {
-    const schema = enumWithFallback([...VALUES], FALLBACK, { optional: true });
+    const schema = enumWithFallback([...VALUES], { optional: true });
 
     it("accepts undefined", () => {
       // eslint-disable-next-line unicorn/no-useless-undefined
@@ -99,12 +105,12 @@ describe("enumWithFallback", () => {
       const actual = schema.safeParse("invalid");
 
       expectToBeSafeParseSuccess(actual);
-      expect(actual.data).toBe(FALLBACK);
+      expect(actual.data).toBe(ENUM_FALLBACK);
     });
   });
 
   describe("with { optional: false }", () => {
-    const schema = enumWithFallback([...VALUES], FALLBACK, { optional: false });
+    const schema = enumWithFallback([...VALUES], { optional: false });
 
     it("rejects undefined", () => {
       // eslint-disable-next-line unicorn/no-useless-undefined
@@ -118,12 +124,12 @@ describe("enumWithFallback", () => {
       const actual = schema.safeParse("invalid");
 
       expectToBeSafeParseSuccess(actual);
-      expect(actual.data).toBe(FALLBACK);
+      expect(actual.data).toBe(ENUM_FALLBACK);
     });
   });
 
   describe("with no options (defaults to required)", () => {
-    const schema = enumWithFallback([...VALUES], FALLBACK);
+    const schema = enumWithFallback([...VALUES]);
 
     it("rejects undefined", () => {
       // eslint-disable-next-line unicorn/no-useless-undefined
@@ -205,13 +211,13 @@ describe("optionalEnum", () => {
 });
 
 describe("accepts readonly values directly without spreading", () => {
-  const STATUSES = ["unspecified", "active", "inactive"] as const;
+  const STATUSES = ["active", "inactive"] as const;
   // Simulates a new enum value the producer added but this consumer
-  // doesn't recognize yet; fallback helpers coerce it to "unspecified".
+  // doesn't recognize yet; fallback helpers coerce it to ENUM_FALLBACK.
   const UNRECOGNIZED_VALUE = "deleted";
 
-  it("requiredEnumWithFallback coerces unknown values to fallback", () => {
-    const schema = requiredEnumWithFallback(STATUSES, "unspecified");
+  it("requiredEnumWithFallback coerces unknown values to ENUM_FALLBACK", () => {
+    const schema = requiredEnumWithFallback(STATUSES);
 
     const valid = schema.safeParse("active");
     expectToBeSafeParseSuccess(valid);
@@ -219,14 +225,14 @@ describe("accepts readonly values directly without spreading", () => {
 
     const unknown = schema.safeParse(UNRECOGNIZED_VALUE);
     expectToBeSafeParseSuccess(unknown);
-    expect(unknown.data).toBe("unspecified");
+    expect(unknown.data).toBe(ENUM_FALLBACK);
 
     // eslint-disable-next-line unicorn/no-useless-undefined
     expectToBeSafeParseError(schema.safeParse(undefined));
   });
 
-  it("optionalEnumWithFallback coerces unknown values to fallback and allows undefined", () => {
-    const schema = optionalEnumWithFallback(STATUSES, "unspecified");
+  it("optionalEnumWithFallback coerces unknown values to ENUM_FALLBACK and allows undefined", () => {
+    const schema = optionalEnumWithFallback(STATUSES);
 
     const valid = schema.safeParse("active");
     expectToBeSafeParseSuccess(valid);
@@ -234,7 +240,7 @@ describe("accepts readonly values directly without spreading", () => {
 
     const unknown = schema.safeParse(UNRECOGNIZED_VALUE);
     expectToBeSafeParseSuccess(unknown);
-    expect(unknown.data).toBe("unspecified");
+    expect(unknown.data).toBe(ENUM_FALLBACK);
 
     // eslint-disable-next-line unicorn/no-useless-undefined
     const undef = schema.safeParse(undefined);

--- a/packages/contract-core/src/lib/schemas/enum.ts
+++ b/packages/contract-core/src/lib/schemas/enum.ts
@@ -3,51 +3,66 @@ import { z } from "zod";
 type EnumValues = readonly [string, ...string[]];
 
 /**
+ * A business-context-neutral sentinel returned when an enum field
+ * receives a value the consumer does not recognize.
+ */
+export const ENUM_FALLBACK = "UNRECOGNIZED_" as const;
+type EnumFallback = typeof ENUM_FALLBACK;
+
+/**
  * @internal Do not use this function directly.
  * Use `requiredEnumWithFallback` or `optionalEnumWithFallback` instead.
- * Enum + "invalid -> fallback" with optionality toggle.
+ * Enum + "invalid -> UNRECOGNIZED_" with optionality toggle.
  * - If optional=true: undefined stays undefined
  * - If optional=false: undefined is rejected (normal enum behavior)
- * - Fallback must be a member of the enum
+ * - Invalid values are coerced to ENUM_FALLBACK ("UNRECOGNIZED_")
  */
-export function enumWithFallback<const V extends EnumValues, const F extends V[number]>(
+export function enumWithFallback<const V extends EnumValues>(
   values: V,
-  fallback: F,
   options?: { optional?: false },
-): z.ZodEffects<z.ZodEnum<[...V]>, V[number], unknown>;
+): z.ZodEffects<z.ZodEnum<[...V, EnumFallback]>, V[number] | EnumFallback, unknown>;
 
-export function enumWithFallback<const V extends EnumValues, const F extends V[number]>(
+export function enumWithFallback<const V extends EnumValues>(
   values: V,
-  fallback: F,
   options: { optional: true },
-): z.ZodEffects<z.ZodOptional<z.ZodEnum<[...V]>>, V[number] | undefined, unknown>;
+): z.ZodEffects<
+  z.ZodOptional<z.ZodEnum<[...V, EnumFallback]>>,
+  V[number] | EnumFallback | undefined,
+  unknown
+>;
 
-export function enumWithFallback<const V extends EnumValues, const F extends V[number]>(
+export function enumWithFallback<const V extends EnumValues>(
   values: V,
-  fallback: F,
   options: { optional?: boolean } = {},
 ) {
-  const Enum = z.enum([...values]);
-  const optional = options.optional ?? false;
-  const schema = optional ? Enum.optional() : Enum;
+  if ((values as readonly string[]).includes(ENUM_FALLBACK)) {
+    throw new Error(
+      `Enum values must not include "${ENUM_FALLBACK}". It is appended automatically.`,
+    );
+  }
 
+  const OriginalEnum = z.enum([...values]);
+  const ExpandedEnum = z.enum([...values, ENUM_FALLBACK]);
+  const optional = options.optional ?? false;
+  const schema = optional ? ExpandedEnum.optional() : ExpandedEnum;
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return z.preprocess((value) => {
     if (value === undefined) {
       return optional ? undefined : value;
     }
-    return Enum.safeParse(value).success ? value : fallback;
+
+    return OriginalEnum.safeParse(value).success ? value : ENUM_FALLBACK;
   }, schema);
 }
 
-export const optionalEnumWithFallback = <const V extends EnumValues, const F extends V[number]>(
-  values: V,
-  fallback: F,
-) => enumWithFallback(values, fallback, { optional: true });
+export function requiredEnumWithFallback<const V extends EnumValues>(values: V) {
+  return enumWithFallback(values, { optional: false });
+}
 
-export const requiredEnumWithFallback = <const V extends EnumValues, const F extends V[number]>(
-  values: V,
-  fallback: F,
-) => enumWithFallback(values, fallback, { optional: false });
+export function optionalEnumWithFallback<const V extends EnumValues>(values: V) {
+  return enumWithFallback(values, { optional: true });
+}
 
 export function requiredEnum<const V extends EnumValues>(values: V): z.ZodEnum<[...V]> {
   return z.enum([...values]);


### PR DESCRIPTION
## Summary

- Remove the user-supplied `fallback` parameter from `requiredEnumWithFallback` and `optionalEnumWithFallback`
- Add `ENUM_FALLBACK` (`"UNRECOGNIZED_"`) constant — a business-context-neutral sentinel automatically appended to the enum's output type
- Invalid values now always coerce to `"UNRECOGNIZED_"` instead of a user-chosen value, preventing misuse where consumers treat the fallback as a default
- Use `"UNRECOGNIZED_"` to avoid any collision with existing UNRECOGNIZED, UNSPECIFIED variation of strings, enums that exist

### Breaking change

The `fallback` parameter has been removed from `requiredEnumWithFallback`, `optionalEnumWithFallback`, and `enumWithFallback`. Consumers must update call sites to drop the second argument and handle `"UNRECOGNIZED_"` in their types.

**Before:**
```ts
requiredEnumWithFallback(["pending", "completed"], "completed")
// type: "pending" | "completed"
```

**After:**
```ts
requiredEnumWithFallback(["pending", "completed"])
// type: "pending" | "completed" | "UNRECOGNIZED_"
```

ATD-178

## Test plan

- [x] All 93 contract-core tests pass
- [x] Lint clean
- [x] Typecheck passes
- [x] Verified breaking change surfaces correctly in contract-backend-main (14 call sites need updating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/clipboardhealth/core-utils/pull/521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
