### PR TITLE
refactor(core): simplify babysit-pr scripts

### DIFF
--- a/.agents/skills/babysit-pr/scripts/_sentinel.sh
+++ b/.agents/skills/babysit-pr/scripts/_sentinel.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# _sentinel.sh — shared SENTINEL constant + append helper.
+# Sourced by unresolvedPrComments.sh, postSentinelReply.sh, postSentinelPrComment.sh.
+# Keeping the sentinel in one place prevents a version bump from silently
+# diverging between the posting scripts and the reader's recency detector.
+
+SENTINEL='<!-- babysit-pr:addressed v1 -->'
+
+# Echo $1 with the sentinel appended on its own trailing paragraph, unless
+# the body already ends with the sentinel.
+ensure_sentinel() {
+  local body="$1"
+  case "$body" in
+    *"$SENTINEL") printf '%s' "$body" ;;
+    *) printf '%s\n\n%s' "$body" "$SENTINEL" ;;
+  esac
+}

--- a/.agents/skills/babysit-pr/scripts/parseNitpicks.sh
+++ b/.agents/skills/babysit-pr/scripts/parseNitpicks.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # parseNitpicks.sh — Parse CodeRabbit nitpick comments from PR review bodies.
-# Copied from plugins/core/skills/unresolved-pr-comments/scripts/parseNitpicks.sh
-# with one addition: each emitted nitpick includes a stable `fingerprint` field
+#
+# Each emitted nitpick includes a stable `fingerprint` field
 # (sha256 of file + normalized line range + title + body), so reposted reviews
 # dedupe to the same fingerprint. Source review timestamps are kept as
 # `createdAt` metadata but NOT included in the fingerprint.
 #
-# Sourced by unresolvedPrComments.sh. Requires: jq, perl with Digest::SHA + Encode.
+# Sourced by unresolvedPrComments.sh. Requires: perl with Digest::SHA + Encode.
 
 extract_nitpick_comments() {
   local reviews_json="$1"
@@ -123,10 +123,4 @@ sub trim {
   return $s;
 }
 '
-}
-
-# Extract code scanning alert number from comment body.
-extract_code_scanning_alert_number() {
-  local body="$1"
-  printf '%s' "$body" | perl -ne 'print $1 if m{/code-scanning/(\d+)}'
 }

--- a/.agents/skills/babysit-pr/scripts/postSentinelPrComment.sh
+++ b/.agents/skills/babysit-pr/scripts/postSentinelPrComment.sh
@@ -8,7 +8,9 @@
 
 set -euo pipefail
 
-SENTINEL='<!-- babysit-pr:addressed v1 -->'
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=_sentinel.sh
+source "${SCRIPT_DIR}/_sentinel.sh"
 
 if [ $# -lt 2 ]; then
   printf '{"error":"Usage: postSentinelPrComment.sh <pr-number> <body>"}\n' >&2
@@ -27,14 +29,7 @@ if [ -z "$BODY" ]; then
   exit 2
 fi
 
-case "$BODY" in
-  *"$SENTINEL") ;;
-  *)
-    BODY="${BODY}
-
-${SENTINEL}"
-    ;;
-esac
+BODY="$(ensure_sentinel "$BODY")"
 
 repo_json="$(gh repo view --json owner,name 2>/dev/null)" || {
   printf '{"error":"Could not determine repository."}\n' >&2

--- a/.agents/skills/babysit-pr/scripts/postSentinelReply.sh
+++ b/.agents/skills/babysit-pr/scripts/postSentinelReply.sh
@@ -11,7 +11,9 @@
 
 set -euo pipefail
 
-SENTINEL='<!-- babysit-pr:addressed v1 -->'
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=_sentinel.sh
+source "${SCRIPT_DIR}/_sentinel.sh"
 
 if [ $# -lt 2 ]; then
   printf '{"error":"Usage: postSentinelReply.sh <thread-id> <body>"}\n' >&2
@@ -30,15 +32,7 @@ if [ -z "$BODY" ]; then
   exit 2
 fi
 
-# Ensure sentinel is present at the end.
-case "$BODY" in
-  *"$SENTINEL") ;;
-  *)
-    BODY="${BODY}
-
-${SENTINEL}"
-    ;;
-esac
+BODY="$(ensure_sentinel "$BODY")"
 
 MUTATION='
 mutation($threadId: ID!, $body: String!) {

--- a/.agents/skills/babysit-pr/scripts/unresolvedPrComments.sh
+++ b/.agents/skills/babysit-pr/scripts/unresolvedPrComments.sh
@@ -11,8 +11,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=parseNitpicks.sh
 source "${SCRIPT_DIR}/parseNitpicks.sh"
-
-SENTINEL='<!-- babysit-pr:addressed v1 -->'
+# shellcheck source=_sentinel.sh
+source "${SCRIPT_DIR}/_sentinel.sh"
 
 exec 3>&1
 
@@ -283,7 +283,7 @@ main() {
     ]
   ')"
 
-  # Flattened unresolved_comments (retained for backward compat with the prose summary).
+  # Flattened unresolved_comments — retained for backward compat with the prose summary.
   # Includes comments from "active" AND "uncertain" threads so the agent never misses new feedback.
   local all_unresolved
   all_unresolved="$(printf '%s' "$threads_json" | jq '[
@@ -300,40 +300,45 @@ main() {
       }
   ]')"
 
