### PR TITLE
docs(ai-rules): add cross-module logic dependency to architecture diagram

### DIFF
--- a/packages/ai-rules/rules/backend/architecture.md
+++ b/packages/ai-rules/rules/backend/architecture.md
@@ -12,6 +12,7 @@ All NestJS microservices follow a three-tier layered architecture:
 │  Logic (NestJS services, message publishers, background jobs)   │
 │  - ALL business logic; works with DOs only                      │
 │  - Knows nothing about HTTP or database specifics               │
+│  - Can depend on other modules' logic (cross-module composition)│
 ├─────────────────────────────────────────────────────────────────┤
 │  Data (Data repositories, gateways)                             │
 │  - Database via ORM (Prisma/Mongoose), DAO ↔ DO translation     │


### PR DESCRIPTION
## Summary

Document that the logic tier can depend on other modules' logic tier for cross-module service composition.

## Why

The architecture diagram in `ai-rules` didn't mention cross-module logic→logic dependencies, causing automated reviewers to flag legitimate dependency-cruiser rules as contradicting documented architecture.

## What

- Add "Can depend on other modules' logic (cross-module composition)" line to the logic tier in the architecture diagram
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/clipboardhealth/core-utils/pull/532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
