### PR TITLE
feat(core): add go workflow and pre-pr simplification

### DIFF
--- a/.agents/skills/commit-push-pr/SKILL.md
+++ b/.agents/skills/commit-push-pr/SKILL.md
@@ -27,7 +27,7 @@ Based on the above changes:
 3. Re-check `git status --short`. If there are changes, create a single conventional commit message.
 4. Push the branch to origin
 5. Check for an existing PR with `gh pr view`.
-   - No PR exists: Create with `gh pr create`. Title = commit subject line. Description = brief explanation of **why**, not what.
+   - No PR exists: Create with `gh pr create`. Title = commit subject line. Description = brief explanation of **why**, not what. Append `<!-- commit-push-pr:created v1 -->` on its own line at the end of the PR description so skill-created PRs can be identified later.
    - PR exists: Report the URL and move on.
 6. You have the capability to call multiple tools in a single response. After the `simplify` skill completes, do the remaining git and PR operations in a single message. Do not use any other tools or do anything else.
 7. After tool calls complete, send one short final text response with the branch name and the full PR URL (e.g., `https://github.com/clipboardhealth/core-utils/pull/123`). Never use shorthand like `repo#123` — always output the complete URL so it is clickable.

--- a/.agents/skills/commit-push-pr/SKILL.md
+++ b/.agents/skills/commit-push-pr/SKILL.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr view:*), Bash(gh pr create:*), Bash(git diff:*)
+allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr view:*), Bash(gh pr create:*), Bash(git diff:*), Bash(git merge-base:*)
 description: Commit, push, and open a PR. Use when the user wants to ship changes, create a pull request, or says things like 'commit and push', 'open a PR', 'ship it', 'send it', 'create a PR for this', or 'push this up'.
 ---
 
@@ -17,16 +17,17 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 **First, decide from the context above. If `Commits ahead of default branch` is `(unknown)`, skip this decision and use the full flow below.**
 
 - If `Git status` is empty AND `Commits ahead of default branch` is empty AND `Existing PR` is `none`: stop. Reply with `nothing to ship.` and do nothing else.
-- If `Git status` is empty but there are `Commits ahead of default branch` or an `Existing PR`: skip step 2 only (no changes to commit). Still run step 1 — its "if on main" check needs to fire so local commits on main are moved to a new branch rather than pushed directly to main. Then continue with step 3 and step 4.
+- If `Git status` is empty but there are `Commits ahead of default branch` or an `Existing PR`: still run step 1 and step 2. Then re-check `git status --short`; skip step 3 only if it remains empty. Then continue with step 4 and step 5.
 - Otherwise: proceed with all steps below.
 
 Based on the above changes:
 
 1. Create a new branch if on main (e.g., `feat/add-user-validation`, `fix/null-check-in-parser`)
-2. Create a single conventional commit message
-3. Push the branch to origin
-4. Check for an existing PR with `gh pr view`.
+2. Run the `simplify` skill on the files included in the PR before committing, pushing, or opening the PR. If the working tree is clean, run `simplify` against `git diff $(git merge-base HEAD origin/HEAD)..HEAD`. If the working tree has changes, run it against `git diff HEAD`; when local commits also exist, include `git diff $(git merge-base HEAD origin/HEAD)..HEAD` as additional PR context. Invoke the skill by name using this agent's normal skill invocation mechanism, not a hard-coded host-specific command. Wait for the skill to finish, then include any resulting fixes in the commit step below.
+3. Re-check `git status --short`. If there are changes, create a single conventional commit message.
+4. Push the branch to origin
+5. Check for an existing PR with `gh pr view`.
    - No PR exists: Create with `gh pr create`. Title = commit subject line. Description = brief explanation of **why**, not what.
    - PR exists: Report the URL and move on.
-5. You have the capability to call multiple tools in a single response. You MUST do all of the above in a single message. Do not use any other tools or do anything else.
-6. After tool calls complete, send one short final text response with the branch name and the full PR URL (e.g., `https://github.com/clipboardhealth/core-utils/pull/123`). Never use shorthand like `repo#123` — always output the complete URL so it is clickable.
+6. You have the capability to call multiple tools in a single response. After the `simplify` skill completes, do the remaining git and PR operations in a single message. Do not use any other tools or do anything else.
+7. After tool calls complete, send one short final text response with the branch name and the full PR URL (e.g., `https://github.com/clipboardhealth/core-utils/pull/123`). Never use shorthand like `repo#123` — always output the complete URL so it is clickable.

--- a/.agents/skills/commit-push-pr/SKILL.md
+++ b/.agents/skills/commit-push-pr/SKILL.md
@@ -23,7 +23,7 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 Based on the above changes:
 
 1. Create a new branch if on main (e.g., `feat/add-user-validation`, `fix/null-check-in-parser`)
