### PR TITLE
chore: add parallel verify all runner

### DIFF
--- a/.agents/skills/go/SKILL.md
+++ b/.agents/skills/go/SKILL.md
@@ -29,7 +29,7 @@ The plan or request is the source of truth for scope:
 
 ## Phase 3: Validate
 
-- Read `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, or equivalent contributor instructions for the mandated pre-PR command (e.g. `npm run affected`). That wins over everything.
+- Read `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, or equivalent contributor instructions for the mandated pre-PR command (e.g. `node --run verify`). That wins over everything.
 - If the repo relies on pre-commit/pre-push hooks and mandates no manual command, don't invent one — let the hooks run during the `commit-push-pr` handoff.
 - If the plan names specific checks, run them when practical. Ask before running anything that's clearly a slow CI-only suite.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,8 @@ jobs:
         with:
           npm_token: ${{ secrets.NPM_TOKEN }}
           start_services: "true"
-      - run: npm run ci:check
       # Don't use the read-write NX_CLOUD_ACCESS_TOKEN when not on `main`, see https://nx.dev/ci/concepts/cache-security#use-a-readwrite-token-in-ci
-      - run: npx nx affected --configuration ci --targets build,lint,test
+      - run: node --run verify
       - run: docker compose down --volumes
         if: always()
 
@@ -97,7 +96,7 @@ jobs:
           git add package.json packages/*/package.json package-lock.json &&
           git diff --staged --quiet || git commit -m "chore(release): sync package versions [skip actions]" --no-verify &&
           git push --no-verify
-      - run: npm run docs
+      - run: node --run docs
       - uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4
         with:
           branch: gh-pages

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -3,6 +3,7 @@
   "extends": ["./packages/oxlint-config/src/vitest.json"],
   "ignorePatterns": [".agents/", ".rules/", "coverage/", "dist/", "node_modules/"],
   "options": {
+    "denyWarnings": true,
     "reportUnusedDisableDirectives": "off",
     "typeAware": true,
     "typeCheck": true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,62 +15,15 @@ IMPORTANT: You MUST read the relevant rule files below before writing or reviewi
 
 <!-- Source: ./OVERLAY.md -->
 
-This is an Nx monorepo containing TypeScript libraries and utilities for Clipboard.
-
-# Commands
-
-## Development
-
-```bash
-# Install dependencies
-npm install
-
-# Build, lint, and test only changed files from main; MUST run before opening PRs
-npm run affected
-
-# Format code
-npm run format
-
-# Check formatting, spelling, etc.
-npm run ci:check
-
-# Lint (oxlint), also runs typecheck
-npm run lint
-
-# Check dependency architecture
-npm run architecture:check
-
-# Check formatting
-npm run format:check
-```
-
-## Package-specific Commands
-
-```bash
-# Install dependency in specific package
-npm install --workspace packages/[PROJECT_NAME] [DEPENDENCY]
-
-# Run specific command against a package
-npx nx run [PROJECT_NAME]:[COMMAND]
-
-# Common targets: build, lint, test
-npx nx run json-api:build
-npx nx run util-ts:test
-
-# For test coverage, run with the "ci" configuration
-npx nx run util-ts:test:ci
-```
+## Project-specific rules
 
 - When modifying ./plugins/core rules or skills, run `node --run sync-ai-rules` to auto-generate the `.rules/` and `.agents/skills` versions
 
-# Project Structure
+### Development workflow
 
-Each package in `packages/` has:
-
-- `project.json`: Nx project configuration with build/lint/test targets
-- `src/index.ts`: Main export file
-- `README.md`: Package-specific documentation with usage examples
-- Individual `tsconfig.lib.json`, `vitest.config.ts`, etc.
+1. Use red, green, refactor test-driven development
+2. Validate changes with at least `node --run verify`
+3. Invoke core:go skill for ALL code changes
 
 <!-- nx configuration start-->
 <!-- Leave the start & end comments to automatically receive updates. -->

--- a/OVERLAY.md
+++ b/OVERLAY.md
@@ -1,59 +1,12 @@
-This is an Nx monorepo containing TypeScript libraries and utilities for Clipboard.
-
-# Commands
-
-## Development
-
-```bash
-# Install dependencies
-npm install
-
-# Build, lint, and test only changed files from main; MUST run before opening PRs
-npm run affected
-
-# Format code
-npm run format
-
-# Check formatting, spelling, etc.
-npm run ci:check
-
-# Lint (oxlint), also runs typecheck
-npm run lint
-
-# Check dependency architecture
-npm run architecture:check
-
-# Check formatting
-npm run format:check
-```
-
-## Package-specific Commands
-
-```bash
-# Install dependency in specific package
-npm install --workspace packages/[PROJECT_NAME] [DEPENDENCY]
-
-# Run specific command against a package
-npx nx run [PROJECT_NAME]:[COMMAND]
-
-# Common targets: build, lint, test
-npx nx run json-api:build
-npx nx run util-ts:test
-
-# For test coverage, run with the "ci" configuration
-npx nx run util-ts:test:ci
-```
+## Project-specific rules
 
 - When modifying ./plugins/core rules or skills, run `node --run sync-ai-rules` to auto-generate the `.rules/` and `.agents/skills` versions
 
-# Project Structure
+### Development workflow
 
-Each package in `packages/` has:
-
-- `project.json`: Nx project configuration with build/lint/test targets
-- `src/index.ts`: Main export file
-- `README.md`: Package-specific documentation with usage examples
-- Individual `tsconfig.lib.json`, `vitest.config.ts`, etc.
+1. Use red, green, refactor test-driven development
+2. Validate changes with at least `node --run verify`
+3. Invoke core:go skill for ALL code changes
 
 <!-- nx configuration start-->
 <!-- Leave the start & end comments to automatically receive updates. -->

--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ See [Nx CLI Commands](https://nx.dev/reference/commands#nx-cli-commands) for opt
 
 ```bash
 # Install dependencies
-npm install
+npm clean-install
 
 # Build, lint, and test only changed files from `main`, helpful prior to opening PRs
-npm run affected
+node --run affected
 
 # For the paranoid: build, lint, and test everything
-npm run all
+node --run verify
 
 # Install a dependency in a specific package
 npm install --workspace packages/[PROJECT_NAME] [DEPENDENCY]

--- a/package.json
+++ b/package.json
@@ -7,10 +7,7 @@
   ],
   "scripts": {
     "affected": "nx affected --base main --configuration ci --parallel 8 --targets build,lint,test",
-    "all": "node scripts/verifyAll.mts",
     "architecture:check": "depcruise packages/*/src",