-  # Filter out fixed code-scanning alerts from github-advanced-security
-  local unresolved_comments="[]"
-  local count
-  count="$(printf '%s' "$all_unresolved" | jq 'length')"
+  # Filter out fixed code-scanning alerts from github-advanced-security.
+  # Two-pass: collect unique alert numbers, query each once, then drop matching
+  # comments in a single jq pass. Avoids the O(N²) rebuild and duplicate gh api
+  # calls the naive per-comment loop would incur.
+  # github-advanced-security posts under either login depending on account type
+  # (app vs direct) — both forms match below.
+  local security_alerts
+  security_alerts="$(printf '%s' "$all_unresolved" | jq -r '
+    .[]
+    | select(.author == "github-advanced-security" or .author == "github-advanced-security[bot]")
+    | try (.body | capture("/code-scanning/(?<n>[0-9]+)") | .n)
+  ' | sort -u)"
 
-  local i=0
-  while [ "$i" -lt "$count" ]; do
-    local comment
-    comment="$(printf '%s' "$all_unresolved" | jq ".[$i]")"
-    local comment_author
-    comment_author="$(printf '%s' "$comment" | jq -r '.author')"
-
-    local keep=true
-    # GitHub Advanced Security's bot posts under either login depending on account
-    # type (app installation vs. direct). Match both forms.
-    case "$comment_author" in
-      "github-advanced-security"|"github-advanced-security[bot]")
-        local comment_body alert_number
-        comment_body="$(printf '%s' "$comment" | jq -r '.body')"
-        alert_number="$(extract_code_scanning_alert_number "$comment_body")"
-        if [ -n "$alert_number" ]; then
-          if is_code_scanning_alert_fixed "$owner" "$repo" "$alert_number"; then
-            keep=false
-          fi
-        fi
-        ;;
-    esac
-
-    if [ "$keep" = true ]; then
-      unresolved_comments="$(printf '%s' "$unresolved_comments" | jq --argjson c "$comment" '. + [$c]')"
+  local fixed_alerts="" alert_number
+  for alert_number in $security_alerts; do
+    if is_code_scanning_alert_fixed "$owner" "$repo" "$alert_number"; then
+      fixed_alerts="${fixed_alerts} ${alert_number}"
     fi
-
-    i=$((i + 1))
   done
+
+  local unresolved_comments
+  if [ -z "$fixed_alerts" ]; then
+    unresolved_comments="$all_unresolved"
+  else
+    # capture() on a non-matching string produces ZERO outputs (not null, not an
+    # error). Without the `// null` guard below, `as $n` would bind to nothing
+    # and the map entry would silently collapse to empty — dropping
+    # github-advanced-security comments that reference no code-scanning URL.
+    unresolved_comments="$(printf '%s' "$all_unresolved" | jq --arg fixed "$fixed_alerts" '
+      ($fixed | split(" ") | map(select(length > 0))) as $fixedSet
+      | map(
+          . as $c
+          | if ($c.author == "github-advanced-security" or $c.author == "github-advanced-security[bot]") then
+              (((try ($c.body | capture("/code-scanning/(?<n>[0-9]+)") | .n)) // null)) as $n
+              | if ($n != null and ($n | IN($fixedSet[]))) then empty else $c end
+            else $c end
+        )
+    ')"
+  fi
 
   # Nitpicks from coderabbit review bodies
   local reviews_json

--- a/plugins/core/skills/babysit-pr/scripts/_sentinel.sh
+++ b/plugins/core/skills/babysit-pr/scripts/_sentinel.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# _sentinel.sh — shared SENTINEL constant + append helper.
+# Sourced by unresolvedPrComments.sh, postSentinelReply.sh, postSentinelPrComment.sh.
+# Keeping the sentinel in one place prevents a version bump from silently
+# diverging between the posting scripts and the reader's recency detector.
+
+SENTINEL='<!-- babysit-pr:addressed v1 -->'
+
+# Echo $1 with the sentinel appended on its own trailing paragraph, unless
+# the body already ends with the sentinel.
+ensure_sentinel() {
+  local body="$1"
+  case "$body" in
+    *"$SENTINEL") printf '%s' "$body" ;;
+    *) printf '%s\n\n%s' "$body" "$SENTINEL" ;;
+  esac
+}