-2. Run the `simplify` skill on the files included in the PR before committing, pushing, or opening the PR. If the working tree is clean, run `simplify` against `git diff $(git merge-base HEAD origin/HEAD)..HEAD`. If the working tree has changes, run it against `git diff HEAD`; when local commits also exist, include `git diff $(git merge-base HEAD origin/HEAD)..HEAD` as additional PR context. Invoke the skill by name using this agent's normal skill invocation mechanism, not a hard-coded host-specific command. Wait for the skill to finish, then include any resulting fixes in the commit step below.
+2. Run the `simplify` skill on the files included in the PR before committing, pushing, or opening the PR. If the working tree is clean, run `simplify` against `git diff $(git merge-base HEAD origin/HEAD)..HEAD`. If the working tree has changes, run it against `git diff HEAD`; when local commits also exist, include `git diff $(git merge-base HEAD origin/HEAD)..HEAD` as additional PR context. Invoke the skill by name using this agent's normal skill invocation mechanism. Wait for the skill to finish, then include any resulting fixes in the commit step below.
 3. Re-check `git status --short`. If there are changes, create a single conventional commit message.
 4. Push the branch to origin
 5. Check for an existing PR with `gh pr view`.

--- a/.agents/skills/go/SKILL.md
+++ b/.agents/skills/go/SKILL.md
@@ -1,0 +1,60 @@
+---
+description: Implement a plan file end-to-end, then hand off to commit-push-pr to ship it. Use when the user says 'go', 'execute the plan', 'implement the plan', or hands off a plan file for execution.
+---
+
+# Go: Execute a Plan and Ship It
+
+Given a plan file, implement everything the plan describes, then invoke the `commit-push-pr` skill to commit, push, and open a PR.
+
+This skill is the bridge between planning and shipping. It does not re-plan or re-design — the plan is the source of truth. If the plan is wrong, surface that; do not silently improvise.
+
+## Phase 1: Locate and Read the Plan
+
+The user invokes this skill with a plan file path or identifier as an argument. Resolve it in this order:
+
+1. **Absolute path** (starts with `/`): read it directly.
+2. **Relative path** (contains `/` or starts with `./`): resolve from the current working directory.
+3. **Bare name** (no path separators, e.g. `my-plan` or `my-plan.md`): look in the host's plans directory. Use whatever directory the current host stores plan files in — do not hard-code a host-specific path. If the host does not expose a plans directory, ask the user where the plan lives.
+4. **No argument given**: ask the user to provide the plan file path. Do not guess.
+
+If the plan file does not exist or cannot be read, stop and tell the user. Do not proceed without a plan.
+
+Read the entire plan before starting. Note the **Critical files**, **Approach**, and **Verification** sections (or their equivalents).
+
+## Phase 2: Implement the Plan
+
+Treat the plan as the source of truth for scope:
+
+- Make exactly the changes the plan describes — no more, no less. Do not add extra refactors, tests, or cleanup the plan did not ask for.
+- If the plan references files, functions, or utilities that no longer exist, stop and surface the discrepancy before guessing.
+- If you discover the plan is wrong (the codebase has moved, an assumption is invalid, a constraint was missed), stop and report. Do not silently rewrite the approach.
+- Do **not** modify the plan file itself.
+
+## Phase 3: Validate
+
+Validation is **mandatory** and runs on every invocation, even when the plan does not include a Verification section. A missing or incomplete Verification section is not permission to skip validation — it is a gap to close.
+
+Run validation in this order:
+
+1. **Repo-mandated pre-PR checks.** Look up the repo's standard pre-PR command. Common signals, in priority order:
+   - An explicit instruction in the repo's agent or contributor instructions, such as `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, or an equivalent host-specific instruction file (e.g. "MUST run before opening PRs"). This wins over everything else.
+   - A conventionally-named script in `package.json` / Python project config / `Makefile` / etc. — `affected`, `precommit`, `validate`, `check`, `verify`, `test`, `lint`, `typecheck`, or repo-equivalent.
+   - If nothing else, run the project's lint + typecheck + test commands directly.
+
+   If you cannot determine the right command, ask the user before proceeding — do not silently skip.
+
+2. **Plan-specific verification.** If the plan has a Verification section, run those checks too. They are additive to (not a replacement for) the repo-mandated checks.
+
+If any check fails, fix the failures and re-run. Do not hand off to `commit-push-pr` with failing checks. If a failure looks pre-existing (unrelated to your changes), confirm that with the user before proceeding — do not assume.
+
+## Phase 4: Hand Off to commit-push-pr
+
+Once implementation is complete and Phase 3 validation passes, invoke the `commit-push-pr` skill by name using this agent's normal skill invocation mechanism — not a hard-coded host-specific command. That skill handles branching (if needed), running `simplify` on the changed files, committing, pushing, and opening the PR.
+
+Do **not** commit, push, or open the PR yourself in this skill. Let `commit-push-pr` own that flow so the shipping logic stays in one place.
+
+If `commit-push-pr` reports `nothing to ship.` (the plan resulted in no actual file changes), surface that to the user — it usually means the plan was already implemented or the plan was a no-op.
+
+## Phase 5: Final Output
+
+After `commit-push-pr` returns, send one short final response with the branch name and the full PR URL it produced. If `commit-push-pr` reported nothing to ship, say so plainly.

