### PR TITLE
feat(core): short-circuit commit-push-pr when nothing to ship

### DIFF
--- a/.agents/skills/commit-push-pr/SKILL.md
+++ b/.agents/skills/commit-push-pr/SKILL.md
@@ -7,17 +7,17 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 
 - Current branch: !`git branch --show-current`
 - Git status: !`git status --short`
-- Commits to push: !`git log --oneline @{u}..HEAD 2>/dev/null || echo "(no upstream)"`
+- Commits ahead of default branch: !`git log --oneline origin/HEAD..HEAD 2>/dev/null || echo "(unknown)"`
 - Existing PR: !`gh pr view --json url --jq .url 2>/dev/null || echo "none"`
 - Diff summary: !`git diff HEAD --stat`
 - Full diff: !`git diff HEAD`
 
 ## Your task
 
-**First, decide from the context above:**
+**First, decide from the context above. If `Commits ahead of default branch` is `(unknown)`, skip this decision and use the full flow below.**
 
-- If `Git status` is empty AND `Commits to push` is empty or `(no upstream)` AND `Existing PR` is `none`: stop. Reply with `nothing to ship.` and do nothing else.
-- If `Git status` is empty but there are `Commits to push` or an `Existing PR`: skip steps 1 and 2 below. Go straight to step 3 (push if needed) and step 4 (PR reconciliation).
+- If `Git status` is empty AND `Commits ahead of default branch` is empty AND `Existing PR` is `none`: stop. Reply with `nothing to ship.` and do nothing else.
+- If `Git status` is empty but there are `Commits ahead of default branch` or an `Existing PR`: skip steps 1 and 2 below. Go straight to step 3 (push if needed) and step 4 (PR reconciliation).
 - Otherwise: proceed with all steps below.
 
 Based on the above changes:

--- a/.agents/skills/commit-push-pr/SKILL.md
+++ b/.agents/skills/commit-push-pr/SKILL.md
@@ -17,7 +17,7 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 **First, decide from the context above. If `Commits ahead of default branch` is `(unknown)`, skip this decision and use the full flow below.**
 
 - If `Git status` is empty AND `Commits ahead of default branch` is empty AND `Existing PR` is `none`: stop. Reply with `nothing to ship.` and do nothing else.
-- If `Git status` is empty but there are `Commits ahead of default branch` or an `Existing PR`: skip steps 1 and 2 below. Go straight to step 3 (push if needed) and step 4 (PR reconciliation).
+- If `Git status` is empty but there are `Commits ahead of default branch` or an `Existing PR`: skip step 2 only (no changes to commit). Still run step 1 — its "if on main" check needs to fire so local commits on main are moved to a new branch rather than pushed directly to main. Then continue with step 3 and step 4.
 - Otherwise: proceed with all steps below.
 
 Based on the above changes:

--- a/.agents/skills/commit-push-pr/SKILL.md
+++ b/.agents/skills/commit-push-pr/SKILL.md
@@ -15,7 +15,7 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 **First, check the `Git status` context above:**
 
 - If it's empty AND the branch has no commits ahead of main (nothing to push, no existing PR): stop. Reply with `nothing to ship.` and do nothing else.
-- If it's empty but the branch has unpushed commits or an existing PR: skip steps 1 and 2 below. Go straight to step 3 (push if needed) and step 4 (PR reconciliation).
+- If it's empty but the branch has commits not yet on origin or an existing PR: skip steps 1 and 2 below. Go straight to step 3 (push if needed) and step 4 (PR reconciliation).
 - Otherwise: proceed with all steps below.
 
 Based on the above changes:

--- a/.agents/skills/commit-push-pr/SKILL.md
+++ b/.agents/skills/commit-push-pr/SKILL.md
@@ -7,15 +7,17 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 
 - Current branch: !`git branch --show-current`
 - Git status: !`git status --short`
+- Commits to push: !`git log --oneline @{u}..HEAD 2>/dev/null || echo "(no upstream)"`
+- Existing PR: !`gh pr view --json url --jq .url 2>/dev/null || echo "none"`
 - Diff summary: !`git diff HEAD --stat`
 - Full diff: !`git diff HEAD`
 
 ## Your task
 