--- a/plugins/core/skills/babysit-pr/scripts/parseNitpicks.sh
+++ b/plugins/core/skills/babysit-pr/scripts/parseNitpicks.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # parseNitpicks.sh — Parse CodeRabbit nitpick comments from PR review bodies.
-# Copied from plugins/core/skills/unresolved-pr-comments/scripts/parseNitpicks.sh
-# with one addition: each emitted nitpick includes a stable `fingerprint` field
+#
+# Each emitted nitpick includes a stable `fingerprint` field
 # (sha256 of file + normalized line range + title + body), so reposted reviews
 # dedupe to the same fingerprint. Source review timestamps are kept as
 # `createdAt` metadata but NOT included in the fingerprint.
 #
-# Sourced by unresolvedPrComments.sh. Requires: jq, perl with Digest::SHA + Encode.
+# Sourced by unresolvedPrComments.sh. Requires: perl with Digest::SHA + Encode.
 
 extract_nitpick_comments() {
   local reviews_json="$1"
@@ -123,10 +123,4 @@ sub trim {
   return $s;
 }
 '
-}
-
-# Extract code scanning alert number from comment body.
-extract_code_scanning_alert_number() {
-  local body="$1"
-  printf '%s' "$body" | perl -ne 'print $1 if m{/code-scanning/(\d+)}'
 }

--- a/plugins/core/skills/babysit-pr/scripts/postSentinelPrComment.sh
+++ b/plugins/core/skills/babysit-pr/scripts/postSentinelPrComment.sh
@@ -8,7 +8,9 @@
 
 set -euo pipefail
 
-SENTINEL='<!-- babysit-pr:addressed v1 -->'
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=_sentinel.sh
+source "${SCRIPT_DIR}/_sentinel.sh"
 
 if [ $# -lt 2 ]; then
   printf '{"error":"Usage: postSentinelPrComment.sh <pr-number> <body>"}\n' >&2
@@ -27,14 +29,7 @@ if [ -z "$BODY" ]; then
   exit 2
 fi
 
-case "$BODY" in
-  *"$SENTINEL") ;;
-  *)
-    BODY="${BODY}
-
-${SENTINEL}"
-    ;;
-esac
+BODY="$(ensure_sentinel "$BODY")"
 
 repo_json="$(gh repo view --json owner,name 2>/dev/null)" || {
   printf '{"error":"Could not determine repository."}\n' >&2

--- a/plugins/core/skills/babysit-pr/scripts/postSentinelReply.sh
+++ b/plugins/core/skills/babysit-pr/scripts/postSentinelReply.sh
@@ -11,7 +11,9 @@
 
 set -euo pipefail
 
-SENTINEL='<!-- babysit-pr:addressed v1 -->'
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=_sentinel.sh
+source "${SCRIPT_DIR}/_sentinel.sh"
 
 if [ $# -lt 2 ]; then
   printf '{"error":"Usage: postSentinelReply.sh <thread-id> <body>"}\n' >&2
@@ -30,15 +32,7 @@ if [ -z "$BODY" ]; then
   exit 2
 fi
 
-# Ensure sentinel is present at the end.
-case "$BODY" in
-  *"$SENTINEL") ;;
-  *)
-    BODY="${BODY}
-
-${SENTINEL}"
-    ;;
-esac
+BODY="$(ensure_sentinel "$BODY")"
 
 MUTATION='
 mutation($threadId: ID!, $body: String!) {

--- a/plugins/core/skills/babysit-pr/scripts/unresolvedPrComments.sh
+++ b/plugins/core/skills/babysit-pr/scripts/unresolvedPrComments.sh
@@ -11,8 +11,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=parseNitpicks.sh
 source "${SCRIPT_DIR}/parseNitpicks.sh"
-
-SENTINEL='<!-- babysit-pr:addressed v1 -->'
+# shellcheck source=_sentinel.sh
+source "${SCRIPT_DIR}/_sentinel.sh"
 
 exec 3>&1
 
@@ -283,7 +283,7 @@ main() {
     ]
   ')"
 
-  # Flattened unresolved_comments (retained for backward compat with the prose summary).
+  # Flattened unresolved_comments — retained for backward compat with the prose summary.
   # Includes comments from "active" AND "uncertain" threads so the agent never misses new feedback.
   local all_unresolved
   all_unresolved="$(printf '%s' "$threads_json" | jq '[
@@ -300,40 +300,45 @@ main() {
       }
   ]')"
 
