### PR TITLE
feat(ALCH-5845): expose cancel workflow endpoint

### DIFF
--- a/.agents/skills/flaky-test-debugger/SKILL.md
+++ b/.agents/skills/flaky-test-debugger/SKILL.md
@@ -141,24 +141,16 @@ This downloads and extracts to `/tmp/playwright-llm-report-{runId}/`. The report
 
 ## Phase 3E: Quick Classification
 
-LLM report structure:
+For the full report schema, field reference, caps, and example reports:
 
-- **`summary`** -- quick pass/fail counts
-- **`tests[].errors[].message`** -- ANSI-stripped, clean error text
-- **`tests[].errors[].diff`** -- extracted expected/actual from assertion errors
-- **`tests[].errors[].location`** -- exact file and line of failure
-- **`tests[].flaky`** -- true if test passed after retry
-- **`tests[].attempts[]`** -- full retry history with per-attempt status, timing, stdio, attachments, steps, and network
-- **`tests[].attempts[].consoleMessages[]`** -- warning/error/pageerror/page-closed/page-crashed trace entries only (2KB text cap with `[truncated]` marker, max 50 per attempt, high-signal entries prioritized over low-signal)
-- **`tests[].steps` / `tests[].network` / `tests[].timeline`** -- convenience aliases from the final attempt
-- **`tests[].attempts[].timeline[]`** -- unified, sorted-by-`offsetMs` array of all retained events (`kind: "step" | "network" | "console"`). Slimmed-down entries for quick temporal scanning; full details remain in the source arrays
-- **`offsetMs`** -- milliseconds since the attempt's `startTime`. Always present on steps (from `TestStep.startTime`). Optional on network entries (from trace `_monotonicTime` or `startedDateTime`, converted via the trace's `context-options` anchor) and console entries (from trace monotonic `time` field + anchor). Absent when the trace lacks a `context-options` event. Entries without `offsetMs` are excluded from the timeline
-- **`tests[].attempts[].network[].traceId`** -- promoted from `x-datadog-trace-id` header for direct access
-- **`tests[].attempts[].network[]`** -- max 200 per attempt, priority-based: fetch/xhr requests, error responses (status >= 400), failed, and aborted requests are retained over static assets (script, stylesheet, image, font). Includes failure details (`failureText`, `wasAborted`), redirect chain (`redirectToUrl`, `redirectFromUrl`, `redirectChain`), timing breakdown (`timings`), `durationMs` derived from available timing components, and allowlisted headers (`requestHeaders`, `responseHeaders`)
-- **`tests[].attempts[].network[].responseHeaders`** -- includes `x-datadog-trace-id` and `x-datadog-span-id` when present (values capped to 256 chars)
-- **`tests[].attempts[].failureArtifacts`** -- for failing/timed-out/interrupted attempts: `screenshotBase64` (base64-encoded screenshot, max 512KB), `videoPath` (first video attachment path). Omitted entirely when neither screenshot nor video is available
-- **`tests[].attachments[].path`** -- relative to Playwright outputDir
-- **`tests[].stdout` / `tests[].stderr`** -- capped at 4KB with `[truncated]` marker
+1. If the repo has `node_modules/@clipboard-health/playwright-reporter-llm/`, read `README.md` and `docs/example-report.json` from there — exact version match to the report.
+2. Otherwise, fetch the latest docs from GitHub:
+   - `https://raw.githubusercontent.com/ClipboardHealth/core-utils/refs/heads/main/packages/playwright-reporter-llm/README.md`
+   - `https://raw.githubusercontent.com/ClipboardHealth/core-utils/refs/heads/main/packages/playwright-reporter-llm/docs/example-report.json`
+
+Cross-check the report's `schemaVersion` against the docs — if they disagree, the `main` docs describe a different version and some field semantics may not apply.
+
+Read the docs if you need field semantics or limits; otherwise the field names used below are enough to drive the investigation.
 
 Classify the flake to narrow the search space:
 
@@ -218,33 +210,21 @@ Filter `tests[]` for entries where `status` is `"failed"` or `flaky` is `true`. 
 
 ### 4Ed: Examine attempts for retry patterns
 
-Each attempt includes:
+For each attempt, compare `status`, `durationMs`, and `error` across retries — timing or error-shape differences between attempts often point at the trigger.
 