--- a/.agents/skills/go/SKILL.md
+++ b/.agents/skills/go/SKILL.md
@@ -12,7 +12,7 @@ This skill is the bridge between intent and shipping. It does not re-plan or re-
 
 The user may invoke this skill with either a plan file path/identifier or a direct implementation request such as "add a button to the homepage to log in." Resolve the input in this order:
 
-1. **Absolute path** (starts with `/`): read it directly.
+1. **Absolute path** (starts with `/`): read it directly only when it is inside the current workspace/repo root or the host's plans directory. If it is outside those roots, ask the user to confirm before reading it; if they do not confirm, stop and ask for an approved path.
 2. **Relative path** (contains `/` or starts with `./`): resolve from the current working directory.
 3. **Bare name** (no path separators, e.g. `my-plan` or `my-plan.md`): if the host exposes a plans directory, look there first. Use whatever directory the current host stores plan files in — do not hard-code a host-specific path. If no plan is found and the input is ambiguous, ask whether it is a plan identifier or an implementation request.
 4. **Natural-language request** (for example, contains spaces or reads like an implementation task): treat it as the implementation request. There may be no separate plan file.
@@ -59,4 +59,4 @@ If `commit-push-pr` reports `nothing to ship.` (the work resulted in no actual f
 
 ## Phase 5: Final Output
 
-After `commit-push-pr` returns, send one short final response with the branch name and the full PR URL it produced. If `commit-push-pr` reported nothing to ship, say so plainly.
+After `commit-push-pr` returns, ensure the user sees one short final response with the branch name and the full PR URL it produced. If the current host already surfaced that response, do not duplicate it. If `commit-push-pr` reported nothing to ship, say so plainly.

--- a/.agents/skills/go/SKILL.md
+++ b/.agents/skills/go/SKILL.md
@@ -1,59 +1,61 @@
 ---
-description: Implement a plan file end-to-end, then hand off to commit-push-pr to ship it. Use when the user says 'go', 'execute the plan', 'implement the plan', or hands off a plan file for execution.
+description: Implement a plan file or direct request end-to-end, then hand off to commit-push-pr to ship it. Use when the user says 'go', 'execute the plan', 'implement the plan', or gives an implementation request.
 ---
 
-# Go: Execute a Plan and Ship It
+# Go: Execute Work and Ship It
 
-Given a plan file, implement everything the plan describes, then invoke the `commit-push-pr` skill to commit, push, and open a PR.
+Given a plan file or direct implementation request, implement the requested work, then invoke the `commit-push-pr` skill to commit, push, and open a PR.
 
-This skill is the bridge between planning and shipping. It does not re-plan or re-design — the plan is the source of truth. If the plan is wrong, surface that; do not silently improvise.
+This skill is the bridge between intent and shipping. It does not re-plan or re-design unless the user asked for that. If the request is wrong or cannot be implemented safely, surface that; do not silently improvise.
 
-## Phase 1: Locate and Read the Plan
+## Phase 1: Understand the Input
 
-The user invokes this skill with a plan file path or identifier as an argument. Resolve it in this order:
+The user may invoke this skill with either a plan file path/identifier or a direct implementation request such as "add a button to the homepage to log in." Resolve the input in this order:
 
 1. **Absolute path** (starts with `/`): read it directly.
 2. **Relative path** (contains `/` or starts with `./`): resolve from the current working directory.
-3. **Bare name** (no path separators, e.g. `my-plan` or `my-plan.md`): look in the host's plans directory. Use whatever directory the current host stores plan files in — do not hard-code a host-specific path. If the host does not expose a plans directory, ask the user where the plan lives.
-4. **No argument given**: ask the user to provide the plan file path. Do not guess.
+3. **Bare name** (no path separators, e.g. `my-plan` or `my-plan.md`): if the host exposes a plans directory, look there first. Use whatever directory the current host stores plan files in — do not hard-code a host-specific path. If no plan is found and the input is ambiguous, ask whether it is a plan identifier or an implementation request.
+4. **Natural-language request** (for example, contains spaces or reads like an implementation task): treat it as the implementation request. There may be no separate plan file.
+5. **No argument given**: ask the user to provide either the plan file path or the implementation request. Do not guess.
 
-If the plan file does not exist or cannot be read, stop and tell the user. Do not proceed without a plan.
+If a path-like input does not exist or cannot be read, stop and tell the user. Do not reinterpret a missing path as a direct request.
 
-Read the entire plan before starting. Note the **Critical files**, **Approach**, and **Verification** sections (or their equivalents).
+When using a plan, read the entire plan before starting. Note the **Critical files**, **Approach**, and **Verification** sections (or their equivalents).
 
-## Phase 2: Implement the Plan
+## Phase 2: Implement the Request
 
-Treat the plan as the source of truth for scope:
+Treat the plan or direct request as the source of truth for scope:
 
-- Make exactly the changes the plan describes — no more, no less. Do not add extra refactors, tests, or cleanup the plan did not ask for.
-- If the plan references files, functions, or utilities that no longer exist, stop and surface the discrepancy before guessing.
-- If you discover the plan is wrong (the codebase has moved, an assumption is invalid, a constraint was missed), stop and report. Do not silently rewrite the approach.
-- Do **not** modify the plan file itself.
+- Make exactly the changes requested — no more, no less. Do not add extra refactors, tests, or cleanup the request did not ask for.
+- If a plan references files, functions, or utilities that no longer exist, stop and surface the discrepancy before guessing.
+- If you discover the request is wrong (the codebase has moved, an assumption is invalid, a constraint was missed), stop and report. Do not silently rewrite the approach.
+- For direct implementation requests, inspect the relevant code before editing and use the repo's existing patterns.
+- Do **not** modify the plan file itself when working from a plan.
 
 ## Phase 3: Validate
 
-Validation is **mandatory** and runs on every invocation, even when the plan does not include a Verification section. A missing or incomplete Verification section is not permission to skip validation — it is a gap to close.
+Validation should follow the repo's instructions and the cost profile of the repo. Some repos intentionally leave slow checks to CI; do not run broad or slow suites unless the repo instructions explicitly require them.
 
 Run validation in this order:
 
-1. **Repo-mandated pre-PR checks.** Look up the repo's standard pre-PR command. Common signals, in priority order:
+1. **Repo instructions.** Look up the repo's standard validation guidance. Common signals, in priority order:
    - An explicit instruction in the repo's agent or contributor instructions, such as `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, or an equivalent host-specific instruction file (e.g. "MUST run before opening PRs"). This wins over everything else.
-   - A conventionally-named script in `package.json` / Python project config / `Makefile` / etc. — `affected`, `precommit`, `validate`, `check`, `verify`, `test`, `lint`, `typecheck`, or repo-equivalent.
-   - If nothing else, run the project's lint + typecheck + test commands directly.
+   - A relevant `package.json` script when the repo instructions point to it, such as `affected`, `precommit`, `validate`, `check`, `verify`, `test`, `lint`, `typecheck`, or repo-equivalent.
+   - A repo-specific equivalent in the rare case the project does not use `package.json`.
 
-   If you cannot determine the right command, ask the user before proceeding — do not silently skip.
+   If the repo primarily relies on git pre-commit or pre-push hooks and does not mandate a manual validation command, do not invent one. Let the hooks run during the `commit-push-pr` handoff.
 
-2. **Plan-specific verification.** If the plan has a Verification section, run those checks too. They are additive to (not a replacement for) the repo-mandated checks.
+2. **Request-specific verification.** If the plan or user request names specific checks, run them when they are practical and consistent with the repo instructions. If a requested check is clearly a slow CI-only suite, ask before running it.
 
-If any check fails, fix the failures and re-run. Do not hand off to `commit-push-pr` with failing checks. If a failure looks pre-existing (unrelated to your changes), confirm that with the user before proceeding — do not assume.
+If any check you run fails, fix the failures and re-run the same check. Do not hand off to `commit-push-pr` with known failing checks unless the user explicitly accepts a pre-existing or unrelated failure.
 
 ## Phase 4: Hand Off to commit-push-pr
 
-Once implementation is complete and Phase 3 validation passes, invoke the `commit-push-pr` skill by name using this agent's normal skill invocation mechanism — not a hard-coded host-specific command. That skill handles branching (if needed), running `simplify` on the changed files, committing, pushing, and opening the PR.
+Once implementation is complete and Phase 3 validation is satisfied, invoke the `commit-push-pr` skill by name using this agent's normal skill invocation mechanism.
 
-Do **not** commit, push, or open the PR yourself in this skill. Let `commit-push-pr` own that flow so the shipping logic stays in one place.
+Do **not** commit, push, or open the PR yourself in this skill. Let `commit-push-pr` own the shipping flow.
 
-If `commit-push-pr` reports `nothing to ship.` (the plan resulted in no actual file changes), surface that to the user — it usually means the plan was already implemented or the plan was a no-op.
+If `commit-push-pr` reports `nothing to ship.` (the work resulted in no actual file changes), surface that to the user — it usually means the request was already implemented or was a no-op.
 
 ## Phase 5: Final Output
 

--- a/.agents/skills/simplify/SKILL.md
+++ b/.agents/skills/simplify/SKILL.md
@@ -12,7 +12,7 @@ Run \`git diff\` (or \`git diff HEAD\` if there are staged changes) to see what 
 
 ## Phase 2: Launch Three Review Agents in Parallel
 
-If you can, use the ${AGENT_TOOL_NAME} tool to launch all three agents concurrently in a single message; otherwise, perform the following yourself. Pass each agent the full diff so it has the complete context.
+If the current host supports parallel delegated reviewers, use that mechanism to launch all three reviews concurrently; otherwise, perform the reviews yourself. Pass each reviewer the full diff so it has the complete context.
 
 ### Agent 1: Code Reuse Review
 

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "3.0.0",
+  "version": "3.2.0",
   "description": "Clipboard's core development tools.",
   "author": {
     "name": "Clipboard",

--- a/plugins/core/skills/commit-push-pr/SKILL.md
+++ b/plugins/core/skills/commit-push-pr/SKILL.md
@@ -27,7 +27,7 @@ Based on the above changes:
 3. Re-check `git status --short`. If there are changes, create a single conventional commit message.
 4. Push the branch to origin
 5. Check for an existing PR with `gh pr view`.
-   - No PR exists: Create with `gh pr create`. Title = commit subject line. Description = brief explanation of **why**, not what.
+   - No PR exists: Create with `gh pr create`. Title = commit subject line. Description = brief explanation of **why**, not what. Append `<!-- commit-push-pr:created v1 -->` on its own line at the end of the PR description so skill-created PRs can be identified later.
    - PR exists: Report the URL and move on.
 6. You have the capability to call multiple tools in a single response. After the `simplify` skill completes, do the remaining git and PR operations in a single message. Do not use any other tools or do anything else.
 7. After tool calls complete, send one short final text response with the branch name and the full PR URL (e.g., `https://github.com/clipboardhealth/core-utils/pull/123`). Never use shorthand like `repo#123` — always output the complete URL so it is clickable.

--- a/plugins/core/skills/commit-push-pr/SKILL.md
+++ b/plugins/core/skills/commit-push-pr/SKILL.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr view:*), Bash(gh pr create:*), Bash(git diff:*)
+allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr view:*), Bash(gh pr create:*), Bash(git diff:*), Bash(git merge-base:*)
 description: Commit, push, and open a PR. Use when the user wants to ship changes, create a pull request, or says things like 'commit and push', 'open a PR', 'ship it', 'send it', 'create a PR for this', or 'push this up'.
 ---
 
