### PR TITLE
feat(contract-core): reject widened string[] in enum helpers

### DIFF
--- a/packages/ai-rules/rules/backend/restApiDesign.md
+++ b/packages/ai-rules/rules/backend/restApiDesign.md
@@ -96,7 +96,7 @@ GET /shifts?filter[verified]=true&sort=startDate,-urgency&page[cursor]=abc&page[
 Use helpers from `@clipboard-health/contract-core` instead of raw Zod methods in contract packages:
 
 - Use `dateTimeSchema()` for date fields — not `z.coerce.date()` (too permissive), `z.string().datetime()` (gives string, not Date), or `z.date()` (won't parse JSON strings)
-- Use `requiredEnumWithFallback`/`optionalEnumWithFallback` for enums — not bare `z.enum()` (breaks old mobile clients when new values are added) or `z.enum().catch()` (doesn't compose with `.optional()`). These helpers automatically append `ENUM_FALLBACK` (`"UNRECOGNIZED_"`) to the output type — do not pass a fallback value
+- Use `requiredEnumWithFallback`/`optionalEnumWithFallback` for enums — not bare `z.enum()` (breaks old mobile clients when new values are added) or `z.enum().catch()` (doesn't compose with `.optional()`). These helpers automatically append `ENUM_FALLBACK` (`"UNRECOGNIZED_"`) to the output type — do not pass a fallback value. Pre-declared array variables must use `as const` to preserve literal types (widened `string[]` is rejected at compile time)
 - Do not use `.default()` in contracts — client and server can drift on defaults. Set defaults in the service layer.
 - Name schemas with a `Schema` suffix: `ShiftAttributeSchema`, not `shiftAttribute`
 - Export at the DTO boundary (request/response schemas), not every intermediate schema

--- a/packages/contract-core/README.md
+++ b/packages/contract-core/README.md
@@ -37,6 +37,21 @@ This package provides four enum validation helpers to cover different use cases:
 - `requiredEnum(values)` - Wraps `z.enum()` for required strict validation. Invalid values fail validation.
 - `optionalEnum(values)` - Wraps `z.enum()` for optional strict validation. Invalid values fail validation, but `undefined` is allowed.
 
+**Type narrowing:** All helpers reject widened `string[]` arrays at compile time. When passing a pre-declared variable, use `as const` to preserve literal types:
+
+```ts
+// Inline arrays work as-is
+requiredEnum(["a", "b"]);
+
+// Pre-declared variables require `as const`
+const VALUES = ["a", "b"] as const;
+requiredEnum(VALUES);
+
+// Without `as const`, the type widens to string[] and is rejected
+const widened = ["a", "b"];
+requiredEnum(widened); // TS error
+```
+
 <embedex source="packages/contract-core/examples/schemas.ts">
 
 ```ts

--- a/packages/contract-core/src/lib/schemas/enum.spec.ts
+++ b/packages/contract-core/src/lib/schemas/enum.spec.ts
@@ -210,6 +210,34 @@ describe("optionalEnum", () => {
   });
 });
 
+describe("rejects widened string[] at compile time", () => {
+  const widened = ["a", "b"];
+
+  it("requiredEnum", () => {
+    // @ts-expect-error: widened string[] should not be accepted
+    const schema = requiredEnum(widened);
+    expect(schema).toBeDefined();
+  });
+
+  it("optionalEnum", () => {
+    // @ts-expect-error: widened string[] should not be accepted
+    const schema = optionalEnum(widened);
+    expect(schema).toBeDefined();
+  });
+
+  it("requiredEnumWithFallback", () => {
+    // @ts-expect-error: widened string[] should not be accepted
+    const schema = requiredEnumWithFallback(widened);
+    expect(schema).toBeDefined();
+  });
+
+  it("optionalEnumWithFallback", () => {
+    // @ts-expect-error: widened string[] should not be accepted
+    const schema = optionalEnumWithFallback(widened);
+    expect(schema).toBeDefined();
+  });
+});
+
 describe("accepts readonly values directly without spreading", () => {
   const STATUSES = ["active", "inactive"] as const;
   // Simulates a new enum value the producer added but this consumer

--- a/packages/contract-core/src/lib/schemas/enum.ts
+++ b/packages/contract-core/src/lib/schemas/enum.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 type EnumValues = readonly [string, ...string[]];
+type NarrowEnum<V extends EnumValues> = string extends V[number] ? never : V;
 
 /**
  * A business-context-neutral sentinel returned when an enum field
@@ -18,12 +19,12 @@ type EnumFallback = typeof ENUM_FALLBACK;
  * - Invalid values are coerced to ENUM_FALLBACK ("UNRECOGNIZED_")
  */
 export function enumWithFallback<const V extends EnumValues>(
-  values: V,
+  values: NarrowEnum<V>,
   options?: { optional?: false },
 ): z.ZodEffects<z.ZodEnum<[...V, EnumFallback]>, V[number] | EnumFallback, unknown>;
 
 export function enumWithFallback<const V extends EnumValues>(
-  values: V,
+  values: NarrowEnum<V>,
   options: { optional: true },
 ): z.ZodEffects<
   z.ZodOptional<z.ZodEnum<[...V, EnumFallback]>>,
@@ -56,20 +57,20 @@ export function enumWithFallback<const V extends EnumValues>(
   }, schema);
 }
 
-export function requiredEnumWithFallback<const V extends EnumValues>(values: V) {
+export function requiredEnumWithFallback<const V extends EnumValues>(values: NarrowEnum<V>) {
   return enumWithFallback(values, { optional: false });
 }
 
-export function optionalEnumWithFallback<const V extends EnumValues>(values: V) {
+export function optionalEnumWithFallback<const V extends EnumValues>(values: NarrowEnum<V>) {
   return enumWithFallback(values, { optional: true });
 }
 
-export function requiredEnum<const V extends EnumValues>(values: V): z.ZodEnum<[...V]> {
+export function requiredEnum<const V extends EnumValues>(values: NarrowEnum<V>): z.ZodEnum<[...V]> {
   return z.enum([...values]);
 }
 
 export function optionalEnum<const V extends EnumValues>(
-  values: V,
+  values: NarrowEnum<V>,
 ): z.ZodOptional<z.ZodEnum<[...V]>> {
   return z.enum([...values]).optional();
 }


### PR DESCRIPTION
## Summary
- Add `NarrowEnum` constraint type that resolves to `never` when the array type parameter widens to `string[]`, forcing callers to use `as const` for pre-declared variables
- Prevents silent type/runtime mismatches where TypeScript infers `string` but Zod enforces literal values at runtime
- Updated contract-core README and ai-rules documentation with `as const` guidance

## Test plan
- [x] Existing tests pass (`nx run contract-core:test`)
- [x] Added compile-time tests with `@ts-expect-error` that fail if the constraint is removed
- [x] Verified typecheck rejects `string[]` with `TS2345: Argument of type 'string[]' is not assignable to parameter of type 'never'`
- [x] Verified inline arrays and `as const` variables continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/clipboardhealth/core-utils/pull/535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
