### PR TITLE
fix(core): match nitpicks with 1 or 3+ severity tags

### DIFF
--- a/.agents/skills/babysit-pr/scripts/parseNitpicks.sh
+++ b/.agents/skills/babysit-pr/scripts/parseNitpicks.sh
@@ -59,7 +59,12 @@ for my $section (@sections) {
     my $raw_file_name = trim($1);
     my $file_content = $2;
 
-    while ($file_content =~ /`(\d+(?:-\d+)?)`:\s*(?:_[^_]+_\s*\|\s*_[^_]+_\s*)?\*\*([^*]+)\*\*\s*([\s\S]*?)(?=---|\n`\d|<\/blockquote>|$)/g) {
+    # Category prefix is optional. CodeRabbit emits 0–N `_…_` tags
+    # separated by `|` (e.g. `_⚠️ Potential issue_ | _🟠 Major_ | _⚡ Quick win_`
+    # or just `_💤 Low value_` on lower-confidence findings). The previous
+    # regex required exactly two tags and silently dropped one-tag and
+    # three-tag variants.
+    while ($file_content =~ /`(\d+(?:-\d+)?)`:\s*(?:_[^_]+_(?:\s*\|\s*_[^_]+_)*\s*)?\*\*([^*]+)\*\*\s*([\s\S]*?)(?=---|\n`\d|<\/blockquote>|$)/g) {
       my $line_range = $1;
       my $title = trim($2);
       my $clean_body = clean_comment_body(trim($3));

--- a/.agents/skills/commit-push-pr/SKILL.md
+++ b/.agents/skills/commit-push-pr/SKILL.md
@@ -14,7 +14,7 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 
 ## Your task
 
-If `Commits ahead of default branch` is `(unknown)`, the ahead-probe failed (e.g., `origin/HEAD` not set) — proceed with the full flow rather than risk skipping real commits. Otherwise, if `Git status`, `Commits ahead of default branch`, and `Existing PR` are all empty/none, stop and reply `nothing to ship.`. Otherwise:
+If `Commits ahead of default branch` is `(unknown)`, `origin/HEAD` couldn't be resolved — stop and tell the user to run `git remote set-head origin -a` (or otherwise set the default branch) before retrying, since the simplify step also depends on it. Otherwise, if `Git status`, `Commits ahead of default branch`, and `Existing PR` are all empty/none, stop and reply `nothing to ship.`. Otherwise:
 
 1. Create a new branch if on main (e.g., `feat/add-user-validation`, `fix/null-check-in-parser`).
 2. Run the `simplify` skill on the full PR diff — `git diff $(git merge-base HEAD origin/HEAD)..HEAD` plus any uncommitted changes. Wait for it to finish, then include any resulting fixes in the commit.

--- a/.agents/skills/commit-push-pr/SKILL.md
+++ b/.agents/skills/commit-push-pr/SKILL.md
@@ -14,20 +14,13 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 
 ## Your task
 
-**First, decide from the context above. If `Commits ahead of default branch` is `(unknown)`, skip this decision and use the full flow below.**
+If `Git status`, `Commits ahead of default branch`, and `Existing PR` are all empty/none, stop and reply `nothing to ship.`. Otherwise:
 
-- If `Git status` is empty AND `Commits ahead of default branch` is empty AND `Existing PR` is `none`: stop. Reply with `nothing to ship.` and do nothing else.
-- If `Git status` is empty but there are `Commits ahead of default branch` or an `Existing PR`: still run step 1 and step 2. Then re-check `git status --short`; skip step 3 only if it remains empty. Then continue with step 4 and step 5.
-- Otherwise: proceed with all steps below.
-
-Based on the above changes:
-
-1. Create a new branch if on main (e.g., `feat/add-user-validation`, `fix/null-check-in-parser`)
-2. Run the `simplify` skill on the files included in the PR before committing, pushing, or opening the PR. If the working tree is clean, run `simplify` against `git diff $(git merge-base HEAD origin/HEAD)..HEAD`. If the working tree has changes, run it against `git diff HEAD`; when local commits also exist, include `git diff $(git merge-base HEAD origin/HEAD)..HEAD` as additional PR context. Invoke the skill by name using this agent's normal skill invocation mechanism. Wait for the skill to finish, then include any resulting fixes in the commit step below.
-3. Re-check `git status --short`. If there are changes, create a single conventional commit message.
-4. Push the branch to origin
+1. Create a new branch if on main (e.g., `feat/add-user-validation`, `fix/null-check-in-parser`).
+2. Run the `simplify` skill on the full PR diff — `git diff $(git merge-base HEAD origin/HEAD)..HEAD` plus any uncommitted changes. Wait for it to finish, then include any resulting fixes in the commit.
+3. If `git status --short` shows changes, create a single conventional commit.
+4. Push the branch to origin.
 5. Check for an existing PR with `gh pr view`.
-   - No PR exists: Create with `gh pr create`. Title = commit subject line. Description = brief explanation of **why**, not what. Append `<!-- commit-push-pr:created v1 -->` on its own line at the end of the PR description so skill-created PRs can be identified later.
-   - PR exists: Report the URL and move on.
-6. You have the capability to call multiple tools in a single response. After the `simplify` skill completes, do the remaining git and PR operations in a single message. Do not use any other tools or do anything else.
-7. After tool calls complete, send one short final text response with the branch name and the full PR URL (e.g., `https://github.com/clipboardhealth/core-utils/pull/123`). Never use shorthand like `repo#123` — always output the complete URL so it is clickable.
+   - No PR: create with `gh pr create`. Title = commit subject. Description = brief explanation of **why**, not what. Append `<!-- commit-push-pr:created v1 -->` on its own line at the end so skill-created PRs can be identified later.
+   - PR exists: report the URL and move on.
+6. End with one short text response: branch name and the full PR URL (e.g., `https://github.com/clipboardhealth/core-utils/pull/123`). Never use shorthand like `repo#123` — always output the complete URL.

--- a/.agents/skills/commit-push-pr/SKILL.md
+++ b/.agents/skills/commit-push-pr/SKILL.md
@@ -7,14 +7,14 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 
 - Current branch: !`git branch --show-current`
 - Git status: !`git status --short`
-- Commits ahead of default branch: !`git log --oneline origin/HEAD..HEAD 2>/dev/null || true`
+- Commits ahead of default branch: !`git log --oneline origin/HEAD..HEAD 2>/dev/null || echo "(unknown)"`
 - Existing PR: !`gh pr view --json url --jq .url 2>/dev/null || echo "none"`
 - Diff summary: !`git diff HEAD --stat`
 - Full diff: !`git diff HEAD`
 
 ## Your task
 
-If `Git status`, `Commits ahead of default branch`, and `Existing PR` are all empty/none, stop and reply `nothing to ship.`. Otherwise:
+If `Commits ahead of default branch` is `(unknown)`, the ahead-probe failed (e.g., `origin/HEAD` not set) — proceed with the full flow rather than risk skipping real commits. Otherwise, if `Git status`, `Commits ahead of default branch`, and `Existing PR` are all empty/none, stop and reply `nothing to ship.`. Otherwise:
 
 1. Create a new branch if on main (e.g., `feat/add-user-validation`, `fix/null-check-in-parser`).
 2. Run the `simplify` skill on the full PR diff — `git diff $(git merge-base HEAD origin/HEAD)..HEAD` plus any uncommitted changes. Wait for it to finish, then include any resulting fixes in the commit.

--- a/.agents/skills/commit-push-pr/SKILL.md
+++ b/.agents/skills/commit-push-pr/SKILL.md
@@ -7,7 +7,7 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 
 - Current branch: !`git branch --show-current`
 - Git status: !`git status --short`
-- Commits ahead of default branch: !`git log --oneline origin/HEAD..HEAD 2>/dev/null || echo "(unknown)"`
+- Commits ahead of default branch: !`git log --oneline origin/HEAD..HEAD 2>/dev/null || true`
 - Existing PR: !`gh pr view --json url --jq .url 2>/dev/null || echo "none"`
 - Diff summary: !`git diff HEAD --stat`
 - Full diff: !`git diff HEAD`

--- a/.agents/skills/go/SKILL.md
+++ b/.agents/skills/go/SKILL.md
@@ -12,7 +12,7 @@ This skill is the bridge between intent and shipping. It does not re-plan or re-
 
 The user invokes this skill with either a plan file path/identifier or a direct request like "add a login button."
 
-- **Path-like input** (absolute, relative, or bare name): try to read it. For bare names, check the host's plans directory first. If an absolute path lies outside the workspace/repo or the host's plans directory, ask the user to confirm before reading it. If the input doesn't resolve to a readable file, stop and tell the user — do not reinterpret a missing path as a direct request.
+- **Path-like input** (absolute, relative, or bare name): try to read it. For bare names, check the host's plans directory first. Resolve the path first; if it lies outside the workspace/repo or the host's plans directory, ask the user to confirm before reading it (applies to both absolute and relative inputs — `..` escapes count). If the input doesn't resolve to a readable file, stop and tell the user — do not reinterpret a missing path as a direct request.
 - **Natural-language request**: treat as the implementation task. There may be no plan file.
 - **No argument**: ask for either a plan path or the implementation request.
 

--- a/.agents/skills/go/SKILL.md
+++ b/.agents/skills/go/SKILL.md
@@ -4,59 +4,43 @@ description: Implement a plan file or direct request end-to-end, then hand off t
 
 # Go: Execute Work and Ship It
 
-Given a plan file or direct implementation request, implement the requested work, then invoke the `commit-push-pr` skill to commit, push, and open a PR.
+Given a plan file or direct implementation request, implement the requested work, then invoke the `commit-push-pr` skill to create a PR.
 
 This skill is the bridge between intent and shipping. It does not re-plan or re-design unless the user asked for that. If the request is wrong or cannot be implemented safely, surface that; do not silently improvise.
 
-## Phase 1: Understand the Input
+## Phase 1: Resolve the Input
 
-The user may invoke this skill with either a plan file path/identifier or a direct implementation request such as "add a button to the homepage to log in." Resolve the input in this order:
+The user invokes this skill with either a plan file path/identifier or a direct request like "add a login button."
 
-1. **Absolute path** (starts with `/`): read it directly only when it is inside the current workspace/repo root or the host's plans directory. If it is outside those roots, ask the user to confirm before reading it; if they do not confirm, stop and ask for an approved path.
-2. **Relative path** (contains `/` or starts with `./`): resolve from the current working directory.
-3. **Bare name** (no path separators, e.g. `my-plan` or `my-plan.md`): if the host exposes a plans directory, look there first. Use whatever directory the current host stores plan files in — do not hard-code a host-specific path. If no plan is found and the input is ambiguous, ask whether it is a plan identifier or an implementation request.
-4. **Natural-language request** (for example, contains spaces or reads like an implementation task): treat it as the implementation request. There may be no separate plan file.
-5. **No argument given**: ask the user to provide either the plan file path or the implementation request. Do not guess.
+- **Path-like input** (absolute, relative, or bare name): try to read it. For bare names, check the host's plans directory first. If an absolute path lies outside the workspace/repo or the host's plans directory, ask the user to confirm before reading it. If the input doesn't resolve to a readable file, stop and tell the user — do not reinterpret a missing path as a direct request.
+- **Natural-language request**: treat as the implementation task. There may be no plan file.
+- **No argument**: ask for either a plan path or the implementation request.
 
-If a path-like input does not exist or cannot be read, stop and tell the user. Do not reinterpret a missing path as a direct request.
+When using a plan, read it fully before starting. Note **Critical files**, **Approach**, and **Verification** sections (or equivalents).
 
-When using a plan, read the entire plan before starting. Note the **Critical files**, **Approach**, and **Verification** sections (or their equivalents).
+## Phase 2: Implement
 
-## Phase 2: Implement the Request
+The plan or request is the source of truth for scope:
 
-Treat the plan or direct request as the source of truth for scope:
-
-- Make exactly the changes requested — no more, no less. Do not add extra refactors, tests, or cleanup the request did not ask for.
-- If a plan references files, functions, or utilities that no longer exist, stop and surface the discrepancy before guessing.
-- If you discover the request is wrong (the codebase has moved, an assumption is invalid, a constraint was missed), stop and report. Do not silently rewrite the approach.
-- For direct implementation requests, inspect the relevant code before editing and use the repo's existing patterns.
-- Do **not** modify the plan file itself when working from a plan.
+- Make exactly the changes requested — no extra refactors, tests, or cleanup.
+- If the plan references files or utilities that no longer exist, stop and report.
+- If an assumption is invalid or a constraint was missed, stop and report. Do not silently rewrite the approach.
+- Do not modify the plan file itself.
 
 ## Phase 3: Validate
 
-Validation should follow the repo's instructions and the cost profile of the repo. Some repos intentionally leave slow checks to CI; do not run broad or slow suites unless the repo instructions explicitly require them.
+- Read `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, or equivalent contributor instructions for the mandated pre-PR command (e.g. `npm run affected`). That wins over everything.
+- If the repo relies on pre-commit/pre-push hooks and mandates no manual command, don't invent one — let the hooks run during the `commit-push-pr` handoff.
+- If the plan names specific checks, run them when practical. Ask before running anything that's clearly a slow CI-only suite.
 
-Run validation in this order:
+Fix any failures before handing off. Do not hand off with known failing checks unless the user explicitly accepts a pre-existing or unrelated failure.
 
-1. **Repo instructions.** Look up the repo's standard validation guidance. Common signals, in priority order:
-   - An explicit instruction in the repo's agent or contributor instructions, such as `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, or an equivalent host-specific instruction file (e.g. "MUST run before opening PRs"). This wins over everything else.
-   - A relevant `package.json` script when the repo instructions point to it, such as `affected`, `precommit`, `validate`, `check`, `verify`, `test`, `lint`, `typecheck`, or repo-equivalent.
-   - A repo-specific equivalent in the rare case the project does not use `package.json`.
+## Phase 4: Hand Off
 
-   If the repo primarily relies on git pre-commit or pre-push hooks and does not mandate a manual validation command, do not invent one. Let the hooks run during the `commit-push-pr` handoff.
+Invoke the `commit-push-pr` skill. Do not commit, push, or open the PR yourself.
 
-2. **Request-specific verification.** If the plan or user request names specific checks, run them when they are practical and consistent with the repo instructions. If a requested check is clearly a slow CI-only suite, ask before running it.
-
-If any check you run fails, fix the failures and re-run the same check. Do not hand off to `commit-push-pr` with known failing checks unless the user explicitly accepts a pre-existing or unrelated failure.
-
-## Phase 4: Hand Off to commit-push-pr
-
-Once implementation is complete and Phase 3 validation is satisfied, invoke the `commit-push-pr` skill by name using this agent's normal skill invocation mechanism.
-
-Do **not** commit, push, or open the PR yourself in this skill. Let `commit-push-pr` own the shipping flow.
-
-If `commit-push-pr` reports `nothing to ship.` (the work resulted in no actual file changes), surface that to the user — it usually means the request was already implemented or was a no-op.
+If `commit-push-pr` reports `nothing to ship.`, surface that.
 
 ## Phase 5: Final Output
 
-After `commit-push-pr` returns, ensure the user sees one short final response with the branch name and the full PR URL it produced. If the current host already surfaced that response, do not duplicate it. If `commit-push-pr` reported nothing to ship, say so plainly.
+Ensure the user sees the branch name and full PR URL.

--- a/plugins/core/skills/babysit-pr/scripts/parseNitpicks.sh
+++ b/plugins/core/skills/babysit-pr/scripts/parseNitpicks.sh
@@ -59,7 +59,12 @@ for my $section (@sections) {
     my $raw_file_name = trim($1);
     my $file_content = $2;
 
-    while ($file_content =~ /`(\d+(?:-\d+)?)`:\s*(?:_[^_]+_\s*\|\s*_[^_]+_\s*)?\*\*([^*]+)\*\*\s*([\s\S]*?)(?=---|\n`\d|<\/blockquote>|$)/g) {
+    # Category prefix is optional. CodeRabbit emits 0–N `_…_` tags
+    # separated by `|` (e.g. `_⚠️ Potential issue_ | _🟠 Major_ | _⚡ Quick win_`
+    # or just `_💤 Low value_` on lower-confidence findings). The previous
+    # regex required exactly two tags and silently dropped one-tag and
+    # three-tag variants.
+    while ($file_content =~ /`(\d+(?:-\d+)?)`:\s*(?:_[^_]+_(?:\s*\|\s*_[^_]+_)*\s*)?\*\*([^*]+)\*\*\s*([\s\S]*?)(?=---|\n`\d|<\/blockquote>|$)/g) {
       my $line_range = $1;
       my $title = trim($2);
       my $clean_body = clean_comment_body(trim($3));

--- a/plugins/core/skills/commit-push-pr/SKILL.md
+++ b/plugins/core/skills/commit-push-pr/SKILL.md
@@ -14,7 +14,7 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 
 ## Your task
 
-If `Commits ahead of default branch` is `(unknown)`, the ahead-probe failed (e.g., `origin/HEAD` not set) — proceed with the full flow rather than risk skipping real commits. Otherwise, if `Git status`, `Commits ahead of default branch`, and `Existing PR` are all empty/none, stop and reply `nothing to ship.`. Otherwise:
+If `Commits ahead of default branch` is `(unknown)`, `origin/HEAD` couldn't be resolved — stop and tell the user to run `git remote set-head origin -a` (or otherwise set the default branch) before retrying, since the simplify step also depends on it. Otherwise, if `Git status`, `Commits ahead of default branch`, and `Existing PR` are all empty/none, stop and reply `nothing to ship.`. Otherwise:
 
 1. Create a new branch if on main (e.g., `feat/add-user-validation`, `fix/null-check-in-parser`).
 2. Run the `simplify` skill on the full PR diff — `git diff $(git merge-base HEAD origin/HEAD)..HEAD` plus any uncommitted changes. Wait for it to finish, then include any resulting fixes in the commit.

--- a/plugins/core/skills/commit-push-pr/SKILL.md
+++ b/plugins/core/skills/commit-push-pr/SKILL.md
@@ -14,20 +14,13 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 
 ## Your task
 
-**First, decide from the context above. If `Commits ahead of default branch` is `(unknown)`, skip this decision and use the full flow below.**
+If `Git status`, `Commits ahead of default branch`, and `Existing PR` are all empty/none, stop and reply `nothing to ship.`. Otherwise:
 
-- If `Git status` is empty AND `Commits ahead of default branch` is empty AND `Existing PR` is `none`: stop. Reply with `nothing to ship.` and do nothing else.
-- If `Git status` is empty but there are `Commits ahead of default branch` or an `Existing PR`: still run step 1 and step 2. Then re-check `git status --short`; skip step 3 only if it remains empty. Then continue with step 4 and step 5.
-- Otherwise: proceed with all steps below.
-
-Based on the above changes:
-
-1. Create a new branch if on main (e.g., `feat/add-user-validation`, `fix/null-check-in-parser`)
-2. Run the `simplify` skill on the files included in the PR before committing, pushing, or opening the PR. If the working tree is clean, run `simplify` against `git diff $(git merge-base HEAD origin/HEAD)..HEAD`. If the working tree has changes, run it against `git diff HEAD`; when local commits also exist, include `git diff $(git merge-base HEAD origin/HEAD)..HEAD` as additional PR context. Invoke the skill by name using this agent's normal skill invocation mechanism. Wait for the skill to finish, then include any resulting fixes in the commit step below.
-3. Re-check `git status --short`. If there are changes, create a single conventional commit message.
-4. Push the branch to origin
+1. Create a new branch if on main (e.g., `feat/add-user-validation`, `fix/null-check-in-parser`).
+2. Run the `simplify` skill on the full PR diff — `git diff $(git merge-base HEAD origin/HEAD)..HEAD` plus any uncommitted changes. Wait for it to finish, then include any resulting fixes in the commit.
+3. If `git status --short` shows changes, create a single conventional commit.
+4. Push the branch to origin.
 5. Check for an existing PR with `gh pr view`.
-   - No PR exists: Create with `gh pr create`. Title = commit subject line. Description = brief explanation of **why**, not what. Append `<!-- commit-push-pr:created v1 -->` on its own line at the end of the PR description so skill-created PRs can be identified later.
-   - PR exists: Report the URL and move on.
-6. You have the capability to call multiple tools in a single response. After the `simplify` skill completes, do the remaining git and PR operations in a single message. Do not use any other tools or do anything else.
-7. After tool calls complete, send one short final text response with the branch name and the full PR URL (e.g., `https://github.com/clipboardhealth/core-utils/pull/123`). Never use shorthand like `repo#123` — always output the complete URL so it is clickable.
+   - No PR: create with `gh pr create`. Title = commit subject. Description = brief explanation of **why**, not what. Append `<!-- commit-push-pr:created v1 -->` on its own line at the end so skill-created PRs can be identified later.
+   - PR exists: report the URL and move on.
+6. End with one short text response: branch name and the full PR URL (e.g., `https://github.com/clipboardhealth/core-utils/pull/123`). Never use shorthand like `repo#123` — always output the complete URL.

--- a/plugins/core/skills/commit-push-pr/SKILL.md
+++ b/plugins/core/skills/commit-push-pr/SKILL.md
@@ -7,14 +7,14 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 
 - Current branch: !`git branch --show-current`
 - Git status: !`git status --short`
-- Commits ahead of default branch: !`git log --oneline origin/HEAD..HEAD 2>/dev/null || true`
+- Commits ahead of default branch: !`git log --oneline origin/HEAD..HEAD 2>/dev/null || echo "(unknown)"`
 - Existing PR: !`gh pr view --json url --jq .url 2>/dev/null || echo "none"`
 - Diff summary: !`git diff HEAD --stat`
 - Full diff: !`git diff HEAD`
 
 ## Your task
 
-If `Git status`, `Commits ahead of default branch`, and `Existing PR` are all empty/none, stop and reply `nothing to ship.`. Otherwise:
+If `Commits ahead of default branch` is `(unknown)`, the ahead-probe failed (e.g., `origin/HEAD` not set) — proceed with the full flow rather than risk skipping real commits. Otherwise, if `Git status`, `Commits ahead of default branch`, and `Existing PR` are all empty/none, stop and reply `nothing to ship.`. Otherwise:
 
 1. Create a new branch if on main (e.g., `feat/add-user-validation`, `fix/null-check-in-parser`).
 2. Run the `simplify` skill on the full PR diff — `git diff $(git merge-base HEAD origin/HEAD)..HEAD` plus any uncommitted changes. Wait for it to finish, then include any resulting fixes in the commit.

--- a/plugins/core/skills/commit-push-pr/SKILL.md
+++ b/plugins/core/skills/commit-push-pr/SKILL.md
@@ -7,7 +7,7 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 
 - Current branch: !`git branch --show-current`
 - Git status: !`git status --short`
-- Commits ahead of default branch: !`git log --oneline origin/HEAD..HEAD 2>/dev/null || echo "(unknown)"`
+- Commits ahead of default branch: !`git log --oneline origin/HEAD..HEAD 2>/dev/null || true`
 - Existing PR: !`gh pr view --json url --jq .url 2>/dev/null || echo "none"`
 - Diff summary: !`git diff HEAD --stat`
 - Full diff: !`git diff HEAD`

--- a/plugins/core/skills/go/SKILL.md
+++ b/plugins/core/skills/go/SKILL.md
@@ -12,7 +12,7 @@ This skill is the bridge between intent and shipping. It does not re-plan or re-
 
 The user invokes this skill with either a plan file path/identifier or a direct request like "add a login button."
 
-- **Path-like input** (absolute, relative, or bare name): try to read it. For bare names, check the host's plans directory first. If an absolute path lies outside the workspace/repo or the host's plans directory, ask the user to confirm before reading it. If the input doesn't resolve to a readable file, stop and tell the user — do not reinterpret a missing path as a direct request.
+- **Path-like input** (absolute, relative, or bare name): try to read it. For bare names, check the host's plans directory first. Resolve the path first; if it lies outside the workspace/repo or the host's plans directory, ask the user to confirm before reading it (applies to both absolute and relative inputs — `..` escapes count). If the input doesn't resolve to a readable file, stop and tell the user — do not reinterpret a missing path as a direct request.
 - **Natural-language request**: treat as the implementation task. There may be no plan file.
 - **No argument**: ask for either a plan path or the implementation request.
 

--- a/plugins/core/skills/go/SKILL.md
+++ b/plugins/core/skills/go/SKILL.md
@@ -4,59 +4,43 @@ description: Implement a plan file or direct request end-to-end, then hand off t
 
 # Go: Execute Work and Ship It
 
-Given a plan file or direct implementation request, implement the requested work, then invoke the `commit-push-pr` skill to commit, push, and open a PR.
+Given a plan file or direct implementation request, implement the requested work, then invoke the `commit-push-pr` skill to create a PR.
 
 This skill is the bridge between intent and shipping. It does not re-plan or re-design unless the user asked for that. If the request is wrong or cannot be implemented safely, surface that; do not silently improvise.
 
-## Phase 1: Understand the Input
+## Phase 1: Resolve the Input
 
-The user may invoke this skill with either a plan file path/identifier or a direct implementation request such as "add a button to the homepage to log in." Resolve the input in this order:
+The user invokes this skill with either a plan file path/identifier or a direct request like "add a login button."
 
-1. **Absolute path** (starts with `/`): read it directly only when it is inside the current workspace/repo root or the host's plans directory. If it is outside those roots, ask the user to confirm before reading it; if they do not confirm, stop and ask for an approved path.
-2. **Relative path** (contains `/` or starts with `./`): resolve from the current working directory.
-3. **Bare name** (no path separators, e.g. `my-plan` or `my-plan.md`): if the host exposes a plans directory, look there first. Use whatever directory the current host stores plan files in — do not hard-code a host-specific path. If no plan is found and the input is ambiguous, ask whether it is a plan identifier or an implementation request.
-4. **Natural-language request** (for example, contains spaces or reads like an implementation task): treat it as the implementation request. There may be no separate plan file.
-5. **No argument given**: ask the user to provide either the plan file path or the implementation request. Do not guess.
+- **Path-like input** (absolute, relative, or bare name): try to read it. For bare names, check the host's plans directory first. If an absolute path lies outside the workspace/repo or the host's plans directory, ask the user to confirm before reading it. If the input doesn't resolve to a readable file, stop and tell the user — do not reinterpret a missing path as a direct request.
+- **Natural-language request**: treat as the implementation task. There may be no plan file.
+- **No argument**: ask for either a plan path or the implementation request.
 
-If a path-like input does not exist or cannot be read, stop and tell the user. Do not reinterpret a missing path as a direct request.
+When using a plan, read it fully before starting. Note **Critical files**, **Approach**, and **Verification** sections (or equivalents).
 
-When using a plan, read the entire plan before starting. Note the **Critical files**, **Approach**, and **Verification** sections (or their equivalents).
+## Phase 2: Implement
 
-## Phase 2: Implement the Request
+The plan or request is the source of truth for scope:
 
-Treat the plan or direct request as the source of truth for scope:
-
-- Make exactly the changes requested — no more, no less. Do not add extra refactors, tests, or cleanup the request did not ask for.
-- If a plan references files, functions, or utilities that no longer exist, stop and surface the discrepancy before guessing.
-- If you discover the request is wrong (the codebase has moved, an assumption is invalid, a constraint was missed), stop and report. Do not silently rewrite the approach.
-- For direct implementation requests, inspect the relevant code before editing and use the repo's existing patterns.
-- Do **not** modify the plan file itself when working from a plan.
+- Make exactly the changes requested — no extra refactors, tests, or cleanup.
+- If the plan references files or utilities that no longer exist, stop and report.
+- If an assumption is invalid or a constraint was missed, stop and report. Do not silently rewrite the approach.
+- Do not modify the plan file itself.
 
 ## Phase 3: Validate
 
-Validation should follow the repo's instructions and the cost profile of the repo. Some repos intentionally leave slow checks to CI; do not run broad or slow suites unless the repo instructions explicitly require them.
+- Read `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, or equivalent contributor instructions for the mandated pre-PR command (e.g. `npm run affected`). That wins over everything.
+- If the repo relies on pre-commit/pre-push hooks and mandates no manual command, don't invent one — let the hooks run during the `commit-push-pr` handoff.
+- If the plan names specific checks, run them when practical. Ask before running anything that's clearly a slow CI-only suite.
 
-Run validation in this order:
+Fix any failures before handing off. Do not hand off with known failing checks unless the user explicitly accepts a pre-existing or unrelated failure.
 
-1. **Repo instructions.** Look up the repo's standard validation guidance. Common signals, in priority order:
-   - An explicit instruction in the repo's agent or contributor instructions, such as `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, or an equivalent host-specific instruction file (e.g. "MUST run before opening PRs"). This wins over everything else.
-   - A relevant `package.json` script when the repo instructions point to it, such as `affected`, `precommit`, `validate`, `check`, `verify`, `test`, `lint`, `typecheck`, or repo-equivalent.
-   - A repo-specific equivalent in the rare case the project does not use `package.json`.
+## Phase 4: Hand Off
 
-   If the repo primarily relies on git pre-commit or pre-push hooks and does not mandate a manual validation command, do not invent one. Let the hooks run during the `commit-push-pr` handoff.
+Invoke the `commit-push-pr` skill. Do not commit, push, or open the PR yourself.
 
-2. **Request-specific verification.** If the plan or user request names specific checks, run them when they are practical and consistent with the repo instructions. If a requested check is clearly a slow CI-only suite, ask before running it.
-
-If any check you run fails, fix the failures and re-run the same check. Do not hand off to `commit-push-pr` with known failing checks unless the user explicitly accepts a pre-existing or unrelated failure.
-
-## Phase 4: Hand Off to commit-push-pr
-
-Once implementation is complete and Phase 3 validation is satisfied, invoke the `commit-push-pr` skill by name using this agent's normal skill invocation mechanism.
-
-Do **not** commit, push, or open the PR yourself in this skill. Let `commit-push-pr` own the shipping flow.
-
-If `commit-push-pr` reports `nothing to ship.` (the work resulted in no actual file changes), surface that to the user — it usually means the request was already implemented or was a no-op.
+If `commit-push-pr` reports `nothing to ship.`, surface that.
 
 ## Phase 5: Final Output
 
-After `commit-push-pr` returns, ensure the user sees one short final response with the branch name and the full PR URL it produced. If the current host already surfaced that response, do not duplicate it. If `commit-push-pr` reported nothing to ship, say so plainly.
+Ensure the user sees the branch name and full PR URL.


### PR DESCRIPTION
## Summary

- The babysit-pr nitpick parser silently dropped CodeRabbit findings with anything other than exactly two severity tags. The regex required `_x_ | _y_`, but CodeRabbit emits 0, 1, 2, or 3 tags depending on confidence/severity (e.g. `_💤 Low value_` alone, or `_⚠️ Potential issue_ | _🟠 Major_ | _⚡ Quick win_`).
- Make the second tag and its `|` separator repeat zero-or-more times so 1/2/3-tag variants all parse.
- Verified by running the fixed parser against a real PR's review JSON: previously returned `0` nitpicks, now returns the expected single-tag finding with a stable fingerprint.

## Test plan

- [x] Regression check on a 1-tag review body (`_💤 Low value_` only) — now extracted correctly.
- [x] Existing 2-tag and 3-tag variants still parse (smoke fixture covers `_x_`, `_x_ | _y_`, and `_x_ | _y_ | _z_`).
- [x] Fingerprints stay stable: the fingerprint is computed over file + line + title + body, none of which include the category prefix, so existing dedupe across runs is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)