### PR TITLE
feat: surface client errors in the notifications package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -207,9 +207,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -224,9 +221,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -241,9 +235,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -258,9 +249,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -5701,9 +5689,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5721,9 +5706,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5741,9 +5723,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5761,9 +5740,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5781,9 +5757,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5801,9 +5774,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5821,9 +5791,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5841,9 +5808,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5861,9 +5825,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5887,9 +5848,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5913,9 +5871,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5939,9 +5894,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5965,9 +5917,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5991,9 +5940,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -6017,9 +5963,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -6043,9 +5986,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -6885,9 +6825,9 @@
       "license": "MIT"
     },
     "node_modules/@knocklabs/node": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@knocklabs/node/-/node-1.30.0.tgz",
-      "integrity": "sha512-qKxZcIEVYF/8fXpOB38HTTBXo6yUfotZpXWWyYPCFkjvyH171QrI287M3RuUf/M28UrPZ8tWkz1Z9g/5p/m/jg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@knocklabs/node/-/node-1.32.0.tgz",
+      "integrity": "sha512-wPRLdsIS79gifgZQRH8l/47gGK12UKqY9zoG4LguvaD50dhVEEkcHz2DB2KMS7KJplxvpT8/qtBviJub8MJISw==",
       "license": "Apache-2.0",
       "dependencies": {
         "jose": "^6.0.11"
@@ -7101,9 +7041,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7121,9 +7058,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7141,9 +7075,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7161,9 +7092,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7181,9 +7109,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7596,9 +7521,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7611,9 +7533,6 @@
       "integrity": "sha512-Z/zMqFClnEyqDXouJKEPoWVhMQIif5F0YuECWBYjd3ZLwQsXGTItoh+6Wm3XF/nGMA2uLOHyTq/X7iFXQY3RzA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7628,9 +7547,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7643,9 +7559,6 @@
       "integrity": "sha512-RVOe2qcwhoIx6mxQURPjUfAW5SEOmT2gdhewvdcvX9ICq1hj5B2VarmkhTg0qroO7xiyqOqwq26mCzoV2I3NgQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -8282,9 +8195,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8302,9 +8212,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8322,9 +8229,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8342,9 +8246,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8362,9 +8263,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8382,9 +8280,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8402,9 +8297,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8422,9 +8314,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8657,9 +8546,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8672,9 +8558,6 @@
       "integrity": "sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -8689,9 +8572,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8704,9 +8584,6 @@
       "integrity": "sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -8721,9 +8598,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8736,9 +8610,6 @@
       "integrity": "sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -8753,9 +8624,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8768,9 +8636,6 @@
       "integrity": "sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9001,9 +8866,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9021,9 +8883,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9041,9 +8900,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9061,9 +8917,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9081,9 +8934,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9101,9 +8951,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9121,9 +8968,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9141,9 +8985,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9418,9 +9259,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9436,9 +9274,6 @@
       "integrity": "sha512-eDYDXZGhQAXyn6GwtwiX/qcLS0HlOLPJ/+iiIY8RYr+3P8oKBmgKxADLlniL6FtWfE7pPk7IGN9/xvDEvDvFeg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9456,9 +9291,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9474,9 +9306,6 @@
       "integrity": "sha512-j1qf/NaUfOWQutjeoooNG1Q0zsK0XGmSu1uDLq3cctquRF3j7t9Hxqf/76ehCc5GEUAanth2W4Fa+XT1RFg/nw==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -9494,9 +9323,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9512,9 +9338,6 @@
       "integrity": "sha512-JkO3C6Gki7Y6h/MiIkFKvHFOz98/YWvQ4WYbK9DLXACMP2rjULzkeGyAzorJE5S1dzLQGFgeqvN779kSFwoV1g==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -9532,9 +9355,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9550,9 +9370,6 @@
       "integrity": "sha512-js29ZWIuPhNWzY8NC7KoffEMEeWG105vbmm+8EOJsC+T/jHBiKIJEUF78+F/IrgEWMMP9N0kRND4Pp75+xAhKg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9773,9 +9590,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9795,9 +9609,6 @@
       "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9819,9 +9630,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9841,9 +9649,6 @@
       "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9865,9 +9670,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9887,9 +9689,6 @@
       "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -10415,9 +10214,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10435,9 +10231,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10455,9 +10248,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10475,9 +10265,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10495,9 +10282,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10515,9 +10299,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10642,9 +10423,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11907,9 +11685,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -11925,9 +11700,6 @@
       "integrity": "sha512-1SYGs2l0Yyyi0pR/P/NKz/x0kqxkoiw+BXeJjLUdecSk/KasncWlJrc6hOvFSgKHOBrzgM5jwuluKtlT8dnrcA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -11945,9 +11717,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -11963,9 +11732,6 @@
       "integrity": "sha512-DCR2YYeyd6DQE4OuDhImouuNcjXEiEdnn1Y0DyGteugPEDvVuvYk8Xddi+4o2SgWH6jiW8/I+3emZvbep1NC+g==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -11983,9 +11749,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -12001,9 +11764,6 @@
       "integrity": "sha512-qyqydP/wyH8alcIP4a2hnGSjHLJjm9H7yDFup+CPy9oTahFgLLwnNcv5UHXqO2Qs3AIND+cls5f/Bb6hqpxdgA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -22731,9 +22491,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -22755,9 +22512,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -22779,9 +22533,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -22803,9 +22554,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -29139,7 +28887,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -29156,7 +28903,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -29173,7 +28919,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -29190,7 +28935,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -29207,7 +28951,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -29224,7 +28967,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -29241,7 +28983,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -29258,7 +28999,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34391,7 +34131,7 @@
         "@clipboard-health/background-jobs-adapter": "2.1.92",
         "@clipboard-health/phone-number": "2.2.94",
         "@clipboard-health/util-ts": "5.3.30",
-        "@knocklabs/node": "1.30.0",
+        "@knocklabs/node": "1.32.0",
         "tslib": "2.8.1"
       },
       "devDependencies": {

--- a/packages/notifications/README.md
+++ b/packages/notifications/README.md
@@ -94,9 +94,13 @@ Send notifications through third-party providers.
          const result = await this.client.triggerChunked(request);
 
          if (isFailure(result)) {
-           // Skip expired notifications, retrying the job won't help.
-           if (result.error.issues[0]?.code === ERROR_CODES.expired) {
-             this.logger.warn("TriggerNotificationJob skipped due to expiry", { ...metadata });
+           const code = result.error.issues[0]?.code;
+
+           // Skip errors that retrying won't fix: expired notifications and non-429 4xx responses
+           // from the provider (e.g. validation errors, missing recipients). 429s surface as
+           // `rateLimited` and fall through to the throw below so the job retries with backoff.
+           if (code === ERROR_CODES.expired || code === ERROR_CODES.clientError) {
+             this.logger.warn("TriggerNotificationJob skipped", { ...metadata, code });
              return;
            }
 

--- a/packages/notifications/examples/triggerNotification.job.ts
+++ b/packages/notifications/examples/triggerNotification.job.ts
@@ -69,9 +69,13 @@ export class TriggerNotificationJob implements BaseHandler<SerializableTriggerCh
       const result = await this.client.triggerChunked(request);
 
       if (isFailure(result)) {
-        // Skip expired notifications, retrying the job won't help.
-        if (result.error.issues[0]?.code === ERROR_CODES.expired) {
-          this.logger.warn("TriggerNotificationJob skipped due to expiry", { ...metadata });
+        const code = result.error.issues[0]?.code;
+
+        // Skip errors that retrying won't fix: expired notifications and non-429 4xx responses
+        // from the provider (e.g. validation errors, missing recipients). 429s surface as
+        // `rateLimited` and fall through to the throw below so the job retries with backoff.
+        if (code === ERROR_CODES.expired || code === ERROR_CODES.clientError) {
+          this.logger.warn("TriggerNotificationJob skipped", { ...metadata, code });
           return;
         }
 

--- a/packages/notifications/examples/usage.md
+++ b/packages/notifications/examples/usage.md
@@ -88,9 +88,13 @@
          const result = await this.client.triggerChunked(request);
 
          if (isFailure(result)) {
-           // Skip expired notifications, retrying the job won't help.
-           if (result.error.issues[0]?.code === ERROR_CODES.expired) {
-             this.logger.warn("TriggerNotificationJob skipped due to expiry", { ...metadata });
+           const code = result.error.issues[0]?.code;
+
+           // Skip errors that retrying won't fix: expired notifications and non-429 4xx responses
+           // from the provider (e.g. validation errors, missing recipients). 429s surface as
+           // `rateLimited` and fall through to the throw below so the job retries with backoff.
+           if (code === ERROR_CODES.expired || code === ERROR_CODES.clientError) {
+             this.logger.warn("TriggerNotificationJob skipped", { ...metadata, code });
              return;
            }
 

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -20,7 +20,7 @@
     "@clipboard-health/background-jobs-adapter": "2.1.92",
     "@clipboard-health/phone-number": "2.2.94",
     "@clipboard-health/util-ts": "5.3.30",
-    "@knocklabs/node": "1.30.0",
+    "@knocklabs/node": "1.32.0",
     "tslib": "2.8.1"
   },
   "devDependencies": {

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./lib/errorCodes";
 export * from "./lib/errorsInResult";
 export * from "./lib/notificationClient";
 export * from "./lib/notificationJobEnqueuer";

--- a/packages/notifications/src/lib/errorCodes.ts
+++ b/packages/notifications/src/lib/errorCodes.ts
@@ -1,0 +1,21 @@
+export const ERROR_CODES = {
+  /**
+   * The third-party provider returned a non-429 4xx response. Retrying without changes is
+   * unlikely to succeed; fix the request or inspect the error before retrying.
+   */
+  clientError: "clientError",
+  expired: "expired",
+  invalidExpiresAt: "invalidExpiresAt",
+  invalidIdempotencyKey: "invalidIdempotencyKey",
+  missingSigningKey: "missingSigningKey",
+  /**
+   * The third-party provider returned 429 (Too Many Requests). Callers should back off and
+   * retry.
+   */
+  rateLimited: "rateLimited",
+  recipientCountAboveMaximum: "recipientCountAboveMaximum",
+  recipientCountBelowMinimum: "recipientCountBelowMinimum",
+  unknown: "unknown",
+} as const;
+
+export type ErrorCode = (typeof ERROR_CODES)[keyof typeof ERROR_CODES];

--- a/packages/notifications/src/lib/internal/toNotificationError.test.ts
+++ b/packages/notifications/src/lib/internal/toNotificationError.test.ts
@@ -1,0 +1,64 @@
+import { ERROR_CODES } from "../errorCodes";
+import { toNotificationError } from "./toNotificationError";
+
+function createErrorWithStatus(message: string, status: unknown): Error {
+  const error = new Error(message) as Error & { status: unknown };
+  error.status = status;
+  return error;
+}
+
+describe(toNotificationError, () => {
+  it("maps 429 responses to rateLimited", () => {
+    const input = createErrorWithStatus("slow down", 429);
+
+    const actual = toNotificationError(input);
+
+    expect(actual.code).toBe(ERROR_CODES.rateLimited);
+    expect(actual.message).toBe("slow down");
+    expect(actual.error).toBe(input);
+  });
+
+  it.each([400, 401, 403, 404, 409, 422, 499])(
+    "maps status %s to clientError",
+    (status: number) => {
+      const input = createErrorWithStatus(`failed with ${status}`, status);
+
+      const actual = toNotificationError(input);
+
+      expect(actual.code).toBe(ERROR_CODES.clientError);
+      expect(actual.message).toBe(`failed with ${status}`);
+    },
+  );
+
+  it.each([500, 502, 503])("maps 5xx status %s to unknown", (status: number) => {
+    const input = createErrorWithStatus(`failed with ${status}`, status);
+
+    const actual = toNotificationError(input);
+
+    expect(actual.code).toBe(ERROR_CODES.unknown);
+  });
+
+  it("maps errors without a status to unknown", () => {
+    const input = new Error("boom");
+
+    const actual = toNotificationError(input);
+
+    expect(actual.code).toBe(ERROR_CODES.unknown);
+    expect(actual.message).toBe("boom");
+  });
+
+  it("maps non-Error throwables to unknown", () => {
+    const actual = toNotificationError("something went wrong");
+
+    expect(actual.code).toBe(ERROR_CODES.unknown);
+    expect(actual.error).toBeInstanceOf(Error);
+  });
+
+  it("ignores non-numeric status values", () => {
+    const input = createErrorWithStatus("weird", "429");
+
+    const actual = toNotificationError(input);
+
+    expect(actual.code).toBe(ERROR_CODES.unknown);
+  });
+});

--- a/packages/notifications/src/lib/internal/toNotificationError.ts
+++ b/packages/notifications/src/lib/internal/toNotificationError.ts
@@ -1,0 +1,36 @@
+import { toError } from "@clipboard-health/util-ts";
+
+import { ERROR_CODES, type ErrorCode } from "../errorCodes";
+
+const RATE_LIMITED_STATUS = 429;
+const MINIMUM_CLIENT_ERROR_STATUS = 400;
+const MAXIMUM_CLIENT_ERROR_STATUS = 499;
+
+/**
+ * Maps a caught error to a notification {@link ErrorCode} and message so that callers can
+ * decide whether retrying makes sense. A 429 is surfaced as {@link ERROR_CODES.rateLimited}
+ * (retry with backoff), other 4xx responses as {@link ERROR_CODES.clientError} (not
+ * retryable), and everything else as {@link ERROR_CODES.unknown}.
+ */
+export function toNotificationError(maybeError: unknown): {
+  code: ErrorCode;
+  error: Error;
+  message: string;
+} {
+  const error = toError(maybeError);
+  const status = "status" in error && typeof error.status === "number" ? error.status : undefined;
+
+  if (status === RATE_LIMITED_STATUS) {
+    return { code: ERROR_CODES.rateLimited, error, message: error.message };
+  }
+
+  if (
+    status !== undefined &&
+    status >= MINIMUM_CLIENT_ERROR_STATUS &&
+    status <= MAXIMUM_CLIENT_ERROR_STATUS
+  ) {
+    return { code: ERROR_CODES.clientError, error, message: error.message };
+  }
+
+  return { code: ERROR_CODES.unknown, error, message: error.message };
+}

--- a/packages/notifications/src/lib/notificationClient.test.ts
+++ b/packages/notifications/src/lib/notificationClient.test.ts
@@ -3,6 +3,7 @@ import { type LogFunction, type Logger, ServiceError } from "@clipboard-health/u
 import type { Knock } from "@knocklabs/node";
 import type { Mocked } from "vitest";
 
+import { ERROR_CODES } from "./errorCodes";
 import { MAXIMUM_RECIPIENTS_COUNT } from "./internal/chunkRecipients";
 import { IdempotentKnock } from "./internal/idempotentKnock";
 import { NotificationClient } from "./notificationClient";
@@ -184,6 +185,47 @@ describe(NotificationClient, () => {
         expect.any(Object),
       );
     });
+
+    it("surfaces 429 responses as rateLimited", async () => {
+      const mockError = createErrorWithStatus("Too many requests", 429);
+      vi.spyOn(provider.workflows, "trigger").mockRejectedValue(mockError);
+
+      const input: TriggerRequest = {
+        workflowKey: mockWorkflowKey,
+        body: { recipients: [{ userId: "user-1" }] },
+        idempotencyKey: mockIdempotencyKey,
+        keysToRedact: [],
+        expiresAt: mockExpiresAt,
+        attempt: mockAttempt,
+      };
+
+      const actual = await client.trigger(input);
+
+      expectToBeFailure(actual);
+      expect(actual.error.issues[0]?.code).toBe(ERROR_CODES.rateLimited);
+    });
+
+    it.each([400, 401, 403, 404, 422])(
+      "surfaces %s responses as clientError",
+      async (status: number) => {
+        const mockError = createErrorWithStatus(`Got ${status}`, status);
+        vi.spyOn(provider.workflows, "trigger").mockRejectedValue(mockError);
+
+        const input: TriggerRequest = {
+          workflowKey: mockWorkflowKey,
+          body: { recipients: [{ userId: "user-1" }] },
+          idempotencyKey: mockIdempotencyKey,
+          keysToRedact: [],
+          expiresAt: mockExpiresAt,
+          attempt: mockAttempt,
+        };
+
+        const actual = await client.trigger(input);
+
+        expectToBeFailure(actual);
+        expect(actual.error.issues[0]?.code).toBe(ERROR_CODES.clientError);
+      },
+    );
 
     it("redacts sensitive data in logs", async () => {
       const mockBody = {
@@ -726,6 +768,34 @@ describe(NotificationClient, () => {
         expect.any(Object),
       );
     });
+
+    it("surfaces 429 responses as rateLimited", async () => {
+      const mockError = createErrorWithStatus("Too many requests", 429);
+      vi.spyOn(provider.workflows, "cancel").mockRejectedValue(mockError);
+
+      const input: CancelRequest = {
+        workflowKey: mockWorkflowKey,
+        cancellationKey: mockCancellationKey,
+      };
+
+      await expect(client.cancel(input)).rejects.toMatchObject({
+        issues: [{ code: ERROR_CODES.rateLimited, message: "Too many requests" }],
+      });
+    });
+
+    it("surfaces other 4xx responses as clientError", async () => {
+      const mockError = createErrorWithStatus("bad request", 400);
+      vi.spyOn(provider.workflows, "cancel").mockRejectedValue(mockError);
+
+      const input: CancelRequest = {
+        workflowKey: mockWorkflowKey,
+        cancellationKey: mockCancellationKey,
+      };
+
+      await expect(client.cancel(input)).rejects.toMatchObject({
+        issues: [{ code: ERROR_CODES.clientError, message: "bad request" }],
+      });
+    });
   });
 
   describe("triggerChunked", () => {
@@ -909,6 +979,42 @@ describe(NotificationClient, () => {
 
       expectToBeFailure(actual);
       expect(actual.error.message).toContain("Knock API error");
+    });
+
+    it("surfaces 429 responses as rateLimited", async () => {
+      const mockError = createErrorWithStatus("Too many requests", 429);
+      vi.spyOn(provider.workflows, "trigger").mockRejectedValue(mockError);
+
+      const input: TriggerChunkedRequest = {
+        workflowKey: mockWorkflowKey,
+        body: { recipients: [{ userId: "user-1" }] },
+        idempotencyKey: mockIdempotencyKey,
+        expiresAt: mockExpiresAt,
+        attempt: mockAttempt,
+      };
+
+      const actual = await client.triggerChunked(input);
+
+      expectToBeFailure(actual);
+      expect(actual.error.issues[0]?.code).toBe(ERROR_CODES.rateLimited);
+    });
+
+    it("surfaces other 4xx responses as clientError", async () => {
+      const mockError = createErrorWithStatus("bad request", 400);
+      vi.spyOn(provider.workflows, "trigger").mockRejectedValue(mockError);
+
+      const input: TriggerChunkedRequest = {
+        workflowKey: mockWorkflowKey,
+        body: { recipients: [{ userId: "user-1" }] },
+        idempotencyKey: mockIdempotencyKey,
+        expiresAt: mockExpiresAt,
+        attempt: mockAttempt,
+      };
+
+      const actual = await client.triggerChunked(input);
+
+      expectToBeFailure(actual);
+      expect(actual.error.issues[0]?.code).toBe(ERROR_CODES.clientError);
     });
 
     it("handles string recipients", async () => {
@@ -1745,7 +1851,11 @@ fQ4QecZi2079UtRo1Amb8+wqaQ==
 });
 
 function createNotFoundError(): Error & { status: number } {
-  const error = new Error("Not found") as Error & { status: number };
-  error.status = 404;
+  return createErrorWithStatus("Not found", 404);
+}
+
+function createErrorWithStatus(message: string, status: number): Error & { status: number } {
+  const error = new Error(message) as Error & { status: number };
+  error.status = status;
   return error;
 }

--- a/packages/notifications/src/lib/notificationClient.ts
+++ b/packages/notifications/src/lib/notificationClient.ts
@@ -10,6 +10,7 @@ import {
 } from "@clipboard-health/util-ts";
 import { signUserToken } from "@knocklabs/node";
 
+import { ERROR_CODES, type ErrorCode } from "./errorCodes";
 import { chunkRecipients, MAXIMUM_RECIPIENTS_COUNT } from "./internal/chunkRecipients";
 import { createTriggerLogParams } from "./internal/createTriggerLogParams";
 import { createTriggerTraceOptions } from "./internal/createTriggerTraceOptions";
@@ -17,6 +18,7 @@ import { IdempotentKnock } from "./internal/idempotentKnock";
 import { parseTriggerIdempotencyKey } from "./internal/parseTriggerIdempotencyKey";
 import { redact } from "./internal/redact";
 import { toKnockUserPreferences } from "./internal/toKnockUserPreferences";
+import { toNotificationError } from "./internal/toNotificationError";
 import { toTenantSetRequest } from "./internal/toTenantSetRequest";
 import { toTriggerBody } from "./internal/toTriggerBody";
 import { triggerIdempotencyKeyParamsToHash } from "./internal/triggerIdempotencyKeyParamsToHash";
@@ -72,17 +74,6 @@ const LOG_PARAMS = {
     destination: "knock.users.setPreferences",
   },
 };
-export const ERROR_CODES = {
-  expired: "expired",
-  invalidExpiresAt: "invalidExpiresAt",
-  invalidIdempotencyKey: "invalidIdempotencyKey",
-  recipientCountBelowMinimum: "recipientCountBelowMinimum",
-  recipientCountAboveMaximum: "recipientCountAboveMaximum",
-  missingSigningKey: "missingSigningKey",
-  unknown: "unknown",
-} as const;
-
-export type ErrorCode = (typeof ERROR_CODES)[keyof typeof ERROR_CODES];
 
 interface NotificationError {
   code: ErrorCode;
@@ -161,12 +152,9 @@ export class NotificationClient {
 
           return success({ id });
         } catch (maybeError) {
-          const error = toError(maybeError);
+          const { code, error, message } = toNotificationError(maybeError);
           return this.createAndLogError({
-            notificationError: {
-              code: ERROR_CODES.unknown,
-              message: error.message,
-            },
+            notificationError: { code, message },
             span,
             logFunction: this.logger.error,
             logParams,
@@ -266,9 +254,13 @@ export class NotificationClient {
    *       const result = await this.client.triggerChunked(request);
    *
    *       if (isFailure(result)) {
-   *         // Skip expired notifications, retrying the job won't help.
-   *         if (result.error.issues[0]?.code === ERROR_CODES.expired) {
-   *           this.logger.warn("TriggerNotificationJob skipped due to expiry", { ...metadata });
+   *         const code = result.error.issues[0]?.code;
+   *
+   *         // Skip errors that retrying won't fix: expired notifications and non-429 4xx responses
+   *         // from the provider (e.g. validation errors, missing recipients). 429s surface as
+   *         // `rateLimited` and fall through to the throw below so the job retries with backoff.
+   *         if (code === ERROR_CODES.expired || code === ERROR_CODES.clientError) {
+   *           this.logger.warn("TriggerNotificationJob skipped", { ...metadata, code });
    *           return;
    *         }
    *
@@ -346,11 +338,11 @@ export class NotificationClient {
 
             responses.push({ chunkNumber: recipientChunk.number, id });
           } catch (maybeError) {
-            const error = toError(maybeError);
+            const { code, error, message } = toNotificationError(maybeError);
             return this.createAndLogError({
               notificationError: {
-                code: ERROR_CODES.unknown,
-                message: `Chunk ${recipientChunk.number}/${chunks.length} failed: ${error.message}`,
+                code,
+                message: `Chunk ${recipientChunk.number}/${chunks.length} failed: ${message}`,
               },
               span,
               logFunction: this.logger.error,
@@ -424,12 +416,9 @@ export class NotificationClient {
 
         this.logger.info(`${logParams.traceName} response`, logParams);
       } catch (maybeError) {
-        const error = toError(maybeError);
+        const { code, error, message } = toNotificationError(maybeError);
         const result = this.createAndLogError({
-          notificationError: {
-            code: ERROR_CODES.unknown,
-            message: error.message,
-          },
+          notificationError: { code, message },
           span,
           logFunction: this.logger.error,
           logParams,
@@ -472,12 +461,9 @@ export class NotificationClient {
 
       return success({ success: true });
     } catch (maybeError) {
-      const error = toError(maybeError);
+      const { code, error, message } = toNotificationError(maybeError);
       return this.createAndLogError({
-        notificationError: {
-          code: ERROR_CODES.unknown,
-          message: error.message,
-        },
+        notificationError: { code, message },
         logFunction: this.logger.error,
         logParams,
         metadata: { error },
@@ -523,12 +509,9 @@ export class NotificationClient {
 
       return success({ token: response });
     } catch (maybeError) {
-      const error = toError(maybeError);
+      const { code, error, message } = toNotificationError(maybeError);
       return this.createAndLogError({
-        notificationError: {
-          code: ERROR_CODES.unknown,
-          message: error.message,
-        },
+        notificationError: { code, message },
         logFunction: this.logger.error,
         logParams,
         metadata: { error },
@@ -561,12 +544,9 @@ export class NotificationClient {
         workplaceId: response.id,
       });
     } catch (maybeError) {
-      const error = toError(maybeError);
+      const { code, error, message } = toNotificationError(maybeError);
       return this.createAndLogError({
-        notificationError: {
-          code: ERROR_CODES.unknown,
-          message: error.message,
-        },
+        notificationError: { code, message },
         logFunction: this.logger.error,
         logParams,
         metadata: { error },
@@ -598,12 +578,9 @@ export class NotificationClient {
 
       return success({ userId });
     } catch (maybeError) {
-      const error = toError(maybeError);
+      const { code, error, message } = toNotificationError(maybeError);
       return this.createAndLogError({
-        notificationError: {
-          code: ERROR_CODES.unknown,
-          message: error.message,
-        },
+        notificationError: { code, message },
         logFunction: this.logger.error,
         logParams,
         metadata: { error },


### PR DESCRIPTION
Part of DEVOP-5060.

Summary
===
Triggering a workflow in a `TriggerNotificationJob` may fail with errors. Currently the `@clipboard-health/notifications` does not expose client errors and the job needlessly attempts to retry (~10 times, ~17minutes total) raising the error rates.

To enable better error handling, the PR updates the notification client to expose client errors. It distinguishes the 429 error since that one should actually be retried.

#### Breakdown of the Knock API errors

| Status | Meaning | Retry? |
|---|---|---|
| 400 `BadRequestError` | Malformed payload | No — same payload fails the same way |
| 401 `AuthenticationError` | Bad API key | No — key is the same on retry |
| 403 `PermissionDeniedError` | Not allowed | No |
| 404 `NotFoundError` | Unknown workflow/recipient | No |
| 422 `UnprocessableEntityError` | Validation | No |
| **429** `RateLimitError` | Throttled | **Yes** (transient) |
| 5xx, network, timeout | Server/infra | Yes |

Changes
---
- Extracted error codes into a separate file and added new ones,
- Added a helper that figures out the error code from error,
- Rewired every catch block,
- Added unit tests,
- Updated examples,
- Update `@knocklabs/node` to latest.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/clipboardhealth/core-utils/pull/586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
