### PR TITLE
feat(contract-core): add commaSeparatedArray schema helper

### DIFF
--- a/packages/contract-core/README.md
+++ b/packages/contract-core/README.md
@@ -19,6 +19,30 @@ npm install @clipboard-health/contract-core
 
 ### Zod schemas
 
+#### Comma-separated array schema
+
+`commaSeparatedArray(itemSchema)` validates comma-separated string or array inputs and normalizes them to typed arrays. Designed for shared contracts where the server receives comma-separated query strings and the client passes typed arrays.
+
+```ts
+// z.input  → string | string[]
+// z.output → string[]
+commaSeparatedArray(nonEmptyString).optional();
+
+// z.input  → string | ("CNA" | "RN" | "LVN")[]
+// z.output → ("CNA" | "RN" | "LVN")[]
+commaSeparatedArray(requiredEnum(["CNA", "RN", "LVN"]));
+
+// z.input  → string | string[]
+// z.output → string[]  (each validated as ObjectId)
+commaSeparatedArray(objectId);
+
+// z.input  → string | (string | Date)[]
+// z.output → Date[]
+commaSeparatedArray(dateTimeSchema());
+```
+
+Composes with all contract-core schemas and enum helpers. Replaces `z.preprocess(splitString, z.array(...))` with proper `z.input` typing (the `splitString` pattern erases input types to `unknown`).
+
 #### DateTime schema
 
 `dateTimeSchema()` validates strict ISO-8601 datetime strings and transforms them to `Date` objects. Unlike `z.coerce.date()`, it rejects loose inputs like epoch numbers and date-only strings. Composable with `.optional()`, `.nullable()`, etc. at the call site.
@@ -58,9 +82,11 @@ requiredEnum(widened); // TS error
 import {
   apiErrors,
   booleanString,
+  commaSeparatedArray,
   dateTimeSchema,
   ENUM_FALLBACK,
   nonEmptyString,
+  objectId,
   optionalEnum,
   optionalEnumWithFallback,
   requiredEnum,
@@ -84,6 +110,35 @@ apiErrors.parse({
     },
   ],
 });
+
+// Comma-separated array examples
+// Designed for shared contracts: server receives "CNA,RN" (string), client passes ["CNA", "RN"] (array).
+// Both normalize to the same typed array output.
+const workerTypes = commaSeparatedArray(requiredEnum(["CNA", "RN", "LVN"]));
+
+// Server-side: comma-separated string from query params
+const fromString = workerTypes.parse("CNA,RN");
+// => ["CNA", "RN"]
+console.log(fromString);
+
+// Client-side: typed array
+const fromArray = workerTypes.parse(["CNA", "LVN"]);
+// => ["CNA", "LVN"]
+console.log(fromArray);
+
+// Composes with other schemas
+const workerIds = commaSeparatedArray(objectId).optional();
+const dates = commaSeparatedArray(dateTimeSchema());
+
+// Works with .optional()
+// eslint-disable-next-line unicorn/no-useless-undefined
+const noIds = workerIds.parse(undefined);
+// => undefined
+console.log(noIds);
+
+const someDates = dates.parse("2026-01-01T00:00:00.000Z,2026-01-02T00:00:00.000Z");
+// => [Date, Date]
+console.log(someDates[0] instanceof Date); // true
 
 booleanString.parse("true");
 

--- a/packages/contract-core/examples/schemas.ts
+++ b/packages/contract-core/examples/schemas.ts
@@ -2,9 +2,11 @@
 import {
   apiErrors,
   booleanString,
+  commaSeparatedArray,
   dateTimeSchema,
   ENUM_FALLBACK,
   nonEmptyString,
+  objectId,
   optionalEnum,
   optionalEnumWithFallback,
   requiredEnum,
@@ -28,6 +30,35 @@ apiErrors.parse({
     },
   ],
 });
+
+// Comma-separated array examples
+// Designed for shared contracts: server receives "CNA,RN" (string), client passes ["CNA", "RN"] (array).
+// Both normalize to the same typed array output.
+const workerTypes = commaSeparatedArray(requiredEnum(["CNA", "RN", "LVN"]));
+
+// Server-side: comma-separated string from query params
+const fromString = workerTypes.parse("CNA,RN");
+// => ["CNA", "RN"]
+console.log(fromString);
+
+// Client-side: typed array
+const fromArray = workerTypes.parse(["CNA", "LVN"]);
+// => ["CNA", "LVN"]
+console.log(fromArray);
+
+// Composes with other schemas
+const workerIds = commaSeparatedArray(objectId).optional();
+const dates = commaSeparatedArray(dateTimeSchema());
+
+// Works with .optional()
+// eslint-disable-next-line unicorn/no-useless-undefined
+const noIds = workerIds.parse(undefined);
+// => undefined
+console.log(noIds);
+
+const someDates = dates.parse("2026-01-01T00:00:00.000Z,2026-01-02T00:00:00.000Z");
+// => [Date, Date]
+console.log(someDates[0] instanceof Date); // true
 
 booleanString.parse("true");
 

