### PR TITLE
feat(oxlint-config): add no-plusplus, jest/valid-title rules and JS/CJS overrides

### DIFF
--- a/packages/oxlint-config/src/base.json
+++ b/packages/oxlint-config/src/base.json
@@ -42,6 +42,7 @@
     "no-continue": "off",
     "no-inline-comments": "off",
     "no-magic-numbers": "off",
+    "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
     "no-named-export": "off",
     "no-ternary": "off",
     "no-undef": "off",
@@ -82,6 +83,13 @@
         "no-console": "off",
         "node/no-process-env": "off",
         "unicorn/no-process-exit": "off"
+      }
+    },
+    {
+      "files": ["**/*.js", "**/*.cjs"],
+      "rules": {
+        "typescript/no-unsafe-call": "off",
+        "typescript/no-unsafe-member-access": "off"
       }
     }
   ]

--- a/packages/oxlint-config/src/index.spec.ts
+++ b/packages/oxlint-config/src/index.spec.ts
@@ -50,7 +50,7 @@ describe("oxlint-config", () => {
         },
       });
 
-      expect(base.overrides).toHaveLength(1);
+      expect(base.overrides).toHaveLength(2);
       expect(base.rules).toMatchObject({
         curly: ["error", "all"],
         "import/no-cycle": ["error", { ignoreExternal: true, maxDepth: 16 }],
@@ -65,11 +65,15 @@ describe("oxlint-config", () => {
 
       expect(jestPreset).toStrictEqual({
         plugins: ["jest"],
+        rules: {
+          "jest/valid-title": ["error", { ignoreTypeOfDescribeName: true }],
+        },
       });
 
       expect(vitest).toStrictEqual({
         plugins: ["vitest"],
         rules: {
+          "jest/valid-title": ["error", { ignoreTypeOfDescribeName: true }],
           "vitest/prefer-importing-vitest-globals": "off",
           "vitest/prefer-to-be-falsy": "off",
           "vitest/prefer-to-be-truthy": "off",

--- a/packages/oxlint-config/src/internal/presets.ts
+++ b/packages/oxlint-config/src/internal/presets.ts
@@ -46,10 +46,14 @@ export const react: OxlintPreset = {
 };
 export const jest: OxlintPreset = {
   plugins: ["jest"],
+  rules: {
+    "jest/valid-title": ["error", { ignoreTypeOfDescribeName: true }],
+  },
 };
 export const vitest: OxlintPreset = {
   plugins: ["vitest"],
   rules: {
+    "jest/valid-title": ["error", { ignoreTypeOfDescribeName: true }],
     "vitest/prefer-importing-vitest-globals": "off",
     "vitest/prefer-to-be-falsy": "off",
     "vitest/prefer-to-be-truthy": "off",


### PR DESCRIPTION
## Summary
- Add `no-plusplus` rule (error, allowing for-loop afterthoughts) to base config
- Add `jest/valid-title` rule with `ignoreTypeOfDescribeName` to jest and vitest presets
- Add override for JS/CJS files to disable `typescript/no-unsafe-call` and `typescript/no-unsafe-member-access`

## Test plan
- [x] `oxlint-config` tests pass (16/16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/clipboardhealth/core-utils/pull/529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
