### PR TITLE
chore(oxlint-config): add vitest.json preset to eliminate rule duplication

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,7 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "extends": ["./packages/oxlint-config/src/base.json"],
-  "plugins": ["vitest"],
+  "extends": ["./packages/oxlint-config/src/vitest.json"],
   "ignorePatterns": [".agents/", ".rules/", "coverage/", "dist/", "node_modules/"],
   "options": {
     "reportUnusedDisableDirectives": "off",
@@ -15,20 +14,6 @@
   },
   "rules": {
     "oxc/no-barrel-file": "off",
-
-    // From [vitest preset](./packages/oxlint-config/src/internal/presets.ts)
-    "jest/max-expects": "off",
-    "jest/max-nested-describe": "off",
-    "jest/no-hooks": "off",
-    "jest/prefer-lowercase-title": "off",
-    "jest/valid-title": ["error", { "ignoreTypeOfDescribeName": true }],
-    "vitest/prefer-importing-vitest-globals": "off",
-    "vitest/prefer-called-once": "off",
-    "vitest/prefer-import-in-mock": "off",
-    "vitest/prefer-to-be-falsy": "off",
-    "vitest/prefer-to-be-truthy": "off",
-    "vitest/require-hook": "off",
-    "vitest/require-test-timeout": "off",
 
     // Temporarily disabled globally until issue gets fixed, should then move to test-only disable
     // in ./packages/oxlint-config/src/base.json

--- a/packages/oxlint-config/README.md
+++ b/packages/oxlint-config/README.md
@@ -104,7 +104,15 @@ Create an `.oxlintrc.json` in your repo root:
 }
 ```
 
-Use JSON only when simple inheritance is enough. JSON `extends` still works for shared `base.json`, but repo-local array fields like `plugins` and `overrides` will not get the additive merge behavior provided by `createOxlintConfig`.
+Use JSON only when simple inheritance is enough. JSON `extends` still works for shared presets, but repo-local array fields like `plugins` and `overrides` will not get the additive merge behavior provided by `createOxlintConfig`.
+
+For repos using Vitest, extend from `vitest.json` instead of `base.json` to include the vitest plugin and rules:
+
+```json
+{
+  "extends": ["./node_modules/@clipboard-health/oxlint-config/src/vitest.json"]
+}
+```
 
 Override shared rules as needed:
 
@@ -122,6 +130,7 @@ Override shared rules as needed:
 The package includes:
 
 - **`base.json`**: the backwards-compatible JSON preset for simple `extends` usage
+- **`vitest.json`**: extends `base.json` with the vitest plugin and rules for JSON `extends` usage
 - **`base` preset**: shared plugins, rules, and overrides exported for TypeScript composition
 - **`react`, `jest`, `vitest` presets**: additive plugin presets for common repo types
 - **`createOxlintConfig`**: helper for composing presets with repo-local config

--- a/packages/oxlint-config/project.json
+++ b/packages/oxlint-config/project.json
@@ -8,7 +8,11 @@
     "build": {
       "executor": "@nx/js:tsc",
       "options": {
-        "assets": ["packages/oxlint-config/*.md", "packages/oxlint-config/src/base.json"],
+        "assets": [
+          "packages/oxlint-config/*.md",
+          "packages/oxlint-config/src/base.json",
+          "packages/oxlint-config/src/vitest.json"
+        ],
         "main": "packages/oxlint-config/src/index.js",
         "outputPath": "dist/packages/oxlint-config",
         "tsConfig": "packages/oxlint-config/tsconfig.lib.json"

--- a/packages/oxlint-config/src/index.test.ts
+++ b/packages/oxlint-config/src/index.test.ts
@@ -531,7 +531,7 @@ function getFirstOverrideFiles(config: {
 }
 
 async function loadPresetsModule(baseJson: unknown): Promise<unknown> {
-  return loadPresetsModuleWithVitestJson(baseJson);
+  return await loadPresetsModuleWithVitestJson(baseJson);
 }
 
 async function loadPresetsModuleWithVitestJson(

--- a/packages/oxlint-config/src/index.test.ts
+++ b/packages/oxlint-config/src/index.test.ts
@@ -414,7 +414,7 @@ describe("oxlint-config", () => {
           plugins: ["unsupported-plugin"],
           rules: {},
         }),
-      ).rejects.toThrow('Unsupported oxlint plugin "unsupported-plugin" in base.json.');
+      ).rejects.toThrow('Unsupported oxlint plugin "unsupported-plugin".');
     });
 
     it("throws when base.json is not an object", async () => {
@@ -452,6 +452,19 @@ describe("oxlint-config", () => {
           rules: {},
         }),
       ).rejects.toThrow("The bundled base.json file is not a valid oxlint config preset.");
+    });
+
+    it("throws when vitest.json is not a valid preset", async () => {
+      await expect(
+        loadPresetsModuleWithVitestJson(
+          {
+            overrides: [],
+            plugins: ["import"],
+            rules: {},
+          },
+          "not-an-object",
+        ),
+      ).rejects.toThrow("The bundled vitest.json file is not a valid oxlint config preset.");
     });
 
     it("supports valid overrides without rules", async () => {
@@ -518,10 +531,23 @@ function getFirstOverrideFiles(config: {
 }
 
 async function loadPresetsModule(baseJson: unknown): Promise<unknown> {
+  return loadPresetsModuleWithVitestJson(baseJson);
+}
+
+async function loadPresetsModuleWithVitestJson(
+  baseJson: unknown,
+  vitestJson?: unknown,
+): Promise<unknown> {
   vi.resetModules();
   // oxlint-disable-next-line jest/no-untyped-mock-factory -- conflicts with consistent-type-imports
   vi.doMock("node:fs", () => ({
-    readFileSync: vi.fn<() => string>(() => JSON.stringify(baseJson)),
+    readFileSync: vi.fn<(filePath: string) => string>((filePath) => {
+      if (vitestJson !== undefined && filePath.includes("vitest.json")) {
+        return JSON.stringify(vitestJson);
+      }
+
+      return JSON.stringify(baseJson);
+    }),
   }));
 
   return await import("./internal/presets");

--- a/packages/oxlint-config/src/internal/presets.ts
+++ b/packages/oxlint-config/src/internal/presets.ts
@@ -108,7 +108,7 @@ function normalizePlugins(plugins: string[]): OxlintPluginName[] {
       return plugin;
     }
 
-    throw new Error(`Unsupported oxlint plugin "${plugin}" in base.json.`);
+    throw new Error(`Unsupported oxlint plugin "${plugin}".`);
   });
 }
 

--- a/packages/oxlint-config/src/internal/presets.ts
+++ b/packages/oxlint-config/src/internal/presets.ts
@@ -57,19 +57,7 @@ export const jest: OxlintPreset = {
   plugins: ["jest"],
   rules: JEST_RULES,
 };
-export const vitest: OxlintPreset = {
-  plugins: ["vitest"],
-  rules: {
-    ...JEST_RULES,
-    "vitest/prefer-importing-vitest-globals": "off",
-    "vitest/prefer-called-once": "off",
-    "vitest/prefer-import-in-mock": "off",
-    "vitest/prefer-to-be-falsy": "off",
-    "vitest/prefer-to-be-truthy": "off",
-    "vitest/require-hook": "off",
-    "vitest/require-test-timeout": "off",
-  },
-};
+export const vitest: OxlintPreset = createVitestPreset();
 
 function createBasePreset(): OxlintPreset {
   const parsedBaseJson = loadBaseJson();
@@ -122,6 +110,20 @@ function normalizePlugins(plugins: string[]): OxlintPluginName[] {
 
     throw new Error(`Unsupported oxlint plugin "${plugin}" in base.json.`);
   });
+}
+
+function createVitestPreset(): OxlintPreset {
+  const vitestJsonPath = path.resolve(__dirname, "../vitest.json");
+  const json = parseUnknownJson(readFileSync(vitestJsonPath, "utf8"));
+
+  if (!isPlainObject(json) || !isStringArray(json["plugins"]) || !isRuleMap(json["rules"])) {
+    throw new Error("The bundled vitest.json file is not a valid oxlint config preset.");
+  }
+
+  return {
+    plugins: normalizePlugins(json["plugins"].filter((p) => !base.plugins?.some((bp) => bp === p))),
+    rules: json["rules"],
+  };
 }
 
 function loadBaseJson(): BaseJsonConfig {

--- a/packages/oxlint-config/src/vitest.json
+++ b/packages/oxlint-config/src/vitest.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["./base.json"],
+  "plugins": ["eslint", "typescript", "unicorn", "oxc", "import", "node", "promise", "vitest"],
+  "rules": {
+    "jest/max-expects": "off",
+    "jest/max-nested-describe": "off",
+    "jest/no-hooks": "off",
+    "jest/prefer-lowercase-title": "off",
+    "jest/valid-title": ["error", { "ignoreTypeOfDescribeName": true }],
+    "vitest/prefer-importing-vitest-globals": "off",
+    "vitest/prefer-called-once": "off",
+    "vitest/prefer-import-in-mock": "off",
+    "vitest/prefer-to-be-falsy": "off",
+    "vitest/prefer-to-be-truthy": "off",
+    "vitest/require-hook": "off",
+    "vitest/require-test-timeout": "off"
+  }
+}


### PR DESCRIPTION
## Summary

The root `.oxlintrc.json` had to manually duplicate 12 vitest rules from `presets.ts` because oxlint's JSON `extends` overwrites (rather than appends) the `plugins` array. This made it easy for the two to drift out of sync.

- Add `vitest.json` preset that includes all plugins (base + vitest) and vitest rules, so JSON consumers can `"extends": ["vitest.json"]` directly
- Update `presets.ts` to read vitest rules from `vitest.json` at build time, making it the single source of truth for both JSON and TS consumers
- Remove the 12 duplicated vitest rules from the root `.oxlintrc.json`

## Test plan

- [x] `npm run lint` passes (0 warnings, 0 errors)
- [x] `nx run oxlint-config:build` succeeds and `vitest.json` is included in dist output
- [x] `nx run oxlint-config:test` passes — existing `toStrictEqual` assertion on the vitest preset validates that `vitest.json` stays in sync
- [x] Verified removing a rule or plugin from `vitest.json` causes test failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/clipboardhealth/core-utils/pull/550" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
