### PR TITLE
docs: warn against using scopes in conventional commits

### DIFF
--- a/.rules/common/gitWorkflow.md
+++ b/.rules/common/gitWorkflow.md
@@ -1,6 +1,9 @@
 # Git Workflow
 
 - Follow Conventional Commits 1.0 spec for commit messages and PR titles.
+- **Do NOT use scopes** in commit messages or PR titles. Scopes (the parenthesized part in `feat(scope): ...`) interfere with Nx release detection in monorepos — Nx uses file-based heuristics to determine which project a commit affects, and an unrecognized scope causes it to skip the release entirely. Put ticket IDs in the description instead.
+  - `feat: add orientation shift type to open shifts response [TFR-239]`
+  - Not: `feat(TFR-239): add orientation shift type to open shifts response`
 - `main` is the default branch.
 
 ## Pull Requests

--- a/packages/ai-rules/rules/common/gitWorkflow.md
+++ b/packages/ai-rules/rules/common/gitWorkflow.md
@@ -1,6 +1,9 @@
 # Git Workflow
 
 - Follow Conventional Commits 1.0 spec for commit messages and PR titles.
+- **Do NOT use scopes** in commit messages or PR titles. Scopes (the parenthesized part in `feat(scope): ...`) interfere with Nx release detection in monorepos — Nx uses file-based heuristics to determine which project a commit affects, and an unrecognized scope causes it to skip the release entirely. Put ticket IDs in the description instead.
+  - `feat: add orientation shift type to open shifts response [TFR-239]`
+  - Not: `feat(TFR-239): add orientation shift type to open shifts response`
 - `main` is the default branch.
 
 ## Pull Requests


### PR DESCRIPTION
## Summary

Adds an explicit rule to the `gitWorkflow` AI rule prohibiting the use of scopes in conventional commit messages and PR titles.

Scopes (e.g. `feat(TFR-239): ...`) interfere with Nx release detection in monorepos — Nx uses file-based heuristics to determine which project a commit affects, and an unrecognized scope causes it to skip the release entirely. This has caused multiple incidents where merged PRs failed to trigger package releases (see [thread context](https://clipboardhealth.slack.com/archives/C04T80HDR7U/p1763566661177569)).

The rule now directs developers to put ticket IDs in the description instead (e.g. `feat: do something [TFR-239]`).

## Review & Testing Checklist for Human

- [x] Verify the wording is clear and actionable for developers and AI agents
- [x] Confirm the examples match your team's preferred ticket ID placement convention

### Notes

This updates `packages/ai-rules/rules/common/gitWorkflow.md` (the source) and the synced `.rules/common/gitWorkflow.md` copy. All repos consuming `@clipboard-health/ai-rules` will pick up this change on their next `npm update`.

Link to Devin session: https://app.devin.ai/sessions/f40fd18e152a4fddaaab042902508bf1
Requested by: @pgbezerra