--- a/packages/contract-core/src/lib/schemas/commaSeparatedArray.test.ts
+++ b/packages/contract-core/src/lib/schemas/commaSeparatedArray.test.ts
@@ -1,0 +1,282 @@
+import {
+  expectToBeSafeParseError,
+  expectToBeSafeParseSuccess,
+} from "@clipboard-health/testing-core";
+import { z } from "zod";
+
+import { commaSeparatedArray } from "./commaSeparatedArray";
+import { dateTimeSchema } from "./dateTime";
+import {
+  ENUM_FALLBACK,
+  optionalEnum,
+  optionalEnumWithFallback,
+  requiredEnum,
+  requiredEnumWithFallback,
+} from "./enum";
+import { nonEmptyString } from "./nonEmptyString";
+import { objectId } from "./objectId";
+
+const WORKER_TYPES = ["CNA", "RN", "LVN"] as const;
+const VALID_OBJECT_ID = "507f1f77bcf86cd799439011";
+const VALID_OBJECT_ID_2 = "507f1f77bcf86cd799439012";
+
+describe(commaSeparatedArray, () => {
+  describe("with nonEmptyString", () => {
+    const schema = commaSeparatedArray(nonEmptyString);
+
+    describe("success cases", () => {
+      it.each<{ expected: string[]; input: unknown; name: string }>([
+        {
+          name: "splits comma-separated string into array",
+          input: "CNA,RN,LVN",
+          expected: ["CNA", "RN", "LVN"],
+        },
+        {
+          name: "handles single-value string",
+          input: "CNA",
+          expected: ["CNA"],
+        },
+        {
+          name: "passes through array unchanged",
+          input: ["CNA", "RN"],
+          expected: ["CNA", "RN"],
+        },
+        {
+          name: "handles single-element array",
+          input: ["CNA"],
+          expected: ["CNA"],
+        },
+      ])("$name", ({ input, expected }) => {
+        const actual = schema.safeParse(input);
+
+        expectToBeSafeParseSuccess(actual);
+        expect(actual.data).toStrictEqual(expected);
+      });
+    });
+
+    describe("error cases", () => {
+      it.each<{ input: unknown; name: string }>([
+        { name: "rejects empty string items after split", input: "CNA,,RN" },
+        { name: "rejects number", input: 42 },
+        { name: "rejects undefined", input: undefined },
+        { name: "rejects null", input: null },
+        { name: "rejects object", input: {} },
+        { name: "rejects array with invalid items", input: [42, true] },
+      ])("$name", ({ input }) => {
+        const actual = schema.safeParse(input);
+
+        expectToBeSafeParseError(actual);
+      });
+    });
+  });
+
+  describe("with objectId", () => {
+    const schema = commaSeparatedArray(objectId);
+
+    it("splits comma-separated ObjectIds", () => {
+      const input = `${VALID_OBJECT_ID},${VALID_OBJECT_ID_2}`;
+
+      const actual = schema.safeParse(input);
+
+      expectToBeSafeParseSuccess(actual);
+      expect(actual.data).toStrictEqual([VALID_OBJECT_ID, VALID_OBJECT_ID_2]);
+    });
+
+    it("passes through ObjectId array", () => {
+      const input = [VALID_OBJECT_ID, VALID_OBJECT_ID_2];
+
+      const actual = schema.safeParse(input);
+
+      expectToBeSafeParseSuccess(actual);
+      expect(actual.data).toStrictEqual([VALID_OBJECT_ID, VALID_OBJECT_ID_2]);
+    });
+
+    it("rejects invalid ObjectIds in comma-separated string", () => {
+      const actual = schema.safeParse(`${VALID_OBJECT_ID},not-an-id`);
+
+      expectToBeSafeParseError(actual);
+    });
+
+    it("rejects invalid ObjectIds in array", () => {
+      const actual = schema.safeParse([VALID_OBJECT_ID, "not-an-id"]);
+
+      expectToBeSafeParseError(actual);
+    });
+  });
+
+  describe("with requiredEnum", () => {
+    const schema = commaSeparatedArray(requiredEnum([...WORKER_TYPES]));
+
+    it("splits comma-separated enum values", () => {
+      const actual = schema.safeParse("CNA,RN");
+
+      expectToBeSafeParseSuccess(actual);
+      expect(actual.data).toStrictEqual(["CNA", "RN"]);
+    });
+
+    it("passes through enum array", () => {
+      const actual = schema.safeParse(["CNA", "LVN"]);
+
+      expectToBeSafeParseSuccess(actual);
+      expect(actual.data).toStrictEqual(["CNA", "LVN"]);
+    });
+
+    it("rejects invalid enum value in comma-separated string", () => {
+      const actual = schema.safeParse("CNA,INVALID");
+
+      expectToBeSafeParseError(actual);
+    });
+
+    it("rejects invalid enum value in array", () => {
+      const actual = schema.safeParse(["CNA", "INVALID"]);
+
+      expectToBeSafeParseError(actual);
+    });
+  });
+
+  describe("with optionalEnum", () => {
+    const schema = commaSeparatedArray(optionalEnum([...WORKER_TYPES]));
+
+    it("splits comma-separated enum values", () => {
+      const actual = schema.safeParse("CNA,RN");
+
+      expectToBeSafeParseSuccess(actual);
+      expect(actual.data).toStrictEqual(["CNA", "RN"]);
+    });
+
+    it("passes through enum array", () => {
+      const actual = schema.safeParse(["CNA", "LVN"]);
+
+      expectToBeSafeParseSuccess(actual);
+      expect(actual.data).toStrictEqual(["CNA", "LVN"]);
+    });
+
+    it("rejects invalid enum value in comma-separated string", () => {
+      const actual = schema.safeParse("CNA,INVALID");
+
+      expectToBeSafeParseError(actual);
+    });
+  });
+
+  describe("with requiredEnumWithFallback", () => {
+    const schema = commaSeparatedArray(requiredEnumWithFallback([...WORKER_TYPES]));
+
+    it("splits comma-separated enum values", () => {
+      const actual = schema.safeParse("CNA,RN");
+
+      expectToBeSafeParseSuccess(actual);
+      expect(actual.data).toStrictEqual(["CNA", "RN"]);
+    });
+
+    it("coerces unrecognized values to ENUM_FALLBACK", () => {
+      const actual = schema.safeParse("CNA,UNKNOWN");
+
+      expectToBeSafeParseSuccess(actual);
+      expect(actual.data).toStrictEqual(["CNA", ENUM_FALLBACK]);
+    });
+
+    it("passes through enum array", () => {
+      const actual = schema.safeParse(["CNA", "LVN"]);
+
+      expectToBeSafeParseSuccess(actual);
+      expect(actual.data).toStrictEqual(["CNA", "LVN"]);
+    });
+
+    it("coerces unrecognized values in array to ENUM_FALLBACK", () => {
+      const actual = schema.safeParse(["CNA", "UNKNOWN"]);
+
+      expectToBeSafeParseSuccess(actual);
+      expect(actual.data).toStrictEqual(["CNA", ENUM_FALLBACK]);
+    });
+  });
+
+  describe("with optionalEnumWithFallback", () => {
+    const schema = commaSeparatedArray(optionalEnumWithFallback([...WORKER_TYPES]));
+
+    it("splits comma-separated enum values", () => {
+      const actual = schema.safeParse("CNA,RN");
+
+      expectToBeSafeParseSuccess(actual);
+      expect(actual.data).toStrictEqual(["CNA", "RN"]);
+    });
+
+    it("coerces unrecognized values to ENUM_FALLBACK", () => {
+      const actual = schema.safeParse("CNA,UNKNOWN");
+
+      expectToBeSafeParseSuccess(actual);
+      expect(actual.data).toStrictEqual(["CNA", ENUM_FALLBACK]);
+    });
+
+    it("passes through enum array", () => {
+      const actual = schema.safeParse(["CNA", "LVN"]);
+
+      expectToBeSafeParseSuccess(actual);
+      expect(actual.data).toStrictEqual(["CNA", "LVN"]);
+    });
+  });
+
+  describe("with dateTimeSchema()", () => {
+    const schema = commaSeparatedArray(dateTimeSchema());
+
+    it("splits comma-separated datetime strings", () => {
+      const input = "2026-01-01T00:00:00.000Z,2026-01-02T00:00:00.000Z";
+
+      const actual = schema.safeParse(input);
+
+      expectToBeSafeParseSuccess(actual);
+      expect(actual.data).toHaveLength(2);
+      expect(actual.data[0]).toBeInstanceOf(Date);
+      expect(actual.data[1]).toBeInstanceOf(Date);
+      expect(actual.data[0]?.toISOString()).toBe("2026-01-01T00:00:00.000Z");
+      expect(actual.data[1]?.toISOString()).toBe("2026-01-02T00:00:00.000Z");
+    });
+
+    it("passes through Date array", () => {
+      const input = [new Date("2026-01-01T00:00:00.000Z"), new Date("2026-01-02T00:00:00.000Z")];
+
+      const actual = schema.safeParse(input);
+
+      expectToBeSafeParseSuccess(actual);
+      expect(actual.data).toHaveLength(2);
+      expect(actual.data[0]?.toISOString()).toBe("2026-01-01T00:00:00.000Z");
+      expect(actual.data[1]?.toISOString()).toBe("2026-01-02T00:00:00.000Z");
+    });
+
+    it("rejects invalid datetime in comma-separated string", () => {
+      const actual = schema.safeParse("not-a-date,2026-01-01T00:00:00.000Z");
+
+      expectToBeSafeParseError(actual);
+    });
+  });
+
+  describe("composability", () => {
+    it("composes with .optional()", () => {
+      const schema = commaSeparatedArray(nonEmptyString).optional();
+
+      // eslint-disable-next-line unicorn/no-useless-undefined
+      const undef = schema.safeParse(undefined);
+      expectToBeSafeParseSuccess(undef);
+      expect(undef.data).toBeUndefined();
+
+      const valid = schema.safeParse("a,b");
+      expectToBeSafeParseSuccess(valid);
+      expect(valid.data).toStrictEqual(["a", "b"]);
+    });
+  });
+
+  describe("error cases", () => {
+    const schema = commaSeparatedArray(z.string());
+
+    it.each<{ input: unknown; name: string }>([
+      { name: "rejects number", input: 42 },
+      { name: "rejects boolean", input: true },
+      { name: "rejects undefined", input: undefined },
+      { name: "rejects null", input: null },
+      { name: "rejects object", input: {} },
+    ])("$name", ({ input }) => {
+      const actual = schema.safeParse(input);
+
+      expectToBeSafeParseError(actual);
+    });
+  });
+});

