### PR TITLE
feat(contract-core): support timezone offsets in dateTimeSchema

### DIFF
--- a/packages/contract-core/src/lib/schemas/dateTime.test.ts
+++ b/packages/contract-core/src/lib/schemas/dateTime.test.ts
@@ -21,6 +21,21 @@ describe(dateTimeSchema, () => {
         expected: "2026-03-15T10:30:00.000Z",
       },
       {
+        name: "accepts ISO-8601 datetime with positive offset",
+        input: "2026-03-15T15:30:00.000+05:00",
+        expected: "2026-03-15T10:30:00.000Z",
+      },
+      {
+        name: "accepts ISO-8601 datetime with negative offset",
+        input: "2026-03-15T06:30:00.000-04:00",
+        expected: "2026-03-15T10:30:00.000Z",
+      },
+      {
+        name: "accepts ISO-8601 datetime with zero offset",
+        input: "2026-03-15T10:30:00.000+00:00",
+        expected: "2026-03-15T10:30:00.000Z",
+      },
+      {
         name: "accepts Date object",
         input: new Date("2026-03-15T10:30:00.000Z"),
         expected: "2026-03-15T10:30:00.000Z",

--- a/packages/contract-core/src/lib/schemas/dateTime.ts
+++ b/packages/contract-core/src/lib/schemas/dateTime.ts
@@ -22,6 +22,6 @@ import { z } from "zod";
  */
 export function dateTimeSchema() {
   return z
-    .union([z.string().datetime(), z.date()])
+    .union([z.string().datetime({ offset: true }), z.date()])
     .transform((value) => (value instanceof Date ? value : new Date(value)));
 }


### PR DESCRIPTION
## Summary

- `dateTimeSchema()` previously only accepted UTC timestamps (ending in `Z`). This adds `{ offset: true }` to `z.string().datetime()` so ISO-8601 strings with timezone offsets (e.g. `+05:00`, `-04:00`) are also accepted and correctly normalized to UTC `Date` objects.

## Test plan

- [x] Added test cases for positive, negative, and zero offsets
- [x] All 14 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/clipboardhealth/core-utils/pull/539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
