### PR TITLE
feat(playwright-reporter-llm): switch trace correlation to W3C traceparent

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -109,6 +109,8 @@
     "Timestamptz",
     "TOCTOU",
     "toplevel",
+    "traceparent",
+    "tracestate",
     "triaging",
     "trunc",
     "tsgo",

--- a/packages/playwright-reporter-llm/README.md
+++ b/packages/playwright-reporter-llm/README.md
@@ -6,6 +6,13 @@ Playwright reporter that outputs structured JSON for LLM agents. Minimal console
 
 - [Install](#install)
 - [Usage](#usage)
+  - [Options](#options)
+  - [Console output](#console-output)
+  - [What to read, by task](#what-to-read-by-task)
+  - [Minimal failure example](#minimal-failure-example)
+  - [Flaky test example (pass-vs-fail comparison)](#flaky-test-example-pass-vs-fail-comparison)
+  - [Full example report](#full-example-report)
+  - [Field reference](#field-reference)
 - [Local development commands](#local-development-commands)
 
 ## Install
@@ -41,189 +48,188 @@ export default defineConfig({
 Report: test-results/llm-report.json
 ```
 
-### Report schema
+### What to read, by task
+
+| Task                         | Fields                                                                                                                                                           |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Pass/fail overview           | `summary`                                                                                                                                                        |
+| Triage failures              | Filter `tests[]` by `status === "failed"`, then read `errors[0].{message,diff,location,snippet}`                                                                 |
+| Identify flakes              | Filter `tests[]` by `flaky === true`; compare `attempts[]` statuses                                                                                              |
+| Reconstruct failure timeline | Pick an attempt where `status !== "passed"` (for flakes this is NOT the last attempt), then read `.timeline[]` (steps + network + console, sorted by `offsetMs`) |
+| Inspect failing requests     | `tests[].attempts[].network[]` — filter by `status >= 400`, `failureText`, or `wasAborted`                                                                       |
+| Correlate with backend trace | `tests[].attempts[].network[].traceId` and `.spanId` (parsed from W3C `traceparent` — works with OpenTelemetry, Datadog, Jaeger, Tempo, Honeycomb, etc.)         |
+| Debug uncaught page errors   | `tests[].attempts[].consoleMessages[]` — filter by `type` in `"error" \| "pageerror" \| "page-crashed"`                                                          |
+| Visual debugging             | `tests[].attempts[].failureArtifacts.{screenshotBase64,videoPath}`                                                                                               |
+
+### Minimal failure example
+
+Walk `attempts[].timeline[]` (steps + network + console, sorted by `offsetMs`) to reconstruct the failure:
 
 ```json
 {
   "schemaVersion": 2,
-  "timestamp": "2026-02-25T19:00:00.000Z",
-  "durationMs": 4200,
   "summary": {
-    "total": 26,
-    "passed": 23,
-    "failed": 2,
+    "total": 10,
+    "passed": 9,
+    "failed": 1,
     "flaky": 0,
-    "skipped": 1,
+    "skipped": 0,
     "timedOut": 0,
     "interrupted": 0
-  },
-  "environment": {
-    "playwrightVersion": "1.58.2",
-    "nodeVersion": "v24.13.1",
-    "os": "darwin",
-    "workers": 4,
-    "retries": 1,
-    "projects": ["chromium"]
   },
   "tests": [
     {
       "id": "abc123",
-      "title": "Suite > passes on retry",
-      "status": "passed",
-      "flaky": true,
-      "durationMs": 88,
-      "location": { "file": "tests/example.spec.ts", "line": 10, "column": 5 },
-      "project": "chromium",
-      "tags": [],
-      "annotations": [],
-      "retries": 1,
-      "errors": [],
-      "attachments": [],
-      "stdout": "",
-      "stderr": "",
-      "steps": [],
-      "network": [],
-      "timeline": [],
+      "title": "Checkout > applies discount code",
+      "status": "failed",
+      "flaky": false,
+      "location": { "file": "tests/checkout.spec.ts", "line": 42, "column": 5 },
+      "errors": [
+        {
+          "message": "Expected: 90\nReceived: 100",
+          "diff": { "expected": "90", "actual": "100" },
+          "location": { "file": "tests/checkout.spec.ts", "line": 58, "column": 7 }
+        }
+      ],
       "attempts": [
         {
           "attempt": 1,
           "status": "failed",
-          "durationMs": 44,
-          "startTime": "2026-02-25T19:00:00.000Z",
-          "workerIndex": 0,
-          "parallelIndex": 0,
-          "error": {
-            "message": "Expected: 1, Received: 2"
-          },
-          "steps": [
-            {
-              "title": "outer step",
-              "category": "test.step",
-              "durationMs": 20,
-              "depth": 0,
-              "offsetMs": 100
-            },
-            {
-              "title": "inner assertion",
-              "category": "pw:api",
-              "durationMs": 6,
-              "depth": 1,
-              "offsetMs": 120,
-              "error": "Expected: 1, Received: 2"
-            }
-          ],
-          "stdout": "",
-          "stderr": "",
-          "consoleMessages": [
-            { "type": "warning", "text": "deprecated API used", "offsetMs": 150 },
-            { "type": "error", "text": "failed to fetch", "offsetMs": 200 },
-            { "type": "pageerror", "text": "Uncaught TypeError: x is undefined", "offsetMs": 250 },
-            { "type": "page-closed", "text": "Page closed", "offsetMs": 300 }
-          ],
-          "attachments": [
-            { "name": "trace", "contentType": "application/zip", "path": "trace.zip" }
-          ],
-          "failureArtifacts": {
-            "screenshotBase64": "iVBORw0KGgo...",
-            "videoPath": "retry-video.webm"
-          },
-          "network": [
-            {
-              "method": "GET",
-              "url": "https://app.example.com/start",
-              "status": 302,
-              "durationMs": 27,
-              "offsetMs": 50,
-              "traceId": "12345",
-              "redirectToUrl": "https://app.example.com/final",
-              "redirectChain": [
-                { "url": "https://app.example.com/start", "status": 302 },
-                { "url": "https://app.example.com/final", "status": 200 }
-              ],
-              "timings": {
-                "dnsMs": 2,
-                "connectMs": 7,
-                "sslMs": 4,
-                "sendMs": 1,
-                "waitMs": 12,
-                "receiveMs": 5
-              },
-              "requestHeaders": {
-                "content-type": "application/json"
-              },
-              "responseHeaders": {
-                "location": "https://app.example.com/final",
-                "x-datadog-trace-id": "12345",
-                "x-datadog-span-id": "67890"
-              }
-            }
-          ],
+          "failureArtifacts": { "screenshotBase64": "iVBORw0KGgo...", "videoPath": "video.webm" },
           "timeline": [
             {
-              "kind": "network",
-              "offsetMs": 50,
-              "method": "GET",
-              "url": "https://app.example.com/start",
-              "status": 302,
-              "durationMs": 27,
-              "traceId": "12345"
-            },
-            {
               "kind": "step",
-              "offsetMs": 100,
-              "title": "outer step",
+              "offsetMs": 1050,
+              "title": "click Apply",
               "category": "test.step",
-              "durationMs": 20,
+              "durationMs": 40,
               "depth": 0
             },
             {
-              "kind": "step",
-              "offsetMs": 120,
-              "title": "inner assertion",
-              "category": "pw:api",
-              "durationMs": 6,
-              "depth": 1,
-              "error": "Expected: 1, Received: 2"
+              "kind": "network",
+              "offsetMs": 1100,
+              "method": "POST",
+              "url": "https://api.example.com/discount",
+              "status": 500,
+              "traceId": "4bf92f3577b34da6a3ce929d0e0e4736",
+              "spanId": "00f067aa0ba902b7"
             },
             {
               "kind": "console",
-              "offsetMs": 150,
-              "type": "warning",
-              "text": "deprecated API used"
-            },
-            { "kind": "console", "offsetMs": 200, "type": "error", "text": "failed to fetch" },
-            {
-              "kind": "console",
-              "offsetMs": 250,
+              "offsetMs": 1240,
               "type": "pageerror",
-              "text": "Uncaught TypeError: x is undefined"
+              "text": "Uncaught TypeError: discount is undefined"
             },
-            { "kind": "console", "offsetMs": 300, "type": "page-closed", "text": "Page closed" }
+            {
+              "kind": "step",
+              "offsetMs": 1300,
+              "title": "expect total to equal 90",
+              "category": "pw:api",
+              "durationMs": 5,
+              "depth": 0,
+              "error": "Expected: 90\nReceived: 100"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+Reads as: click Apply → backend returned 500 → page threw → assertion failed. `traceId` lets you correlate the 500 with your tracing backend (Datadog, Jaeger, Tempo, Honeycomb, etc.).
+
+### Flaky test example (pass-vs-fail comparison)
+
+For a test that fails on attempt 1 and passes on attempt 2, the divergence between the two timelines is the diagnosis. Find the first entry that differs:
+
+```json
+{
+  "tests": [
+    {
+      "title": "Checkout > shows confirmation",
+      "status": "passed",
+      "flaky": true,
+      "attempts": [
+        {
+          "attempt": 1,
+          "status": "failed",
+          "timeline": [
+            {
+              "kind": "step",
+              "offsetMs": 800,
+              "title": "goto /checkout",
+              "category": "test.step",
+              "durationMs": 120,
+              "depth": 0
+            },
+            {
+              "kind": "network",
+              "offsetMs": 950,
+              "method": "GET",
+              "url": "https://api.example.com/cart",
+              "status": 200
+            },
+            {
+              "kind": "step",
+              "offsetMs": 1400,
+              "title": "expect banner visible",
+              "category": "pw:api",
+              "durationMs": 5000,
+              "depth": 0,
+              "error": "Timeout 5000ms exceeded"
+            }
           ]
         },
         {
           "attempt": 2,
           "status": "passed",
-          "durationMs": 88,
-          "startTime": "2026-02-25T19:00:01.000Z",
-          "workerIndex": 0,
-          "parallelIndex": 0,
-          "steps": [],
-          "stdout": "",
-          "stderr": "",
-          "consoleMessages": [],
-          "attachments": [],
-          "network": [],
-          "timeline": []
+          "timeline": [
+            {
+              "kind": "step",
+              "offsetMs": 800,
+              "title": "goto /checkout",
+              "category": "test.step",
+              "durationMs": 120,
+              "depth": 0
+            },
+            {
+              "kind": "network",
+              "offsetMs": 950,
+              "method": "GET",
+              "url": "https://api.example.com/cart",
+              "status": 200
+            },
+            {
+              "kind": "network",
+              "offsetMs": 1100,
+              "method": "GET",
+              "url": "https://api.example.com/inventory",
+              "status": 200
+            },
+            {
+              "kind": "step",
+              "offsetMs": 1350,
+              "title": "expect banner visible",
+              "category": "pw:api",
+              "durationMs": 40,
+              "depth": 0
+            }
+          ]
         }
       ]
     }
-  ],
-  "globalErrors": []
+  ]
 }
 ```
 
-Key fields for agents:
+Divergence: the passing attempt made an extra `/inventory` call that the failing attempt didn't. That's either a stale frontend cache or a race — not a flaky test, a real bug.
+
+### Full example report
+
+See [`docs/example-report.json`](./docs/example-report.json) for a complete report with every optional field populated (network timings, redirect chains, headers, attachments, step nesting, multi-attempt retries).
+
+### Field reference
 
 - **`summary`** -- quick pass/fail counts
 - **`tests[].errors[].message`** -- ANSI-stripped, clean error text
@@ -235,9 +241,9 @@ Key fields for agents:
 - **`tests[].steps` / `tests[].network` / `tests[].timeline`** -- convenience aliases from the final attempt
 - **`tests[].attempts[].timeline[]`** -- unified, sorted-by-`offsetMs` array of all retained events (`kind: "step" | "network" | "console"`). Slimmed-down entries for quick temporal scanning; full details remain in the source arrays
 - **`offsetMs`** -- milliseconds since the attempt's `startTime`. Always present on steps (from `TestStep.startTime`). Optional on network entries (from trace `_monotonicTime` or `startedDateTime`, converted via the trace's `context-options` anchor) and console entries (from trace monotonic `time` field + anchor). Absent when the trace lacks a `context-options` event. Entries without `offsetMs` are excluded from the timeline
-- **`tests[].attempts[].network[].traceId`** -- promoted from `x-datadog-trace-id` header for direct access
-- **`tests[].attempts[].network[]`** -- max 200 per attempt, priority-based: fetch/xhr requests, error responses (status >= 400), failed, and aborted requests are retained over static assets (script, stylesheet, image, font). Includes failure details (`failureText`, `wasAborted`), redirect chain (`redirectToUrl`, `redirectFromUrl`, `redirectChain`), timing breakdown (`timings`), `durationMs` derived from available timing components, and allowlisted headers (`requestHeaders`, `responseHeaders`)
-- **`tests[].attempts[].network[].responseHeaders`** -- includes `x-datadog-trace-id` and `x-datadog-span-id` when present (values capped to 256 chars)
+- **`tests[].attempts[].network[].traceId`** / **`spanId`** -- parsed from the W3C Trace Context [`traceparent`](https://www.w3.org/TR/trace-context/) header (preferring response over request). `traceId` is 32 hex chars (128-bit), `spanId` is 16 hex chars (64-bit). Compatible with OpenTelemetry and Datadog (dd-trace ≥ 2.0 emits `traceparent` by default). Malformed or all-zero values are rejected.
+- **`tests[].attempts[].network[]`** -- max 200 per attempt, priority-based: fetch/xhr requests, error responses (status >= 400), failed, and aborted requests are retained over static assets (script, stylesheet, image, font, media). Includes failure details (`failureText`, `wasAborted`), redirect chain (`redirectToUrl`, `redirectFromUrl`, `redirectChain`), timing breakdown (`timings`), `durationMs` derived from available timing components, allowlisted headers (`requestHeaders`, `responseHeaders`), and JSON/text `requestBody` / `responseBody` pulled from the trace archive (capped at 2KB with `[truncated]` marker)
+- **`tests[].attempts[].network[].requestHeaders`** / **`responseHeaders`** -- allowlisted only: `content-type`, `location` (response), `x-request-id`, `x-correlation-id`, `traceparent`, `tracestate`. Values capped at 256 chars.
 - **`tests[].attempts[].failureArtifacts`** -- for failing/timed-out/interrupted attempts: `screenshotBase64` (base64-encoded screenshot, max 512KB), `videoPath` (first video attachment path). Omitted entirely when neither screenshot nor video is available
 - **`tests[].attachments[].path`** -- relative to Playwright outputDir
 - **`tests[].stdout` / `tests[].stderr`** -- capped at 4KB with `[truncated]` marker

--- a/packages/playwright-reporter-llm/README.md
+++ b/packages/playwright-reporter-llm/README.md
@@ -227,7 +227,7 @@ Divergence: the passing attempt made an extra `/inventory` call that the failing
 
 ### Full example report
 
-See [`docs/example-report.json`](./docs/example-report.json) for a complete report with every optional field populated (network timings, redirect chains, headers, attachments, step nesting, multi-attempt retries).
+See [`docs/example-report.json`](./docs/example-report.json) for a complete report with representative optional fields populated (network timings, redirect chains, headers, attachments, step nesting, multi-attempt retries).
 
 ### Field reference
 

--- a/packages/playwright-reporter-llm/docs/example-report.json
+++ b/packages/playwright-reporter-llm/docs/example-report.json
@@ -3,11 +3,11 @@
   "timestamp": "2026-02-25T19:00:00.000Z",
   "durationMs": 4200,
   "summary": {
-    "total": 26,
-    "passed": 23,
-    "failed": 2,
-    "flaky": 0,
-    "skipped": 1,
+    "total": 1,
+    "passed": 0,
+    "failed": 0,
+    "flaky": 1,
+    "skipped": 0,
     "timedOut": 0,
     "interrupted": 0
   },

--- a/packages/playwright-reporter-llm/docs/example-report.json
+++ b/packages/playwright-reporter-llm/docs/example-report.json
@@ -1,0 +1,179 @@
+{
+  "schemaVersion": 2,
+  "timestamp": "2026-02-25T19:00:00.000Z",
+  "durationMs": 4200,
+  "summary": {
+    "total": 26,
+    "passed": 23,
+    "failed": 2,
+    "flaky": 0,
+    "skipped": 1,
+    "timedOut": 0,
+    "interrupted": 0
+  },
+  "environment": {
+    "playwrightVersion": "1.58.2",
+    "nodeVersion": "v24.13.1",
+    "os": "darwin",
+    "workers": 4,
+    "retries": 1,
+    "projects": ["chromium"]
+  },
+  "tests": [
+    {
+      "id": "abc123",
+      "title": "Suite > passes on retry",
+      "status": "passed",
+      "flaky": true,
+      "durationMs": 88,
+      "location": { "file": "tests/example.spec.ts", "line": 10, "column": 5 },
+      "project": "chromium",
+      "tags": [],
+      "annotations": [],
+      "retries": 1,
+      "errors": [],
+      "attachments": [],
+      "stdout": "",
+      "stderr": "",
+      "steps": [],
+      "network": [],
+      "timeline": [],
+      "attempts": [
+        {
+          "attempt": 1,
+          "status": "failed",
+          "durationMs": 44,
+          "startTime": "2026-02-25T19:00:00.000Z",
+          "workerIndex": 0,
+          "parallelIndex": 0,
+          "error": {
+            "message": "Expected: 1, Received: 2"
+          },
+          "steps": [
+            {
+              "title": "outer step",
+              "category": "test.step",
+              "durationMs": 20,
+              "depth": 0,
+              "offsetMs": 100
+            },
+            {
+              "title": "inner assertion",
+              "category": "pw:api",
+              "durationMs": 6,
+              "depth": 1,
+              "offsetMs": 120,
+              "error": "Expected: 1, Received: 2"
+            }
+          ],
+          "stdout": "",
+          "stderr": "",
+          "consoleMessages": [
+            { "type": "warning", "text": "deprecated API used", "offsetMs": 150 },
+            { "type": "error", "text": "failed to fetch", "offsetMs": 200 },
+            { "type": "pageerror", "text": "Uncaught TypeError: x is undefined", "offsetMs": 250 },
+            { "type": "page-closed", "text": "Page closed", "offsetMs": 300 }
+          ],
+          "attachments": [
+            { "name": "trace", "contentType": "application/zip", "path": "trace.zip" }
+          ],
+          "failureArtifacts": {
+            "screenshotBase64": "iVBORw0KGgo...",
+            "videoPath": "retry-video.webm"
+          },
+          "network": [
+            {
+              "method": "GET",
+              "url": "https://app.example.com/start",
+              "status": 302,
+              "durationMs": 27,
+              "offsetMs": 50,
+              "traceId": "4bf92f3577b34da6a3ce929d0e0e4736",
+              "spanId": "00f067aa0ba902b7",
+              "redirectToUrl": "https://app.example.com/final",
+              "redirectChain": [
+                { "url": "https://app.example.com/start", "status": 302 },
+                { "url": "https://app.example.com/final", "status": 200 }
+              ],
+              "timings": {
+                "dnsMs": 2,
+                "connectMs": 7,
+                "sslMs": 4,
+                "sendMs": 1,
+                "waitMs": 12,
+                "receiveMs": 5
+              },
+              "requestHeaders": {
+                "content-type": "application/json",
+                "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+              },
+              "responseHeaders": {
+                "location": "https://app.example.com/final",
+                "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+              }
+            }
+          ],
+          "timeline": [
+            {
+              "kind": "network",
+              "offsetMs": 50,
+              "method": "GET",
+              "url": "https://app.example.com/start",
+              "status": 302,
+              "durationMs": 27,
+              "traceId": "4bf92f3577b34da6a3ce929d0e0e4736",
+              "spanId": "00f067aa0ba902b7"
+            },
+            {
+              "kind": "step",
+              "offsetMs": 100,
+              "title": "outer step",
+              "category": "test.step",
+              "durationMs": 20,
+              "depth": 0
+            },
+            {
+              "kind": "step",
+              "offsetMs": 120,
+              "title": "inner assertion",
+              "category": "pw:api",
+              "durationMs": 6,
+              "depth": 1,
+              "error": "Expected: 1, Received: 2"
+            },
+            {
+              "kind": "console",
+              "offsetMs": 150,
+              "type": "warning",
+              "text": "deprecated API used"
+            },
+            { "kind": "console", "offsetMs": 200, "type": "error", "text": "failed to fetch" },
+            {
+              "kind": "console",
+              "offsetMs": 250,
+              "type": "pageerror",
+              "text": "Uncaught TypeError: x is undefined"
+            },
+            { "kind": "console", "offsetMs": 300, "type": "page-closed", "text": "Page closed" }
+          ]
+        },
+        {
+          "attempt": 2,
+          "status": "passed",
+          "durationMs": 88,
+          "startTime": "2026-02-25T19:00:01.000Z",
+          "workerIndex": 0,
+          "parallelIndex": 0,
+          "steps": [],
+          "stdout": "",
+          "stderr": "",
+          "consoleMessages": [],
+          "attachments": [],
+          "network": [],
+          "timeline": []
+        }
+      ]
+    }
+  ],
+  "globalErrors": []
+}

--- a/packages/playwright-reporter-llm/project.json
+++ b/packages/playwright-reporter-llm/project.json
@@ -8,7 +8,10 @@
     "build": {
       "executor": "@nx/js:tsc",
       "options": {
-        "assets": ["packages/playwright-reporter-llm/*.md"],
+        "assets": [
+          "packages/playwright-reporter-llm/*.md",
+          "packages/playwright-reporter-llm/docs/*.json"
+        ],
         "main": "packages/playwright-reporter-llm/src/index.js",
         "outputPath": "dist/packages/playwright-reporter-llm",
         "tsConfig": "packages/playwright-reporter-llm/tsconfig.lib.json"

--- a/packages/playwright-reporter-llm/src/lib/internal/attemptBuilder.ts
+++ b/packages/playwright-reporter-llm/src/lib/internal/attemptBuilder.ts
@@ -70,6 +70,10 @@ function buildTimeline(
         entry.traceId = request.traceId;
       }
 
+      if (request.spanId) {
+        entry.spanId = request.spanId;
+      }
+
       if (request.failureText) {
         entry.failureText = request.failureText;
       }

--- a/packages/playwright-reporter-llm/src/lib/internal/constants.ts
+++ b/packages/playwright-reporter-llm/src/lib/internal/constants.ts
@@ -11,9 +11,8 @@ export const REQUEST_HEADER_ALLOWLIST = new Set([
   "content-type",
   "x-request-id",
   "x-correlation-id",
-  "x-datadog-trace-id",
-  "x-datadog-parent-id",
-  "x-datadog-span-id",
+  "traceparent",
+  "tracestate",
 ]);
 
 export const RESPONSE_HEADER_ALLOWLIST = new Set([
@@ -21,9 +20,8 @@ export const RESPONSE_HEADER_ALLOWLIST = new Set([
   "location",
   "x-request-id",
   "x-correlation-id",
-  "x-datadog-trace-id",
-  "x-datadog-parent-id",
-  "x-datadog-span-id",
+  "traceparent",
+  "tracestate",
 ]);
 
 export const HIGH_SIGNAL_CONSOLE_ENTRY_TYPES = new Set(["warning", "error", "pageerror"]);

--- a/packages/playwright-reporter-llm/src/lib/internal/networkProcessing.test.ts
+++ b/packages/playwright-reporter-llm/src/lib/internal/networkProcessing.test.ts
@@ -111,7 +111,7 @@ describe(buildNetworkRequestFromEvent, () => {
         method: "GET",
         url: "https://api.example.com/data",
         headers: [
-          { name: "x-datadog-trace-id", value: "12345" },
+          { name: "traceparent", value: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01" },
           { name: "x-ignore-me", value: "ignore" },
         ],
       },
@@ -126,7 +126,9 @@ describe(buildNetworkRequestFromEvent, () => {
 
     const result = buildNetworkRequestFromEvent(event, {}, undefined, 0);
 
-    expect(result?.requestHeaders).toStrictEqual({ "x-datadog-trace-id": "12345" });
+    expect(result?.requestHeaders).toStrictEqual({
+      traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+    });
     expect(result?.responseHeaders).toStrictEqual({ "content-type": "application/json" });
   });
 
@@ -162,22 +164,96 @@ describe(buildNetworkRequestFromEvent, () => {
     expect(result?.durationMs).toBeUndefined();
   });
 
-  it("extracts traceId from response header preferring over request", () => {
+  it("extracts traceId and spanId from traceparent, preferring response over request", () => {
     const event = makeResourceSnapshot({
       request: {
         method: "GET",
         url: "https://api.example.com/data",
-        headers: [{ name: "x-datadog-trace-id", value: "req-trace" }],
+        headers: [
+          { name: "traceparent", value: "00-11111111111111111111111111111111-aaaaaaaaaaaaaaaa-01" },
+        ],
       },
       response: {
         status: 200,
-        headers: [{ name: "x-datadog-trace-id", value: "resp-trace" }],
+        headers: [
+          { name: "traceparent", value: "00-22222222222222222222222222222222-bbbbbbbbbbbbbbbb-01" },
+        ],
       },
     });
 
     const result = buildNetworkRequestFromEvent(event, {}, undefined, 0);
 
-    expect(result?.traceId).toBe("resp-trace");
+    expect(result?.traceId).toBe("22222222222222222222222222222222");
+    expect(result?.spanId).toBe("bbbbbbbbbbbbbbbb");
+  });
+
+  it("falls back to request traceparent when response lacks one", () => {
+    const event = makeResourceSnapshot({
+      request: {
+        method: "GET",
+        url: "https://api.example.com/data",
+        headers: [
+          { name: "traceparent", value: "00-11111111111111111111111111111111-aaaaaaaaaaaaaaaa-01" },
+        ],
+      },
+      response: { status: 200 },
+    });
+
+    const result = buildNetworkRequestFromEvent(event, {}, undefined, 0);
+
+    expect(result?.traceId).toBe("11111111111111111111111111111111");
+    expect(result?.spanId).toBe("aaaaaaaaaaaaaaaa");
+  });
+
+  it("ignores malformed traceparent", () => {
+    const event = makeResourceSnapshot({
+      request: {
+        method: "GET",
+        url: "https://api.example.com/data",
+        headers: [{ name: "traceparent", value: "not-a-valid-traceparent" }],
+      },
+      response: { status: 200 },
+    });
+
+    const result = buildNetworkRequestFromEvent(event, {}, undefined, 0);
+
+    expect(result?.traceId).toBeUndefined();
+    expect(result?.spanId).toBeUndefined();
+  });
+
+  it("ignores traceparent with invalid all-zero trace or span id", () => {
+    const event = makeResourceSnapshot({
+      request: {
+        method: "GET",
+        url: "https://api.example.com/data",
+        headers: [
+          { name: "traceparent", value: "00-00000000000000000000000000000000-aaaaaaaaaaaaaaaa-01" },
+        ],
+      },
+      response: { status: 200 },
+    });
+
+    const result = buildNetworkRequestFromEvent(event, {}, undefined, 0);
+
+    expect(result?.traceId).toBeUndefined();
+    expect(result?.spanId).toBeUndefined();
+  });
+
+  it("ignores traceparent with invalid ff version", () => {
+    const event = makeResourceSnapshot({
+      request: {
+        method: "GET",
+        url: "https://api.example.com/data",
+        headers: [
+          { name: "traceparent", value: "ff-11111111111111111111111111111111-aaaaaaaaaaaaaaaa-01" },
+        ],
+      },
+      response: { status: 200 },
+    });
+
+    const result = buildNetworkRequestFromEvent(event, {}, undefined, 0);
+
+    expect(result?.traceId).toBeUndefined();
   });
 
   it("extracts failureText and wasAborted", () => {

--- a/packages/playwright-reporter-llm/src/lib/internal/networkProcessing.test.ts
+++ b/packages/playwright-reporter-llm/src/lib/internal/networkProcessing.test.ts
@@ -112,6 +112,7 @@ describe(buildNetworkRequestFromEvent, () => {
         url: "https://api.example.com/data",
         headers: [
           { name: "traceparent", value: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01" },
+          { name: "tracestate", value: "test=00f067aa0ba902b7" },
           { name: "x-ignore-me", value: "ignore" },
         ],
       },
@@ -119,6 +120,7 @@ describe(buildNetworkRequestFromEvent, () => {
         status: 200,
         headers: [
           { name: "content-type", value: "application/json" },
+          { name: "tracestate", value: "acme=t61rcWkgMzE" },
           { name: "x-ignore-me", value: "ignore" },
         ],
       },
@@ -128,8 +130,12 @@ describe(buildNetworkRequestFromEvent, () => {
 
     expect(result?.requestHeaders).toStrictEqual({
       traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+      tracestate: "test=00f067aa0ba902b7",
     });
-    expect(result?.responseHeaders).toStrictEqual({ "content-type": "application/json" });
+    expect(result?.responseHeaders).toStrictEqual({
+      "content-type": "application/json",
+      tracestate: "acme=t61rcWkgMzE",
+    });
   });
 
   it("extracts timings and derives duration excluding ssl", () => {
@@ -221,13 +227,31 @@ describe(buildNetworkRequestFromEvent, () => {
     expect(result?.spanId).toBeUndefined();
   });
 
-  it("ignores traceparent with invalid all-zero trace or span id", () => {
+  it("ignores traceparent with invalid all-zero trace id", () => {
     const event = makeResourceSnapshot({
       request: {
         method: "GET",
         url: "https://api.example.com/data",
         headers: [
           { name: "traceparent", value: "00-00000000000000000000000000000000-aaaaaaaaaaaaaaaa-01" },
+        ],
+      },
+      response: { status: 200 },
+    });
+
+    const result = buildNetworkRequestFromEvent(event, {}, undefined, 0);
+
+    expect(result?.traceId).toBeUndefined();
+    expect(result?.spanId).toBeUndefined();
+  });
+
+  it("ignores traceparent with invalid all-zero span id", () => {
+    const event = makeResourceSnapshot({
+      request: {
+        method: "GET",
+        url: "https://api.example.com/data",
+        headers: [
+          { name: "traceparent", value: "00-11111111111111111111111111111111-0000000000000000-01" },
         ],
       },
       response: { status: 200 },
@@ -254,6 +278,7 @@ describe(buildNetworkRequestFromEvent, () => {
     const result = buildNetworkRequestFromEvent(event, {}, undefined, 0);
 
     expect(result?.traceId).toBeUndefined();
+    expect(result?.spanId).toBeUndefined();
   });
 
   it("extracts failureText and wasAborted", () => {

--- a/packages/playwright-reporter-llm/src/lib/internal/networkProcessing.ts
+++ b/packages/playwright-reporter-llm/src/lib/internal/networkProcessing.ts
@@ -102,11 +102,35 @@ function deriveNetworkDurationMs(timings: NetworkTimingBreakdown | undefined): n
   return totalDurationMs;
 }
 
-function extractTraceId(
+const INVALID_TRACE_ID = "00000000000000000000000000000000";
+const INVALID_SPAN_ID = "0000000000000000";
+const TRACEPARENT_PATTERN = /^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/;
+
+function parseTraceparent(
+  header: string | undefined,
+): { traceId: string; spanId: string } | undefined {
+  if (!header) {
+    return undefined;
+  }
+  const match = TRACEPARENT_PATTERN.exec(header.trim().toLowerCase());
+  if (!match) {
+    return undefined;
+  }
+  const [, version, traceId, spanId] = match;
+  if (version === "ff" || traceId === INVALID_TRACE_ID || spanId === INVALID_SPAN_ID) {
+    return undefined;
+  }
+  return { traceId: traceId!, spanId: spanId! };
+}
+
+function extractTraceContext(
   requestHeaders: Record<string, string> | undefined,
   responseHeaders: Record<string, string> | undefined,
-): string | undefined {
-  return responseHeaders?.["x-datadog-trace-id"] ?? requestHeaders?.["x-datadog-trace-id"];
+): { traceId: string; spanId: string } | undefined {
+  return (
+    parseTraceparent(responseHeaders?.["traceparent"]) ??
+    parseTraceparent(requestHeaders?.["traceparent"])
+  );
 }
 
 function readTraceResourceBody(
@@ -206,9 +230,10 @@ function enrichNetworkRequest(params: {
     networkRequest.responseHeaders = responseHeaders;
   }
 
-  const traceId = extractTraceId(requestHeaders, responseHeaders);
-  if (traceId) {
-    networkRequest.traceId = traceId;
+  const traceContext = extractTraceContext(requestHeaders, responseHeaders);
+  if (traceContext) {
+    networkRequest.traceId = traceContext.traceId;
+    networkRequest.spanId = traceContext.spanId;
   }
 
   const requestBody = readTraceResourceBody(archiveEntries, asRecord(requestRecord["postData"]));

--- a/packages/playwright-reporter-llm/src/lib/types.ts
+++ b/packages/playwright-reporter-llm/src/lib/types.ts
@@ -75,6 +75,7 @@ export interface NetworkRequest {
   resourceType?: string;
   offsetMs?: number;
   traceId?: string;
+  spanId?: string;
   requestBody?: string;
   responseBody?: string;
   failureText?: string;
@@ -117,6 +118,7 @@ export interface TimelineNetworkEntry {
   durationMs?: number;
   resourceType?: string;
   traceId?: string;
+  spanId?: string;
   failureText?: string;
   wasAborted?: boolean;
 }

--- a/plugins/core/skills/flaky-test-debugger/SKILL.md
+++ b/plugins/core/skills/flaky-test-debugger/SKILL.md
@@ -141,24 +141,16 @@ This downloads and extracts to `/tmp/playwright-llm-report-{runId}/`. The report
 
 ## Phase 3E: Quick Classification
 
-LLM report structure:
+For the full report schema, field reference, caps, and example reports:
 
-- **`summary`** -- quick pass/fail counts
-- **`tests[].errors[].message`** -- ANSI-stripped, clean error text
-- **`tests[].errors[].diff`** -- extracted expected/actual from assertion errors
-- **`tests[].errors[].location`** -- exact file and line of failure
-- **`tests[].flaky`** -- true if test passed after retry
-- **`tests[].attempts[]`** -- full retry history with per-attempt status, timing, stdio, attachments, steps, and network
-- **`tests[].attempts[].consoleMessages[]`** -- warning/error/pageerror/page-closed/page-crashed trace entries only (2KB text cap with `[truncated]` marker, max 50 per attempt, high-signal entries prioritized over low-signal)
-- **`tests[].steps` / `tests[].network` / `tests[].timeline`** -- convenience aliases from the final attempt
-- **`tests[].attempts[].timeline[]`** -- unified, sorted-by-`offsetMs` array of all retained events (`kind: "step" | "network" | "console"`). Slimmed-down entries for quick temporal scanning; full details remain in the source arrays
-- **`offsetMs`** -- milliseconds since the attempt's `startTime`. Always present on steps (from `TestStep.startTime`). Optional on network entries (from trace `_monotonicTime` or `startedDateTime`, converted via the trace's `context-options` anchor) and console entries (from trace monotonic `time` field + anchor). Absent when the trace lacks a `context-options` event. Entries without `offsetMs` are excluded from the timeline
-- **`tests[].attempts[].network[].traceId`** -- promoted from `x-datadog-trace-id` header for direct access
-- **`tests[].attempts[].network[]`** -- max 200 per attempt, priority-based: fetch/xhr requests, error responses (status >= 400), failed, and aborted requests are retained over static assets (script, stylesheet, image, font). Includes failure details (`failureText`, `wasAborted`), redirect chain (`redirectToUrl`, `redirectFromUrl`, `redirectChain`), timing breakdown (`timings`), `durationMs` derived from available timing components, and allowlisted headers (`requestHeaders`, `responseHeaders`)
-- **`tests[].attempts[].network[].responseHeaders`** -- includes `x-datadog-trace-id` and `x-datadog-span-id` when present (values capped to 256 chars)
-- **`tests[].attempts[].failureArtifacts`** -- for failing/timed-out/interrupted attempts: `screenshotBase64` (base64-encoded screenshot, max 512KB), `videoPath` (first video attachment path). Omitted entirely when neither screenshot nor video is available
-- **`tests[].attachments[].path`** -- relative to Playwright outputDir
-- **`tests[].stdout` / `tests[].stderr`** -- capped at 4KB with `[truncated]` marker
+1. If the repo has `node_modules/@clipboard-health/playwright-reporter-llm/`, read `README.md` and `docs/example-report.json` from there — exact version match to the report.
+2. Otherwise, fetch the latest docs from GitHub:
+   - `https://raw.githubusercontent.com/ClipboardHealth/core-utils/refs/heads/main/packages/playwright-reporter-llm/README.md`
+   - `https://raw.githubusercontent.com/ClipboardHealth/core-utils/refs/heads/main/packages/playwright-reporter-llm/docs/example-report.json`
+
+Cross-check the report's `schemaVersion` against the docs — if they disagree, the `main` docs describe a different version and some field semantics may not apply.
+
+Read the docs if you need field semantics or limits; otherwise the field names used below are enough to drive the investigation.
 
 Classify the flake to narrow the search space:
 
@@ -218,33 +210,21 @@ Filter `tests[]` for entries where `status` is `"failed"` or `flaky` is `true`. 
 
 ### 4Ed: Examine attempts for retry patterns
 
-Each attempt includes:
+For each attempt, compare `status`, `durationMs`, and `error` across retries — timing or error-shape differences between attempts often point at the trigger.
 
-- `status` and `durationMs` — spot timing differences between passing and failing attempts
-- `error` — failure reason per attempt (may differ across retries)
-- `consoleMessages[]` — browser warnings/errors (only warning, error, pageerror, page-closed, page-crashed entries; capped at 2KB / 50 per attempt)
-- `failureArtifacts` — for failed/timed-out/interrupted attempts:
-  - `screenshotBase64` — base64-encoded failure screenshot (max 512KB). **Decode and inspect this** to see exactly what the page showed at failure time — often reveals modals, loading spinners, error banners, or unexpected navigation that the assertion text alone doesn't explain.
-  - `videoPath` — path to video recording
-- `network[]` — HTTP requests/responses for that attempt
-- `timeline[]` — unified sorted event stream
+**Always decode `failureArtifacts.screenshotBase64` when present.** The page state at failure often reveals modals, loading spinners, error banners, or unexpected navigation that the assertion text alone doesn't explain.
 
 ### 4Ee: Inspect network activity and extract trace IDs
 
-The `network[]` array (on tests or individual attempts) includes:
+Scan `network[]` for 4xx/5xx responses, `failureText`, and `wasAborted` near the failure's `offsetMs`. Use `timings` to isolate slow phases (DNS, connect, wait, receive).
 
-- `method`, `url`, `status` — identify 4xx/5xx responses
-- `timings` — detailed breakdown: `dnsMs`, `connectMs`, `sslMs`, `sendMs`, `waitMs`, `receiveMs`
-- `durationMs` — total request duration derived from timing components
-- `requestHeaders`, `responseHeaders` — allowlisted headers
-- `redirectChain` — full redirect sequence
-- **`traceId`** — Datadog trace ID extracted from `x-datadog-trace-id` response header. **When present near a failure, you must use references/datadog-apm-traces.md for backend correlation to bridge the gap between frontend test failure and potential backend root cause.**
+**`traceId`** — when present on a failing request, you must follow [`references/datadog-apm-traces.md`](./references/datadog-apm-traces.md) to correlate with backend behavior. This is the bridge between frontend test failure and potential backend root cause.
 
-Network is capped at 200 entries per attempt, prioritized: fetch/xhr and error responses are retained over static assets. Headers/values capped at 256 chars. If all 200 entries are static assets (script/stylesheet/font) with no API calls, the capture is saturated.
+If the `network[]` array is full (200 entries) but contains only static assets, the capture is saturated and the relevant API calls may have been dropped — note this as a confidence-reducing factor.
 
 ### 4Ef: Review test steps
 
-`tests[].steps[]` provides a step-by-step breakdown of test actions with timing (`offsetMs`, `durationMs`, `depth`). Prefer the timeline view (4Ea) which interleaves steps with network and console. Use steps directly when you need the full hierarchy (nested steps via `depth`).
+Prefer the timeline view (4Ea) which interleaves steps with network and console. Fall back to `tests[].attempts[].steps[]` directly when you need the full nesting hierarchy via `depth`.
 
 ## Phase 4E Evidence Standard
 


### PR DESCRIPTION
## Summary

Replace Datadog-specific `x-datadog-*` handling in the Playwright LLM reporter with W3C Trace Context (`traceparent`), so the open-source output works uniformly with OpenTelemetry, Jaeger, Tempo, Honeycomb, and Datadog (dd-trace ≥ 2.0 emits `traceparent` alongside DD headers by default).

- Parse `traceparent` into first-class `traceId` (32-hex) and new `spanId` (16-hex) fields on `NetworkRequest` and `TimelineNetworkEntry`. Prefer response header over request. Reject malformed, `ff`-version, and all-zero IDs per spec
- Header allowlists: add `traceparent` + `tracestate`, drop `x-datadog-trace-id` / `-parent-id` / `-span-id`
- Tests cover response-preferred extraction, request fallback, malformed header, all-zero IDs, `ff` version rejection
- README reorganized: new "What to read, by task" table, `timeline[]`-first minimal failure example, new flaky-test pass-vs-fail example; full schema moved to `docs/example-report.json` (bundled into the published package via `project.json` assets)
- flaky-test-debugger skill deduplicated — now points at reporter README/example (local `node_modules` first, fall back to GitHub main) instead of restating field semantics and caps

Paired server-side change in clipboard-health: https://github.com/ClipboardHealth/clipboard-health/pull/24034

## Test plan

- [x] `npm run affected` (build, lint, test — all green)
- [x] Reporter unit tests pass, including new W3C parsing cases
- [x] `docs/example-report.json` validates as JSON and ships in the build output (`dist/packages/playwright-reporter-llm/docs/example-report.json`)
- [ ] After both PRs merge + deploy, run an E2E in CI and confirm `llm-report.json` shows populated `traceId`/`spanId` that resolve in Datadog

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/clipboardhealth/core-utils/pull/576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