-**First, check the `Git status` context above:**
+**First, decide from the context above:**
 
-- If it's empty AND the branch has no commits ahead of main (nothing to push, no existing PR): stop. Reply with `nothing to ship.` and do nothing else.
-- If it's empty but the branch has commits not yet on origin or an existing PR: skip steps 1 and 2 below. Go straight to step 3 (push if needed) and step 4 (PR reconciliation).
+- If `Git status` is empty AND `Commits to push` is empty or `(no upstream)` AND `Existing PR` is `none`: stop. Reply with `nothing to ship.` and do nothing else.
+- If `Git status` is empty but there are `Commits to push` or an `Existing PR`: skip steps 1 and 2 below. Go straight to step 3 (push if needed) and step 4 (PR reconciliation).
 - Otherwise: proceed with all steps below.
 
 Based on the above changes:

--- a/.agents/skills/commit-push-pr/SKILL.md
+++ b/.agents/skills/commit-push-pr/SKILL.md
@@ -12,6 +12,12 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 
 ## Your task
 
+**First, check the `Git status` context above:**
+
+- If it's empty AND the branch has no commits ahead of main (nothing to push, no existing PR): stop. Reply with `nothing to ship.` and do nothing else.
+- If it's empty but the branch has unpushed commits or an existing PR: skip steps 1 and 2 below. Go straight to step 3 (push if needed) and step 4 (PR reconciliation).
+- Otherwise: proceed with all steps below.
+
 Based on the above changes:
 
 1. Create a new branch if on main (e.g., `feat/add-user-validation`, `fix/null-check-in-parser`)

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Clipboard's core development tools.",
   "author": {
     "name": "Clipboard",

--- a/plugins/core/skills/commit-push-pr/SKILL.md
+++ b/plugins/core/skills/commit-push-pr/SKILL.md
@@ -7,17 +7,17 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 
 - Current branch: !`git branch --show-current`
 - Git status: !`git status --short`
-- Commits to push: !`git log --oneline @{u}..HEAD 2>/dev/null || echo "(no upstream)"`
+- Commits ahead of default branch: !`git log --oneline origin/HEAD..HEAD 2>/dev/null || echo "(unknown)"`
 - Existing PR: !`gh pr view --json url --jq .url 2>/dev/null || echo "none"`
 - Diff summary: !`git diff HEAD --stat`
 - Full diff: !`git diff HEAD`
 
 ## Your task
 
-**First, decide from the context above:**
+**First, decide from the context above. If `Commits ahead of default branch` is `(unknown)`, skip this decision and use the full flow below.**
 
-- If `Git status` is empty AND `Commits to push` is empty or `(no upstream)` AND `Existing PR` is `none`: stop. Reply with `nothing to ship.` and do nothing else.
-- If `Git status` is empty but there are `Commits to push` or an `Existing PR`: skip steps 1 and 2 below. Go straight to step 3 (push if needed) and step 4 (PR reconciliation).
+- If `Git status` is empty AND `Commits ahead of default branch` is empty AND `Existing PR` is `none`: stop. Reply with `nothing to ship.` and do nothing else.
+- If `Git status` is empty but there are `Commits ahead of default branch` or an `Existing PR`: skip steps 1 and 2 below. Go straight to step 3 (push if needed) and step 4 (PR reconciliation).
 - Otherwise: proceed with all steps below.
 
 Based on the above changes:

--- a/plugins/core/skills/commit-push-pr/SKILL.md
+++ b/plugins/core/skills/commit-push-pr/SKILL.md
@@ -17,7 +17,7 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 **First, decide from the context above. If `Commits ahead of default branch` is `(unknown)`, skip this decision and use the full flow below.**
 
 - If `Git status` is empty AND `Commits ahead of default branch` is empty AND `Existing PR` is `none`: stop. Reply with `nothing to ship.` and do nothing else.
-- If `Git status` is empty but there are `Commits ahead of default branch` or an `Existing PR`: skip steps 1 and 2 below. Go straight to step 3 (push if needed) and step 4 (PR reconciliation).
+- If `Git status` is empty but there are `Commits ahead of default branch` or an `Existing PR`: skip step 2 only (no changes to commit). Still run step 1 — its "if on main" check needs to fire so local commits on main are moved to a new branch rather than pushed directly to main. Then continue with step 3 and step 4.
 - Otherwise: proceed with all steps below.
 
 Based on the above changes:

--- a/plugins/core/skills/commit-push-pr/SKILL.md
+++ b/plugins/core/skills/commit-push-pr/SKILL.md
@@ -15,7 +15,7 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 **First, check the `Git status` context above:**
 
 - If it's empty AND the branch has no commits ahead of main (nothing to push, no existing PR): stop. Reply with `nothing to ship.` and do nothing else.
-- If it's empty but the branch has unpushed commits or an existing PR: skip steps 1 and 2 below. Go straight to step 3 (push if needed) and step 4 (PR reconciliation).
+- If it's empty but the branch has commits not yet on origin or an existing PR: skip steps 1 and 2 below. Go straight to step 3 (push if needed) and step 4 (PR reconciliation).
 - Otherwise: proceed with all steps below.
 
 Based on the above changes:

--- a/plugins/core/skills/commit-push-pr/SKILL.md
+++ b/plugins/core/skills/commit-push-pr/SKILL.md
@@ -7,15 +7,17 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 
 - Current branch: !`git branch --show-current`
 - Git status: !`git status --short`
+- Commits to push: !`git log --oneline @{u}..HEAD 2>/dev/null || echo "(no upstream)"`
+- Existing PR: !`gh pr view --json url --jq .url 2>/dev/null || echo "none"`
 - Diff summary: !`git diff HEAD --stat`
 - Full diff: !`git diff HEAD`
 
 ## Your task
 
-**First, check the `Git status` context above:**
+**First, decide from the context above:**
 
-- If it's empty AND the branch has no commits ahead of main (nothing to push, no existing PR): stop. Reply with `nothing to ship.` and do nothing else.
-- If it's empty but the branch has commits not yet on origin or an existing PR: skip steps 1 and 2 below. Go straight to step 3 (push if needed) and step 4 (PR reconciliation).
+- If `Git status` is empty AND `Commits to push` is empty or `(no upstream)` AND `Existing PR` is `none`: stop. Reply with `nothing to ship.` and do nothing else.
+- If `Git status` is empty but there are `Commits to push` or an `Existing PR`: skip steps 1 and 2 below. Go straight to step 3 (push if needed) and step 4 (PR reconciliation).
 - Otherwise: proceed with all steps below.
 
 Based on the above changes:

--- a/plugins/core/skills/commit-push-pr/SKILL.md
+++ b/plugins/core/skills/commit-push-pr/SKILL.md
@@ -12,6 +12,12 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 
 ## Your task
 
+**First, check the `Git status` context above:**
+
+- If it's empty AND the branch has no commits ahead of main (nothing to push, no existing PR): stop. Reply with `nothing to ship.` and do nothing else.
+- If it's empty but the branch has unpushed commits or an existing PR: skip steps 1 and 2 below. Go straight to step 3 (push if needed) and step 4 (PR reconciliation).
+- Otherwise: proceed with all steps below.
+
 Based on the above changes:
 
 1. Create a new branch if on main (e.g., `feat/add-user-validation`, `fix/null-check-in-parser`)


### PR DESCRIPTION
Summary
===
The commit-push-pr skill previously assumed a dirty working tree. When the agent invoked it on a clean branch that just needed pushing or PR reconciliation, it would still try to stage/commit — wasting tool calls or producing empty commits.

This adds an explicit short-circuit at the top of "Your task": refuse cleanly when there is truly nothing to do, skip the commit step when the tree is clean but work is unpushed, and otherwise proceed as before.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/clipboardhealth/core-utils/pull/590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
