### PR TITLE
fix(ai-rules): add comment explaining error stack preference

### DIFF
--- a/packages/ai-rules/scripts/toErrorMessage.ts
+++ b/packages/ai-rules/scripts/toErrorMessage.ts
@@ -1,3 +1,4 @@
+// Prefer stack over message for Error instances to preserve debugging context.
 export function toErrorMessage(error: unknown): string {
   return error instanceof Error ? (error.stack ?? error.message) : String(error);
 }


### PR DESCRIPTION
## Summary

Adds a brief comment in `toErrorMessage` clarifying why `error.stack` is preferred over `error.message` for `Error` instances — the stack carries more debugging context for logs and observability.

Uses `fix:` so semantic-release publishes a new patch version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/clipboardhealth/core-utils/pull/595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