-- `status` and `durationMs` — spot timing differences between passing and failing attempts
-- `error` — failure reason per attempt (may differ across retries)
-- `consoleMessages[]` — browser warnings/errors (only warning, error, pageerror, page-closed, page-crashed entries; capped at 2KB / 50 per attempt)
-- `failureArtifacts` — for failed/timed-out/interrupted attempts:
-  - `screenshotBase64` — base64-encoded failure screenshot (max 512KB). **Decode and inspect this** to see exactly what the page showed at failure time — often reveals modals, loading spinners, error banners, or unexpected navigation that the assertion text alone doesn't explain.
-  - `videoPath` — path to video recording
-- `network[]` — HTTP requests/responses for that attempt
-- `timeline[]` — unified sorted event stream
+**Always decode `failureArtifacts.screenshotBase64` when present.** The page state at failure often reveals modals, loading spinners, error banners, or unexpected navigation that the assertion text alone doesn't explain.
 
 ### 4Ee: Inspect network activity and extract trace IDs
 
-The `network[]` array (on tests or individual attempts) includes:
+Scan `network[]` for 4xx/5xx responses, `failureText`, and `wasAborted` near the failure's `offsetMs`. Use `timings` to isolate slow phases (DNS, connect, wait, receive).
 
-- `method`, `url`, `status` — identify 4xx/5xx responses
-- `timings` — detailed breakdown: `dnsMs`, `connectMs`, `sslMs`, `sendMs`, `waitMs`, `receiveMs`
-- `durationMs` — total request duration derived from timing components
-- `requestHeaders`, `responseHeaders` — allowlisted headers
-- `redirectChain` — full redirect sequence
-- **`traceId`** — Datadog trace ID extracted from `x-datadog-trace-id` response header. **When present near a failure, you must use references/datadog-apm-traces.md for backend correlation to bridge the gap between frontend test failure and potential backend root cause.**
+**`traceId`** — when present on a failing request, you must follow [`references/datadog-apm-traces.md`](./references/datadog-apm-traces.md) to correlate with backend behavior. This is the bridge between frontend test failure and potential backend root cause.
 
-Network is capped at 200 entries per attempt, prioritized: fetch/xhr and error responses are retained over static assets. Headers/values capped at 256 chars. If all 200 entries are static assets (script/stylesheet/font) with no API calls, the capture is saturated.
+If the `network[]` array is full (200 entries) but contains only static assets, the capture is saturated and the relevant API calls may have been dropped — note this as a confidence-reducing factor.
 
 ### 4Ef: Review test steps
 
-`tests[].steps[]` provides a step-by-step breakdown of test actions with timing (`offsetMs`, `durationMs`, `depth`). Prefer the timeline view (4Ea) which interleaves steps with network and console. Use steps directly when you need the full hierarchy (nested steps via `depth`).
+Prefer the timeline view (4Ea) which interleaves steps with network and console. Fall back to `tests[].attempts[].steps[]` directly when you need the full nesting hierarchy via `depth`.
 
 ## Phase 4E Evidence Standard
 

