### PR TITLE
fix: tidy trailing punctuation in oxlint-config comment

### DIFF
--- a/packages/oxlint-config/src/internal/createOxlintConfig.ts
+++ b/packages/oxlint-config/src/internal/createOxlintConfig.ts
@@ -126,7 +126,7 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-// Wrapper to allow swapping clone strategies if needed
+// Wrapper to allow swapping clone strategies if needed.
 function cloneValue<Value>(value: Value): Value {
   return structuredClone(value);
 }


### PR DESCRIPTION
## Summary
- Add trailing period to a code comment in `packages/oxlint-config/src/internal/createOxlintConfig.ts` for consistency.

## Test plan
- [x] CI affected build/lint/test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/clipboardhealth/core-utils/pull/575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