@@ -17,16 +17,17 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 **First, decide from the context above. If `Commits ahead of default branch` is `(unknown)`, skip this decision and use the full flow below.**
 
 - If `Git status` is empty AND `Commits ahead of default branch` is empty AND `Existing PR` is `none`: stop. Reply with `nothing to ship.` and do nothing else.
-- If `Git status` is empty but there are `Commits ahead of default branch` or an `Existing PR`: skip step 2 only (no changes to commit). Still run step 1 — its "if on main" check needs to fire so local commits on main are moved to a new branch rather than pushed directly to main. Then continue with step 3 and step 4.
+- If `Git status` is empty but there are `Commits ahead of default branch` or an `Existing PR`: still run step 1 and step 2. Then re-check `git status --short`; skip step 3 only if it remains empty. Then continue with step 4 and step 5.
 - Otherwise: proceed with all steps below.
 
 Based on the above changes:
 
 1. Create a new branch if on main (e.g., `feat/add-user-validation`, `fix/null-check-in-parser`)
-2. Create a single conventional commit message
-3. Push the branch to origin
-4. Check for an existing PR with `gh pr view`.
+2. Run the `simplify` skill on the files included in the PR before committing, pushing, or opening the PR. If the working tree is clean, run `simplify` against `git diff $(git merge-base HEAD origin/HEAD)..HEAD`. If the working tree has changes, run it against `git diff HEAD`; when local commits also exist, include `git diff $(git merge-base HEAD origin/HEAD)..HEAD` as additional PR context. Invoke the skill by name using this agent's normal skill invocation mechanism, not a hard-coded host-specific command. Wait for the skill to finish, then include any resulting fixes in the commit step below.
+3. Re-check `git status --short`. If there are changes, create a single conventional commit message.
+4. Push the branch to origin
+5. Check for an existing PR with `gh pr view`.
    - No PR exists: Create with `gh pr create`. Title = commit subject line. Description = brief explanation of **why**, not what.
    - PR exists: Report the URL and move on.