-  # Filter out fixed code-scanning alerts from github-advanced-security
-  local unresolved_comments="[]"
-  local count
-  count="$(printf '%s' "$all_unresolved" | jq 'length')"
+  # Filter out fixed code-scanning alerts from github-advanced-security.
+  # Two-pass: collect unique alert numbers, query each once, then drop matching
+  # comments in a single jq pass. Avoids the O(N²) rebuild and duplicate gh api
+  # calls the naive per-comment loop would incur.
+  # github-advanced-security posts under either login depending on account type
+  # (app vs direct) — both forms match below.
+  local security_alerts
+  security_alerts="$(printf '%s' "$all_unresolved" | jq -r '
+    .[]
+    | select(.author == "github-advanced-security" or .author == "github-advanced-security[bot]")
+    | try (.body | capture("/code-scanning/(?<n>[0-9]+)") | .n)
+  ' | sort -u)"
 
-  local i=0
-  while [ "$i" -lt "$count" ]; do
-    local comment
-    comment="$(printf '%s' "$all_unresolved" | jq ".[$i]")"
-    local comment_author
-    comment_author="$(printf '%s' "$comment" | jq -r '.author')"
-
-    local keep=true
-    # GitHub Advanced Security's bot posts under either login depending on account
-    # type (app installation vs. direct). Match both forms.
-    case "$comment_author" in
-      "github-advanced-security"|"github-advanced-security[bot]")
-        local comment_body alert_number
-        comment_body="$(printf '%s' "$comment" | jq -r '.body')"
-        alert_number="$(extract_code_scanning_alert_number "$comment_body")"
-        if [ -n "$alert_number" ]; then
-          if is_code_scanning_alert_fixed "$owner" "$repo" "$alert_number"; then
-            keep=false
-          fi
-        fi
-        ;;
-    esac
-
-    if [ "$keep" = true ]; then
-      unresolved_comments="$(printf '%s' "$unresolved_comments" | jq --argjson c "$comment" '. + [$c]')"
+  local fixed_alerts="" alert_number
+  for alert_number in $security_alerts; do
+    if is_code_scanning_alert_fixed "$owner" "$repo" "$alert_number"; then
+      fixed_alerts="${fixed_alerts} ${alert_number}"
     fi
-
-    i=$((i + 1))
   done
+
+  local unresolved_comments
+  if [ -z "$fixed_alerts" ]; then
+    unresolved_comments="$all_unresolved"
+  else
+    # capture() on a non-matching string produces ZERO outputs (not null, not an
+    # error). Without the `// null` guard below, `as $n` would bind to nothing
+    # and the map entry would silently collapse to empty — dropping
+    # github-advanced-security comments that reference no code-scanning URL.
+    unresolved_comments="$(printf '%s' "$all_unresolved" | jq --arg fixed "$fixed_alerts" '
+      ($fixed | split(" ") | map(select(length > 0))) as $fixedSet
+      | map(
+          . as $c
+          | if ($c.author == "github-advanced-security" or $c.author == "github-advanced-security[bot]") then
+              (((try ($c.body | capture("/code-scanning/(?<n>[0-9]+)") | .n)) // null)) as $n
+              | if ($n != null and ($n | IN($fixedSet[]))) then empty else $c end
+            else $c end
+        )
+    ')"
+  fi
 
   # Nitpicks from coderabbit review bodies
   local reviews_json


### PR DESCRIPTION
## Summary

- Replace the per-comment filter loop in `unresolvedPrComments.sh` with a two-pass approach: collect unique code-scanning alert numbers, query each once, then drop matching comments in a single jq pass. Eliminates both the O(N²) accumulator rebuild and the duplicate `gh api` calls for the same alert.
- Extract the `SENTINEL` constant and sentinel-append logic into `_sentinel.sh`, sourced by the three scripts that need it. The constant was previously duplicated across `unresolvedPrComments.sh`, `postSentinelReply.sh`, and `postSentinelPrComment.sh` — a silent correctness hazard if the version ever bumped in one file and not the others.
- Remove the now-unused `extract_code_scanning_alert_number` perl helper and refresh a stale header comment in `parseNitpicks.sh`.

## Test plan

- [x] `bash -n` passes for every script in the directory
- [x] Synthetic jq filter test: 5-comment payload with fixedSet `{42,100}` correctly keeps the non-GitHub-Advanced-Security comment, keeps alerts not in the set, keeps comments that reference no alert at all, and drops only the two alerts in the set
- [x] `node --run sync-ai-rules` reran cleanly and `.agents/skills/` mirrors the plugin source

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/clipboardhealth/core-utils/pull/592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