-    "ci:check": "node --run format:check && node --run cspell -- . && syncpack lint && node --run embed:check && node --run knip && node --run lint && node --run lint:md && node --run architecture:check",
-    "ci:install": "npm clean-install",
     "cspell": "cspell --no-summary --no-progress --no-must-find-files",
     "docs": "rm -rf docs && typedoc",
     "embed": "tsx packages/embedex/src/bin/cli.ts --sourcesGlob 'packages/*/examples/**/*.{md,ts}'",
@@ -20,13 +17,15 @@
     "format": "oxfmt",
     "format:check": "oxfmt --check",
     "hook:pre-commit": "lint-staged",
-    "hook:pre-push": "node --run all",
+    "hook:pre-push": "node --run verify",
     "knip": "NX_DAEMON=false knip",
-    "lint": "oxlint --deny-warnings",
-    "lint:md": "markdownlint-cli2 \"**/*.md\"",
+    "lint": "oxlint",
+    "markdown:lint": "markdownlint-cli2 \"**/*.md\"",
     "postinstall": "node --run sync-ai-rules",
     "prepare": "husky",
-    "sync-ai-rules": "nx build ai-rules && node ./dist/packages/ai-rules/scripts/sync.js common --exclude common/featureFlags"
+    "sync-ai-rules": "nx build ai-rules && node ./dist/packages/ai-rules/scripts/sync.js common --exclude common/featureFlags",
+    "syncpack:lint": "syncpack lint",
+    "verify": "node scripts/verifyAll.mts"
   },
   "dependencies": {
     "tslib": "2.8.1"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "scripts": {
     "affected": "nx affected --base main --configuration ci --parallel 8 --targets build,lint,test",
-    "all": "node --run ci:check && nx run-many --configuration ci --parallel 8 --targets build,lint,test",
+    "all": "node scripts/verifyAll.mts",
     "architecture:check": "depcruise packages/*/src",
     "ci:check": "node --run format:check && node --run cspell -- . && syncpack lint && node --run embed:check && node --run knip && node --run lint && node --run lint:md && node --run architecture:check",
     "ci:install": "npm clean-install",
@@ -20,7 +20,7 @@
     "format": "oxfmt",
     "format:check": "oxfmt --check",
     "hook:pre-commit": "lint-staged",
-    "hook:pre-push": "node --run format:check && node --run lint && node --run knip && node --run architecture:check",
+    "hook:pre-push": "node --run all",
     "knip": "NX_DAEMON=false knip",
     "lint": "oxlint --deny-warnings",
     "lint:md": "markdownlint-cli2 \"**/*.md\"",

--- a/packages/ai-rules/README.md
+++ b/packages/ai-rules/README.md
@@ -41,7 +41,7 @@ npm install --save-dev @clipboard-health/ai-rules
    {
      "scripts": {
        "sync-ai-rules": "node ./node_modules/@clipboard-health/ai-rules/scripts/sync.js [PROFILE_NAME]",
-       "postinstall": "npm run sync-ai-rules"
+       "postinstall": "node --run sync-ai-rules"
      }
    }
    ```

--- a/plugins/core/README.md
+++ b/plugins/core/README.md
@@ -89,7 +89,7 @@ This plugin syncs components from external repositories using a sync script. Thi
 To run the sync:
 
 ```bash
-npm run sync-plugins
+node --run sync-plugins
 ```
 
 ### Adding a new repository
@@ -116,7 +116,7 @@ Edit [`syncPlugins.ts`](../../scripts/syncPlugins.ts) and add an entry to `SYNC_
 
 ### Keeping in sync
 
-Run `npm run sync-plugins` periodically or when upstream repositories have changes you want to pull in.
+Run `node --run sync-plugins` periodically or when upstream repositories have changes you want to pull in.
 
 ## Recommended plugins
 

--- a/plugins/core/skills/go/SKILL.md
+++ b/plugins/core/skills/go/SKILL.md
@@ -29,7 +29,7 @@ The plan or request is the source of truth for scope:
 
 ## Phase 3: Validate
 
-- Read `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, or equivalent contributor instructions for the mandated pre-PR command (e.g. `npm run affected`). That wins over everything.
+- Read `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, or equivalent contributor instructions for the mandated pre-PR command (e.g. `node --run verify`). That wins over everything.
 - If the repo relies on pre-commit/pre-push hooks and mandates no manual command, don't invent one — let the hooks run during the `commit-push-pr` handoff.
 - If the plan names specific checks, run them when practical. Ask before running anything that's clearly a slow CI-only suite.
 

--- a/scripts/verifyAll.mts
+++ b/scripts/verifyAll.mts
@@ -1,0 +1,104 @@
+import { exec } from "node:child_process";
+
+const EXEC_TIMEOUT_MS = 10 * 60_000;
+const EXEC_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
+
+interface CheckResult {
+  name: string;
+  ok: boolean;
+  output: string;
+  durationMs: number;
+}
+
+// These run a pre-push hook and should not modify files
+const CHECKS = [
+  { cmd: "node --run ci:check", name: "ci:check" },
+  {
+    cmd: "./node_modules/.bin/nx run-many --configuration ci --parallel 8 --targets build,lint,test",
+    name: "run-many",
+  },
+] as const;
+
+async function main(): Promise<void> {
+  const totalStart = performance.now();
+
+  print("▶ Running in parallel");
+  const results = await Promise.all(CHECKS.map(async ({ name, cmd }) => await runCheck(name, cmd)));
+
+  for (const result of results) {
+    const icon = result.ok ? "✓" : "✗";
+    print(`  ${icon} ${result.name} (${formatDuration(result.durationMs)})`);
+  }
+
+  printSummary(results, totalStart);
+
+  if (!results.every((result) => result.ok)) {
+    process.exitCode = 1;
+  }
+}
+
+async function runCheck(name: string, cmd: string): Promise<CheckResult> {
+  const start = performance.now();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      exec(
+        cmd,
+        {
+          maxBuffer: EXEC_MAX_BUFFER_BYTES,
+          timeout: EXEC_TIMEOUT_MS,
+        },
+        (error, stdout, stderr) => {
+          if (error) {
+            const combined = `${stdout}${stderr}`.trim();
+            reject(new Error(combined || error.message));
+          } else {
+            resolve();
+          }
+        },
+      );
+    });
+    return { durationMs: performance.now() - start, name, ok: true, output: "" };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { durationMs: performance.now() - start, name, ok: false, output: message };
+  }
+}
+
+function printSummary(results: CheckResult[], totalStart: number): void {
+  const failures = results.filter((result) => !result.ok);
+  const totalMs = performance.now() - totalStart;
+
+  print("\n─── Summary ───");
+  print(`Total: ${formatDuration(totalMs)}`);
+
+  if (failures.length === 0) {
+    print("All checks passed.");
+    return;
+  }
+
+  print(`\nFailed (${failures.length}):`);
+  for (const failure of failures) {
+    print(`\n  ✗ ${failure.name}`);
+    if (failure.output.trim()) {
+      const indented = failure.output
+        .trim()
+        .split("\n")
+        .map((line) => `    ${line}`)
+        .join("\n");
+      print(indented);
+    }
+  }
+}
+
+function formatDuration(milliseconds: number): string {
+  if (milliseconds >= 1000) {
+    return `${(milliseconds / 1000).toFixed(1)}s`;
+  }
+  return `${Math.round(milliseconds)}ms`;
+}
+
+function print(message: string): void {
+  process.stdout.write(`${message}\n`);
+}
+
+await main();