-5. You have the capability to call multiple tools in a single response. You MUST do all of the above in a single message. Do not use any other tools or do anything else.
-6. After tool calls complete, send one short final text response with the branch name and the full PR URL (e.g., `https://github.com/clipboardhealth/core-utils/pull/123`). Never use shorthand like `repo#123` — always output the complete URL so it is clickable.
+6. You have the capability to call multiple tools in a single response. After the `simplify` skill completes, do the remaining git and PR operations in a single message. Do not use any other tools or do anything else.
+7. After tool calls complete, send one short final text response with the branch name and the full PR URL (e.g., `https://github.com/clipboardhealth/core-utils/pull/123`). Never use shorthand like `repo#123` — always output the complete URL so it is clickable.

--- a/plugins/core/skills/commit-push-pr/SKILL.md
+++ b/plugins/core/skills/commit-push-pr/SKILL.md
@@ -23,7 +23,7 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 Based on the above changes:
 
 1. Create a new branch if on main (e.g., `feat/add-user-validation`, `fix/null-check-in-parser`)
-2. Run the `simplify` skill on the files included in the PR before committing, pushing, or opening the PR. If the working tree is clean, run `simplify` against `git diff $(git merge-base HEAD origin/HEAD)..HEAD`. If the working tree has changes, run it against `git diff HEAD`; when local commits also exist, include `git diff $(git merge-base HEAD origin/HEAD)..HEAD` as additional PR context. Invoke the skill by name using this agent's normal skill invocation mechanism, not a hard-coded host-specific command. Wait for the skill to finish, then include any resulting fixes in the commit step below.
+2. Run the `simplify` skill on the files included in the PR before committing, pushing, or opening the PR. If the working tree is clean, run `simplify` against `git diff $(git merge-base HEAD origin/HEAD)..HEAD`. If the working tree has changes, run it against `git diff HEAD`; when local commits also exist, include `git diff $(git merge-base HEAD origin/HEAD)..HEAD` as additional PR context. Invoke the skill by name using this agent's normal skill invocation mechanism. Wait for the skill to finish, then include any resulting fixes in the commit step below.
 3. Re-check `git status --short`. If there are changes, create a single conventional commit message.
 4. Push the branch to origin
 5. Check for an existing PR with `gh pr view`.