--- a/packages/contract-core/src/lib/schemas/commaSeparatedArray.ts
+++ b/packages/contract-core/src/lib/schemas/commaSeparatedArray.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+/**
+ * Validates comma-separated string or array inputs and normalizes them to typed arrays.
+ *
+ * Accepts:
+ * - Comma-separated strings (split and validated per item)
+ * - Arrays of items (validated per item)
+ *
+ * Designed for shared contracts where the server receives comma-separated query strings
+ * and the client passes typed arrays.
+ *
+ * Composable with `.optional()`, `.nullable()`, etc. at the call site:
+ * ```ts
+ * z.object({
+ *   workerTypes: commaSeparatedArray(z.string().min(1)).optional(),
+ *   dates: commaSeparatedArray(dateTimeSchema()).optional(),
+ * });
+ * ```
+ *
+ * z.input  → string | T[]  (where T is z.input of the item schema)
+ * z.output → T[]           (where T is z.output of the item schema)
+ */
+export function commaSeparatedArray<T extends z.ZodTypeAny>(itemSchema: T) {
+  return z
+    .union([z.string().transform((value) => value.split(",")), z.array(itemSchema)])
+    .pipe(z.array(itemSchema));
+}

--- a/packages/contract-core/src/lib/schemas/index.ts
+++ b/packages/contract-core/src/lib/schemas/index.ts
@@ -1,5 +1,6 @@
 export * from "./apiError";
 export * from "./booleanString";
+export * from "./commaSeparatedArray";
 export * from "./dateTime";
 export * from "./enum";
 export * from "./money";


### PR DESCRIPTION
## Summary
- Adds `commaSeparatedArray(itemSchema)` to `@clipboard-health/contract-core` for shared contracts where the server receives comma-separated query strings and the client passes typed arrays
- Preserves proper `z.input` / `z.output` typing, replacing `z.preprocess(splitString, ...)` which erases input types to `unknown`
- Composes with all contract-core schemas: `requiredEnum`, `optionalEnum`, `requiredEnumWithFallback`, `optionalEnumWithFallback`, `objectId`, `nonEmptyString`, `dateTimeSchema`

Part of [ATD-215](https://linear.app/clipboardhealth/issue/ATD-215) / [ATD-216](https://linear.app/clipboardhealth/issue/ATD-216)

## Test plan
- [x] 37 unit tests covering all schema compositions, string splitting, array passthrough, error cases, and composability
- [x] TypeScript type inference verified for all compositions
- [x] Pre-commit hooks pass (lint, spell check, embed sync, format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)