### PR TITLE
fix(ai-rules): stop sourcing nvm.sh in persisted CLAUDE_ENV_FILE

### DIFF
--- a/.claude/setup.sh
+++ b/.claude/setup.sh
@@ -106,6 +106,7 @@ persist_claude_env() {
     echo "$begin"
     if command -v nvm >/dev/null 2>&1 \
       && node_dir="$(dirname "$(nvm which current)" 2>/dev/null)" \
+      && [[ -n "${NVM_DIR:-}" ]] \
       && [[ "$node_dir" == "$NVM_DIR"/* ]]; then
       echo "export PATH=\"$node_dir:\$PATH\""
     fi

--- a/.claude/setup.sh
+++ b/.claude/setup.sh
@@ -98,15 +98,15 @@ persist_claude_env() {
     : > "$tmp"
   fi
 
-  # Always persist general env vars; conditionally include NVM-specific lines
+  # Persist only the resolved PATH to the node binary — never source nvm.sh here.
+  # Sourcing nvm.sh on every Bash call is fragile (fails if nvm.sh is missing or
+  # errors out) and unnecessary since the PATH entry is sufficient for node/npm.
   local node_dir
   {
     echo "$begin"
     if command -v nvm >/dev/null 2>&1 \
       && node_dir="$(dirname "$(nvm which current)" 2>/dev/null)" \
       && [[ "$node_dir" == "$NVM_DIR"/* ]]; then
-      echo "export NVM_DIR=\"$NVM_DIR\""
-      echo ". \"\$NVM_DIR/nvm.sh\" --no-use"
       echo "export PATH=\"$node_dir:\$PATH\""
     fi
     echo "export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true"

--- a/packages/ai-rules/scripts/setup.sh
+++ b/packages/ai-rules/scripts/setup.sh
@@ -106,6 +106,7 @@ persist_claude_env() {
     echo "$begin"
     if command -v nvm >/dev/null 2>&1 \
       && node_dir="$(dirname "$(nvm which current)" 2>/dev/null)" \
+      && [[ -n "${NVM_DIR:-}" ]] \
       && [[ "$node_dir" == "$NVM_DIR"/* ]]; then
       echo "export PATH=\"$node_dir:\$PATH\""
     fi

--- a/packages/ai-rules/scripts/setup.sh
+++ b/packages/ai-rules/scripts/setup.sh
@@ -98,15 +98,15 @@ persist_claude_env() {
     : > "$tmp"
   fi
 
-  # Always persist general env vars; conditionally include NVM-specific lines
+  # Persist only the resolved PATH to the node binary — never source nvm.sh here.
+  # Sourcing nvm.sh on every Bash call is fragile (fails if nvm.sh is missing or
+  # errors out) and unnecessary since the PATH entry is sufficient for node/npm.
   local node_dir
   {
     echo "$begin"
     if command -v nvm >/dev/null 2>&1 \
       && node_dir="$(dirname "$(nvm which current)" 2>/dev/null)" \
       && [[ "$node_dir" == "$NVM_DIR"/* ]]; then
-      echo "export NVM_DIR=\"$NVM_DIR\""
-      echo ". \"\$NVM_DIR/nvm.sh\" --no-use"
       echo "export PATH=\"$node_dir:\$PATH\""
     fi
     echo "export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true"


### PR DESCRIPTION
## Summary

- Remove `nvm.sh` sourcing and `NVM_DIR` export from the env block that `persist_claude_env` writes to `CLAUDE_ENV_FILE`
- Keep only the resolved `PATH` entry pointing to the node binary directory

## Why

`persist_claude_env` wrote `. "$NVM_DIR/nvm.sh" --no-use` to the env file that Claude Code sources before every Bash tool call. On "Claude Code on the web" (remote sessions), if `nvm.sh` doesn't exist or errors out, the `source` command returns non-zero and kills the entire bash call under `set -e`.

The `export PATH` line already resolves the node binary directory at setup time, so re-sourcing the full `nvm.sh` script on every bash call is unnecessary. Removing it eliminates the fragile dependency while keeping node/npm available on PATH.

## Test plan

- [ ] Verify "Claude Code on the web" bash calls work after setup (no nvm.sh errors)
- [ ] Verify local remote sessions still get node/npm on PATH
- [ ] Verify `--deps-only` path still works (no NVM block written when NVM unavailable)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/clipboardhealth/core-utils/pull/528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