--- a/plugins/core/skills/go/SKILL.md
+++ b/plugins/core/skills/go/SKILL.md
@@ -1,0 +1,60 @@
+---
+description: Implement a plan file end-to-end, then hand off to commit-push-pr to ship it. Use when the user says 'go', 'execute the plan', 'implement the plan', or hands off a plan file for execution.
+---
+
+# Go: Execute a Plan and Ship It
+
+Given a plan file, implement everything the plan describes, then invoke the `commit-push-pr` skill to commit, push, and open a PR.
+
+This skill is the bridge between planning and shipping. It does not re-plan or re-design — the plan is the source of truth. If the plan is wrong, surface that; do not silently improvise.
+
+## Phase 1: Locate and Read the Plan
+
+The user invokes this skill with a plan file path or identifier as an argument. Resolve it in this order:
+
+1. **Absolute path** (starts with `/`): read it directly.
+2. **Relative path** (contains `/` or starts with `./`): resolve from the current working directory.
+3. **Bare name** (no path separators, e.g. `my-plan` or `my-plan.md`): look in the host's plans directory. Use whatever directory the current host stores plan files in — do not hard-code a host-specific path. If the host does not expose a plans directory, ask the user where the plan lives.
+4. **No argument given**: ask the user to provide the plan file path. Do not guess.
+
+If the plan file does not exist or cannot be read, stop and tell the user. Do not proceed without a plan.
+
+Read the entire plan before starting. Note the **Critical files**, **Approach**, and **Verification** sections (or their equivalents).
+
+## Phase 2: Implement the Plan
+
+Treat the plan as the source of truth for scope:
+
+- Make exactly the changes the plan describes — no more, no less. Do not add extra refactors, tests, or cleanup the plan did not ask for.
+- If the plan references files, functions, or utilities that no longer exist, stop and surface the discrepancy before guessing.
+- If you discover the plan is wrong (the codebase has moved, an assumption is invalid, a constraint was missed), stop and report. Do not silently rewrite the approach.
+- Do **not** modify the plan file itself.
+
+## Phase 3: Validate
+
+Validation is **mandatory** and runs on every invocation, even when the plan does not include a Verification section. A missing or incomplete Verification section is not permission to skip validation — it is a gap to close.
+
+Run validation in this order:
+
+1. **Repo-mandated pre-PR checks.** Look up the repo's standard pre-PR command. Common signals, in priority order:
+   - An explicit instruction in the repo's agent or contributor instructions, such as `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, or an equivalent host-specific instruction file (e.g. "MUST run before opening PRs"). This wins over everything else.
+   - A conventionally-named script in `package.json` / Python project config / `Makefile` / etc. — `affected`, `precommit`, `validate`, `check`, `verify`, `test`, `lint`, `typecheck`, or repo-equivalent.
+   - If nothing else, run the project's lint + typecheck + test commands directly.
+
+   If you cannot determine the right command, ask the user before proceeding — do not silently skip.
+
+2. **Plan-specific verification.** If the plan has a Verification section, run those checks too. They are additive to (not a replacement for) the repo-mandated checks.
+
+If any check fails, fix the failures and re-run. Do not hand off to `commit-push-pr` with failing checks. If a failure looks pre-existing (unrelated to your changes), confirm that with the user before proceeding — do not assume.
+
+## Phase 4: Hand Off to commit-push-pr
+
+Once implementation is complete and Phase 3 validation passes, invoke the `commit-push-pr` skill by name using this agent's normal skill invocation mechanism — not a hard-coded host-specific command. That skill handles branching (if needed), running `simplify` on the changed files, committing, pushing, and opening the PR.
+
+Do **not** commit, push, or open the PR yourself in this skill. Let `commit-push-pr` own that flow so the shipping logic stays in one place.
+
+If `commit-push-pr` reports `nothing to ship.` (the plan resulted in no actual file changes), surface that to the user — it usually means the plan was already implemented or the plan was a no-op.
+
+## Phase 5: Final Output
+
+After `commit-push-pr` returns, send one short final response with the branch name and the full PR URL it produced. If `commit-push-pr` reported nothing to ship, say so plainly.

--- a/plugins/core/skills/go/SKILL.md
+++ b/plugins/core/skills/go/SKILL.md
@@ -12,7 +12,7 @@ This skill is the bridge between intent and shipping. It does not re-plan or re-
 
 The user may invoke this skill with either a plan file path/identifier or a direct implementation request such as "add a button to the homepage to log in." Resolve the input in this order:
 