--- a/packages/notifications/src/lib/notificationClient.test.ts
+++ b/packages/notifications/src/lib/notificationClient.test.ts
@@ -719,7 +719,7 @@ describe(NotificationClient, () => {
         cancellationKey: mockCancellationKey,
       };
 
-      await expect(client.cancel(input)).rejects.toThrow(mockError);
+      await expect(client.cancel(input)).rejects.toThrow(ServiceError);
 
       expect(mockLogger.error).toHaveBeenCalledWith(
         "notifications.cancel [unknown] Knock cancel failed",

--- a/packages/notifications/src/lib/notificationClient.test.ts
+++ b/packages/notifications/src/lib/notificationClient.test.ts
@@ -11,6 +11,7 @@ import {
   type TriggerIdempotencyKey,
 } from "./triggerIdempotencyKey";
 import type {
+  CancelRequest,
   SignUserTokenRequest,
   Span,
   TraceOptions,
@@ -647,6 +648,82 @@ describe(NotificationClient, () => {
         {
           idempotencyKey: expect.any(String),
         },
+      );
+    });
+  });
+
+  describe("cancel", () => {
+    const mockWorkflowKey = "test-workflow";
+    const mockCancellationKey = "cancel-key-123";
+
+    it("cancels workflow with recipients", async () => {
+      const cancelSpy = vi
+        .spyOn(provider.workflows, "cancel")
+        .mockResolvedValue(
+          undefined as unknown as Awaited<ReturnType<Knock["workflows"]["cancel"]>>,
+        );
+
+      const input: CancelRequest = {
+        workflowKey: mockWorkflowKey,
+        cancellationKey: mockCancellationKey,
+        recipients: ["user-1", "user-2"],
+      };
+
+      await client.cancel(input);
+
+      expect(cancelSpy).toHaveBeenCalledWith(mockWorkflowKey, {
+        cancellation_key: mockCancellationKey,
+        recipients: ["user-1", "user-2"],
+      });
+    });
+
+    it("cancels workflow without recipients", async () => {
+      const cancelSpy = vi
+        .spyOn(provider.workflows, "cancel")
+        .mockResolvedValue(
+          undefined as unknown as Awaited<ReturnType<Knock["workflows"]["cancel"]>>,
+        );
+
+      const input: CancelRequest = {
+        workflowKey: mockWorkflowKey,
+        cancellationKey: mockCancellationKey,
+      };
+
+      await client.cancel(input);
+
+      expect(cancelSpy).toHaveBeenCalledWith(mockWorkflowKey, {
+        cancellation_key: mockCancellationKey,
+      });
+    });
+
+    it("skips provider call when dryRun is true", async () => {
+      const cancelSpy = vi.spyOn(provider.workflows, "cancel");
+
+      const input: CancelRequest = {
+        workflowKey: mockWorkflowKey,
+        cancellationKey: mockCancellationKey,
+        dryRun: true,
+      };
+
+      await client.cancel(input);
+
+      expect(cancelSpy).not.toHaveBeenCalled();
+    });
+
+    it("logs and re-throws provider errors", async () => {
+      const mockError = new Error("Knock cancel failed");
+      vi.spyOn(provider.workflows, "cancel").mockRejectedValue(mockError);
+
+      const input: CancelRequest = {
+        workflowKey: mockWorkflowKey,
+        cancellationKey: mockCancellationKey,
+      };
+
+      await expect(client.cancel(input)).rejects.toThrow(mockError);
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "notifications.cancel [unknown] Knock cancel failed",
+        expect.any(Object),
       );
     });
   });