--- a/scripts/verifyAll.mts
+++ b/scripts/verifyAll.mts
@@ -1,4 +1,6 @@
-import { exec } from "node:child_process";
+/// <reference types="node" />
+
+import { exec, type ExecException } from "node:child_process";
 
 const EXEC_TIMEOUT_MS = 10 * 60_000;
 const EXEC_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
@@ -12,11 +14,15 @@ interface CheckResult {
 
 // These run a pre-push hook and should not modify files
 const CHECKS = [
-  { cmd: "node --run format:check", name: "format:check" },
-  { cmd: "node --run lint", name: "lint" },
-  { cmd: "node --run knip", name: "knip" },
-  { cmd: "node --run architecture:check", name: "architecture:check" },
   { cmd: "node --run affected", name: "affected" },
+  { cmd: "node --run architecture:check", name: "architecture:check" },
+  { cmd: "node --run cspell -- .", name: "cspell" },
+  { cmd: "node --run embed:check", name: "embed:check" },
+  { cmd: "node --run format:check", name: "format:check" },
+  { cmd: "node --run knip", name: "knip" },
+  { cmd: "node --run lint", name: "lint" },
+  { cmd: "node --run markdown:lint", name: "markdown:lint" },
+  { cmd: "node --run syncpack:lint", name: "syncpack:lint" },
 ] as const;
 
 async function main(): Promise<void> {
@@ -40,24 +46,26 @@ async function main(): Promise<void> {
 async function runCheck(name: string, cmd: string): Promise<CheckResult> {
   const start = performance.now();
   try {
-    await new Promise<void>((resolve, reject) => {
+    const output = await new Promise<string>((resolve, reject) => {
       exec(
         cmd,
         {
           maxBuffer: EXEC_MAX_BUFFER_BYTES,
           timeout: EXEC_TIMEOUT_MS,
         },
-        (error, stdout, stderr) => {
-          if (error) {
-            const combined = `${stdout}${stderr}`.trim();
-            reject(new Error(combined || error.message));
-          } else {
-            resolve();
+        (error: ExecException | null, stdout: string, stderr: string) => {
+          const combinedOutput = combineProcessOutput(stdout, stderr);
+
+          if (error !== null) {
+            reject(new Error(combinedOutput.length > 0 ? combinedOutput : error.message));
+            return;
           }
+
+          resolve(combinedOutput);
         },
       );
     });
-    return { durationMs: performance.now() - start, name, ok: true, output: "" };
+    return { durationMs: performance.now() - start, name, ok: true, output };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return { durationMs: performance.now() - start, name, ok: false, output: message };
@@ -71,23 +79,53 @@ function printSummary(results: CheckResult[], totalStart: number): void {
   print("\n─── Summary ───");
   print(`Total: ${formatDuration(totalMs)}`);
 
+  const successesWithOutput = results.filter((result) => result.ok && hasOutput(result.output));
+
   if (failures.length === 0) {
     print("All checks passed.");
+    printCheckOutputs(`Passed with output (${successesWithOutput.length}):`, successesWithOutput);
     return;
   }
 
-  print(`\nFailed (${failures.length}):`);
-  for (const failure of failures) {
-    print(`\n  ✗ ${failure.name}`);
-    if (failure.output.trim()) {
-      const indented = failure.output
-        .trim()
-        .split("\n")
-        .map((line) => `    ${line}`)
-        .join("\n");
-      print(indented);
-    }
+  printCheckOutputs(`Failed (${failures.length}):`, failures);
+  printCheckOutputs(`Passed with output (${successesWithOutput.length}):`, successesWithOutput);
+}
+
+function combineProcessOutput(stdout: string, stderr: string): string {
+  return [stdout, stderr]
+    .map((output) => output.trim())
+    .filter((output) => output.length > 0)
+    .join("\n");
+}
+
+function printCheckOutputs(title: string, results: CheckResult[]): void {
+  if (results.length === 0) {
+    return;
   }
+
+  print(`\n${title}`);
+  for (const result of results) {
+    const icon = result.ok ? "✓" : "✗";
+    print(`\n  ${icon} ${result.name}`);
+    printIndentedOutput(result.output);
+  }
+}
+
+function printIndentedOutput(output: string): void {
+  if (!hasOutput(output)) {
+    return;
+  }
+
+  const indented = output
+    .trim()
+    .split("\n")
+    .map((line) => `    ${line}`)
+    .join("\n");
+  print(indented);
+}
+
+function hasOutput(output: string): boolean {
+  return output.trim().length > 0;
 }
 
 function formatDuration(milliseconds: number): string {

--- a/scripts/verifyAll.mts
+++ b/scripts/verifyAll.mts
@@ -12,11 +12,11 @@ interface CheckResult {
 
 // These run a pre-push hook and should not modify files
 const CHECKS = [
-  { cmd: "node --run ci:check", name: "ci:check" },
-  {
-    cmd: "npx nx run-many --configuration ci --parallel 8 --targets build,lint,test",
-    name: "run-many",
-  },
+  { cmd: "node --run format:check", name: "format:check" },
+  { cmd: "node --run lint", name: "lint" },
+  { cmd: "node --run knip", name: "knip" },
+  { cmd: "node --run architecture:check", name: "architecture:check" },
+  { cmd: "node --run affected", name: "affected" },
 ] as const;
 
 async function main(): Promise<void> {

--- a/scripts/verifyAll.mts
+++ b/scripts/verifyAll.mts
@@ -14,7 +14,7 @@ interface CheckResult {
 const CHECKS = [
   { cmd: "node --run ci:check", name: "ci:check" },
   {
-    cmd: "./node_modules/.bin/nx run-many --configuration ci --parallel 8 --targets build,lint,test",
+    cmd: "npx nx run-many --configuration ci --parallel 8 --targets build,lint,test",
     name: "run-many",
   },
 ] as const;
@@ -101,4 +101,8 @@ function print(message: string): void {
   process.stdout.write(`${message}\n`);
 }
 
-await main();
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Why
Core-utils needs one pre-push verification entrypoint that matches CI and exposes useful command output even when a check exits successfully. That keeps warnings visible to engineers while still collecting independent check results in one parallel run.

Linear: none

## Validation
- `node --run sync-ai-rules`
- `node --run verify`
- Pre-commit hook passed while creating `fix: show successful verify check output`
- Push hook passed on `git push`

Agent session ID: codex 019df3dc-f709-7ca0-90d8-3c5f075c8f1a
<!-- commit-push-pr:created v1 -->