-1. **Absolute path** (starts with `/`): read it directly.
+1. **Absolute path** (starts with `/`): read it directly only when it is inside the current workspace/repo root or the host's plans directory. If it is outside those roots, ask the user to confirm before reading it; if they do not confirm, stop and ask for an approved path.
 2. **Relative path** (contains `/` or starts with `./`): resolve from the current working directory.
 3. **Bare name** (no path separators, e.g. `my-plan` or `my-plan.md`): if the host exposes a plans directory, look there first. Use whatever directory the current host stores plan files in — do not hard-code a host-specific path. If no plan is found and the input is ambiguous, ask whether it is a plan identifier or an implementation request.
 4. **Natural-language request** (for example, contains spaces or reads like an implementation task): treat it as the implementation request. There may be no separate plan file.
@@ -59,4 +59,4 @@ If `commit-push-pr` reports `nothing to ship.` (the work resulted in no actual f
 
 ## Phase 5: Final Output
 
-After `commit-push-pr` returns, send one short final response with the branch name and the full PR URL it produced. If `commit-push-pr` reported nothing to ship, say so plainly.
+After `commit-push-pr` returns, ensure the user sees one short final response with the branch name and the full PR URL it produced. If the current host already surfaced that response, do not duplicate it. If `commit-push-pr` reported nothing to ship, say so plainly.

--- a/plugins/core/skills/go/SKILL.md
+++ b/plugins/core/skills/go/SKILL.md
@@ -1,59 +1,61 @@
 ---
-description: Implement a plan file end-to-end, then hand off to commit-push-pr to ship it. Use when the user says 'go', 'execute the plan', 'implement the plan', or hands off a plan file for execution.
+description: Implement a plan file or direct request end-to-end, then hand off to commit-push-pr to ship it. Use when the user says 'go', 'execute the plan', 'implement the plan', or gives an implementation request.
 ---
 
-# Go: Execute a Plan and Ship It
+# Go: Execute Work and Ship It
 
-Given a plan file, implement everything the plan describes, then invoke the `commit-push-pr` skill to commit, push, and open a PR.
+Given a plan file or direct implementation request, implement the requested work, then invoke the `commit-push-pr` skill to commit, push, and open a PR.
 
-This skill is the bridge between planning and shipping. It does not re-plan or re-design — the plan is the source of truth. If the plan is wrong, surface that; do not silently improvise.
+This skill is the bridge between intent and shipping. It does not re-plan or re-design unless the user asked for that. If the request is wrong or cannot be implemented safely, surface that; do not silently improvise.
 
-## Phase 1: Locate and Read the Plan
+## Phase 1: Understand the Input
 
-The user invokes this skill with a plan file path or identifier as an argument. Resolve it in this order:
+The user may invoke this skill with either a plan file path/identifier or a direct implementation request such as "add a button to the homepage to log in." Resolve the input in this order:
 
 1. **Absolute path** (starts with `/`): read it directly.
 2. **Relative path** (contains `/` or starts with `./`): resolve from the current working directory.
-3. **Bare name** (no path separators, e.g. `my-plan` or `my-plan.md`): look in the host's plans directory. Use whatever directory the current host stores plan files in — do not hard-code a host-specific path. If the host does not expose a plans directory, ask the user where the plan lives.
-4. **No argument given**: ask the user to provide the plan file path. Do not guess.
+3. **Bare name** (no path separators, e.g. `my-plan` or `my-plan.md`): if the host exposes a plans directory, look there first. Use whatever directory the current host stores plan files in — do not hard-code a host-specific path. If no plan is found and the input is ambiguous, ask whether it is a plan identifier or an implementation request.
+4. **Natural-language request** (for example, contains spaces or reads like an implementation task): treat it as the implementation request. There may be no separate plan file.
+5. **No argument given**: ask the user to provide either the plan file path or the implementation request. Do not guess.
 
-If the plan file does not exist or cannot be read, stop and tell the user. Do not proceed without a plan.
+If a path-like input does not exist or cannot be read, stop and tell the user. Do not reinterpret a missing path as a direct request.
 
-Read the entire plan before starting. Note the **Critical files**, **Approach**, and **Verification** sections (or their equivalents).
+When using a plan, read the entire plan before starting. Note the **Critical files**, **Approach**, and **Verification** sections (or their equivalents).
 
-## Phase 2: Implement the Plan
+## Phase 2: Implement the Request
 
-Treat the plan as the source of truth for scope:
+Treat the plan or direct request as the source of truth for scope:
 
-- Make exactly the changes the plan describes — no more, no less. Do not add extra refactors, tests, or cleanup the plan did not ask for.
-- If the plan references files, functions, or utilities that no longer exist, stop and surface the discrepancy before guessing.
-- If you discover the plan is wrong (the codebase has moved, an assumption is invalid, a constraint was missed), stop and report. Do not silently rewrite the approach.
-- Do **not** modify the plan file itself.
+- Make exactly the changes requested — no more, no less. Do not add extra refactors, tests, or cleanup the request did not ask for.
+- If a plan references files, functions, or utilities that no longer exist, stop and surface the discrepancy before guessing.
+- If you discover the request is wrong (the codebase has moved, an assumption is invalid, a constraint was missed), stop and report. Do not silently rewrite the approach.
+- For direct implementation requests, inspect the relevant code before editing and use the repo's existing patterns.
+- Do **not** modify the plan file itself when working from a plan.
 
 ## Phase 3: Validate
 
-Validation is **mandatory** and runs on every invocation, even when the plan does not include a Verification section. A missing or incomplete Verification section is not permission to skip validation — it is a gap to close.
+Validation should follow the repo's instructions and the cost profile of the repo. Some repos intentionally leave slow checks to CI; do not run broad or slow suites unless the repo instructions explicitly require them.
 
 Run validation in this order:
 
-1. **Repo-mandated pre-PR checks.** Look up the repo's standard pre-PR command. Common signals, in priority order:
+1. **Repo instructions.** Look up the repo's standard validation guidance. Common signals, in priority order:
    - An explicit instruction in the repo's agent or contributor instructions, such as `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, or an equivalent host-specific instruction file (e.g. "MUST run before opening PRs"). This wins over everything else.
-   - A conventionally-named script in `package.json` / Python project config / `Makefile` / etc. — `affected`, `precommit`, `validate`, `check`, `verify`, `test`, `lint`, `typecheck`, or repo-equivalent.
-   - If nothing else, run the project's lint + typecheck + test commands directly.
+   - A relevant `package.json` script when the repo instructions point to it, such as `affected`, `precommit`, `validate`, `check`, `verify`, `test`, `lint`, `typecheck`, or repo-equivalent.
+   - A repo-specific equivalent in the rare case the project does not use `package.json`.
 
-   If you cannot determine the right command, ask the user before proceeding — do not silently skip.
+   If the repo primarily relies on git pre-commit or pre-push hooks and does not mandate a manual validation command, do not invent one. Let the hooks run during the `commit-push-pr` handoff.
 
-2. **Plan-specific verification.** If the plan has a Verification section, run those checks too. They are additive to (not a replacement for) the repo-mandated checks.
+2. **Request-specific verification.** If the plan or user request names specific checks, run them when they are practical and consistent with the repo instructions. If a requested check is clearly a slow CI-only suite, ask before running it.
 
-If any check fails, fix the failures and re-run. Do not hand off to `commit-push-pr` with failing checks. If a failure looks pre-existing (unrelated to your changes), confirm that with the user before proceeding — do not assume.
+If any check you run fails, fix the failures and re-run the same check. Do not hand off to `commit-push-pr` with known failing checks unless the user explicitly accepts a pre-existing or unrelated failure.
 
 ## Phase 4: Hand Off to commit-push-pr
 
-Once implementation is complete and Phase 3 validation passes, invoke the `commit-push-pr` skill by name using this agent's normal skill invocation mechanism — not a hard-coded host-specific command. That skill handles branching (if needed), running `simplify` on the changed files, committing, pushing, and opening the PR.
+Once implementation is complete and Phase 3 validation is satisfied, invoke the `commit-push-pr` skill by name using this agent's normal skill invocation mechanism.
 
-Do **not** commit, push, or open the PR yourself in this skill. Let `commit-push-pr` own that flow so the shipping logic stays in one place.
+Do **not** commit, push, or open the PR yourself in this skill. Let `commit-push-pr` own the shipping flow.
 
-If `commit-push-pr` reports `nothing to ship.` (the plan resulted in no actual file changes), surface that to the user — it usually means the plan was already implemented or the plan was a no-op.
+If `commit-push-pr` reports `nothing to ship.` (the work resulted in no actual file changes), surface that to the user — it usually means the request was already implemented or was a no-op.
 
 ## Phase 5: Final Output
 

--- a/plugins/core/skills/simplify/SKILL.md
+++ b/plugins/core/skills/simplify/SKILL.md
@@ -12,7 +12,7 @@ Run \`git diff\` (or \`git diff HEAD\` if there are staged changes) to see what 
 
 ## Phase 2: Launch Three Review Agents in Parallel
 
-If you can, use the ${AGENT_TOOL_NAME} tool to launch all three agents concurrently in a single message; otherwise, perform the following yourself. Pass each agent the full diff so it has the complete context.
+If the current host supports parallel delegated reviewers, use that mechanism to launch all three reviews concurrently; otherwise, perform the reviews yourself. Pass each reviewer the full diff so it has the complete context.
 
 ### Agent 1: Code Reuse Review
 


### PR DESCRIPTION
## Summary
- Add the core go skill for executing plan files and handing off to commit-push-pr.
- Update commit-push-pr to run simplify before shipping and handle clean-tree PR diffs explicitly.
- Make simplify delegation wording host-neutral for different agent runtimes.

## Why
This keeps plan execution, simplification, and PR shipping consistent across agent hosts without hard-coding Claude- or Codex-specific invocation syntax.

## Validation
- NX_DAEMON=false node --run sync-ai-rules
- npm run affected
- git diff --check
- commit hook: lint-staged, cspell, embed:check, markdownlint
- pre-push hook: formatting and dependency architecture check completed with warnings only

Linear ticket: not provided

<!-- commit-push-pr:created v1 -->