--- a/packages/notifications/src/lib/notificationClient.ts
+++ b/packages/notifications/src/lib/notificationClient.ts
@@ -23,11 +23,13 @@ import type { TriggerIdempotencyKeyParams } from "./triggerIdempotencyKey";
 import type {
   AppendPushTokenRequest,
   AppendPushTokenResponse,
+  CancelRequest,
   LogParams,
   NotificationClientParams,
   SignUserTokenRequest,
   SignUserTokenResponse,
   Span,
+  TraceOptions,
   TriggerBody,
   TriggerChunkedRequest,
   TriggerChunkedResponse,
@@ -47,6 +49,10 @@ const LOG_PARAMS = {
   triggerChunked: {
     traceName: "notifications.triggerChunked",
     destination: "knock.workflows.trigger",
+  },
+  cancel: {
+    traceName: "notifications.cancel",
+    destination: "knock.workflows.cancel",
   },
   appendPushToken: {
     traceName: "notifications.appendPushToken",
@@ -373,6 +379,64 @@ export class NotificationClient {
         return success({ responses });
       },
     );
+  }
+
+  /**
+   * Cancels any queued workflow runs associated with the given `workflowKey` / `cancellationKey`
+   * pair. Optionally scope to specific recipients.
+   *
+   * Errors from the provider are logged and traced, then re-thrown.
+   *
+   * @see {@link https://docs.knock.app/send-notifications/canceling-workflows}
+   */
+  public async cancel(params: CancelRequest): Promise<void> {
+    const { workflowKey, cancellationKey, recipients, dryRun = false } = params;
+    const logParams = { ...LOG_PARAMS.cancel, workflowKey, dryRun };
+    const traceOptions: TraceOptions = {
+      resource: `notification.${workflowKey}`,
+      tags: {
+        "span.kind": "producer",
+        component: "customer-notifications",
+        "messaging.system": "knock.app",
+        "messaging.operation": "publish",
+        "messaging.destination": LOG_PARAMS.cancel.destination,
+        "notification.dryRun": String(dryRun),
+      },
+    };
+
+    await this.tracer.trace(logParams.traceName, traceOptions, async (span) => {
+      this.logger.info(`${logParams.traceName} request`, {
+        ...logParams,
+        recipientCount: recipients?.length,
+      });
+
+      if (dryRun) {
+        this.logger.info(`${logParams.traceName} response`, { ...logParams, dryRun: true });
+        return;
+      }
+
+      try {
+        await this.provider.workflows.cancel(workflowKey, {
+          cancellation_key: cancellationKey,
+          ...(recipients ? { recipients } : {}),
+        });
+
+        this.logger.info(`${logParams.traceName} response`, logParams);
+      } catch (maybeError) {
+        const error = toError(maybeError);
+        this.createAndLogError({
+          notificationError: {
+            code: ERROR_CODES.unknown,
+            message: error.message,
+          },
+          span,
+          logFunction: this.logger.error,
+          logParams,
+          metadata: { error },
+        });
+        throw error;
+      }
+    });
   }
 
   /**

--- a/packages/notifications/src/lib/notificationClient.ts
+++ b/packages/notifications/src/lib/notificationClient.ts
@@ -1,5 +1,6 @@
 import {
   failure,
+  type FailureResult,
   isFailure,
   type LogFunction,
   ServiceError,
@@ -424,7 +425,7 @@ export class NotificationClient {
         this.logger.info(`${logParams.traceName} response`, logParams);
       } catch (maybeError) {
         const error = toError(maybeError);
-        this.createAndLogError({
+        const result = this.createAndLogError({
           notificationError: {
             code: ERROR_CODES.unknown,
             message: error.message,
@@ -434,7 +435,7 @@ export class NotificationClient {
           logParams,
           metadata: { error },
         });
-        throw error;
+        throw result.error;
       }
     });
   }
@@ -616,7 +617,7 @@ export class NotificationClient {
     logFunction?: LogFunction;
     logParams: LogParams;
     metadata?: Record<string, unknown>;
-  }): ServiceResult<never> {
+  }): FailureResult {
     const { logParams, notificationError, span, metadata, logFunction = this.logger.warn } = params;
     const { code, message } = notificationError;
 

--- a/packages/notifications/src/lib/types.ts
+++ b/packages/notifications/src/lib/types.ts
@@ -224,6 +224,36 @@ export interface TriggerResponse {
 }
 
 /**
+ * Request parameters for cancelling a previously triggered workflow.
+ *
+ * Cancels any queued workflow runs associated with the given `workflowKey` / `cancellationKey`
+ * pair. The `cancellationKey` must match the one passed in {@link TriggerBody.cancellationKey}
+ * when the workflow was triggered.
+ *
+ * @see {@link https://docs.knock.app/send-notifications/canceling-workflows}
+ */
+export interface CancelRequest {
+  /** Workflow key. */
+  workflowKey: string;
+
+  /**
+   * The cancellation key used when originally triggering the workflow.
+   *
+   * @see {@link TriggerBody.cancellationKey}
+   */
+  cancellationKey: string;
+
+  /**
+   * Scope the cancellation to specific user IDs. If omitted, cancels for all recipients
+   * associated with the `cancellationKey`.
+   */
+  recipients?: string[];
+
+  /** If true, the cancellation will not be sent, but the request will be validated and logged. */
+  dryRun?: boolean;
+}
+
+/**
  * Request parameters for appending a push token.
  */
 export interface AppendPushTokenRequest {

--- a/packages/util-ts/src/lib/functional/serviceResult.ts
+++ b/packages/util-ts/src/lib/functional/serviceResult.ts
@@ -40,7 +40,7 @@ export function success<A>(value: A): ServiceResult<A> {
 /**
  * Creates a failed ServiceResult.
  */
-export function failure<A = never>(params: ServiceErrorParams | ServiceError): ServiceResult<A> {
+export function failure(params: ServiceErrorParams | ServiceError): FailureResult {
   const error = params instanceof ServiceError ? params : new ServiceError(params);
   return Object.freeze({
     isRight: false,


### PR DESCRIPTION
Summary
===
https://linear.app/clipboardhealth/issue/ALCH-5845/expose-cancellation-of-workflow-from-notification-client

Notification library already exposes `cancellationKey` parameter in trigger function. The PR adds a function to send cancellation request to cancel previously sent workflow.

Changes
---
- add function `.cancel` to the notification client

Videos/screenshots
---
N/A