### PR TITLE
fix(commit-push-pr): prevent stopping after simplify step

### DIFF
--- a/.agents/skills/commit-push-pr/SKILL.md
+++ b/.agents/skills/commit-push-pr/SKILL.md
@@ -16,8 +16,10 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 
 If `Commits ahead of default branch` is `(unknown)`, `origin/HEAD` couldn't be resolved — stop and tell the user to run `git remote set-head origin -a` (or otherwise set the default branch) before retrying, since the simplify step also depends on it. Otherwise, if `Git status`, `Commits ahead of default branch`, and `Existing PR` are all empty/none, stop and reply `nothing to ship.`. Otherwise:
 
+Before doing any step, output the full 7-step checklist below in your first response so it stays in recent context across sub-skill calls. Do not skip this — it's what keeps you from stopping after `simplify`.
+
 1. Create a new branch if on main (e.g., `feat/add-user-validation`, `fix/null-check-in-parser`).
-2. Run the `simplify` skill on the full PR diff — `git diff $(git merge-base HEAD origin/HEAD)..HEAD` plus any uncommitted changes. When it returns, continue to step 3 in the same turn; do not stop.
+2. Run the `simplify` skill on the full PR diff — `git diff $(git merge-base HEAD origin/HEAD)..HEAD` plus any uncommitted changes. When it returns, your very next action is to restate the remaining steps (3–7) and continue with step 3 in the same turn. Do not stop, do not end the turn with a simplify summary.
 3. If `git status --short` shows changes, create a single conventional commit.
 4. Push the branch to origin.
 5. Look up the current agent session ID with `bash scripts/find-session-id.sh '<phrase>'`. Pass a distinctive verbatim chunk (≥10 words) from the most recent user message; see the script header for quoting constraints. On success the script prints `<agent> <id>`; otherwise nothing — if empty, omit the session ID line below.

--- a/.agents/skills/commit-push-pr/SKILL.md
+++ b/.agents/skills/commit-push-pr/SKILL.md
@@ -20,7 +20,7 @@ Before doing any step, output the full 7-step checklist below in your first resp
 
 1. Create a new branch if on main (e.g., `feat/add-user-validation`, `fix/null-check-in-parser`).
 2. Run the `simplify` skill on the full PR diff — `git diff $(git merge-base HEAD origin/HEAD)..HEAD` plus any uncommitted changes. When it returns, your very next action is to restate the remaining steps (3–7) and continue with step 3 in the same turn. Do not stop, do not end the turn with a simplify summary.
-3. If `git status --short` shows changes, create a single conventional commit.
+3. If `git status --short` shows changes, create a single conventional commit with `git commit --no-gpg-sign`.
 4. Push the branch to origin.
 5. Look up the current agent session ID with `bash scripts/find-session-id.sh '<phrase>'`. Pass a distinctive verbatim chunk (≥10 words) from the most recent user message; see the script header for quoting constraints. On success the script prints `<agent> <id>`; otherwise nothing — if empty, omit the session ID line below.
 6. Check for an existing PR with `gh pr view`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ IMPORTANT: You MUST read the relevant rule files below before writing or reviewi
 ## Project-specific rules
 
 - When modifying ./plugins/core rules or skills, run `node --run sync-ai-rules` to auto-generate the `.rules/` and `.agents/skills` versions
+- Create agent-agnostic ./plugins/core skills unless explicitly told otherwise
 
 ### Development workflow
 

--- a/OVERLAY.md
+++ b/OVERLAY.md
@@ -1,6 +1,7 @@
 ## Project-specific rules
 
 - When modifying ./plugins/core rules or skills, run `node --run sync-ai-rules` to auto-generate the `.rules/` and `.agents/skills` versions
+- Create agent-agnostic ./plugins/core skills unless explicitly told otherwise
 
 ### Development workflow
 

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Clipboard's core development tools.",
   "author": {
     "name": "Clipboard",

--- a/plugins/core/skills/commit-push-pr/SKILL.md
+++ b/plugins/core/skills/commit-push-pr/SKILL.md
@@ -16,8 +16,10 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 
 If `Commits ahead of default branch` is `(unknown)`, `origin/HEAD` couldn't be resolved — stop and tell the user to run `git remote set-head origin -a` (or otherwise set the default branch) before retrying, since the simplify step also depends on it. Otherwise, if `Git status`, `Commits ahead of default branch`, and `Existing PR` are all empty/none, stop and reply `nothing to ship.`. Otherwise:
 
+Before doing any step, output the full 7-step checklist below in your first response so it stays in recent context across sub-skill calls. Do not skip this — it's what keeps you from stopping after `simplify`.
+
 1. Create a new branch if on main (e.g., `feat/add-user-validation`, `fix/null-check-in-parser`).
-2. Run the `simplify` skill on the full PR diff — `git diff $(git merge-base HEAD origin/HEAD)..HEAD` plus any uncommitted changes. When it returns, continue to step 3 in the same turn; do not stop.
+2. Run the `simplify` skill on the full PR diff — `git diff $(git merge-base HEAD origin/HEAD)..HEAD` plus any uncommitted changes. When it returns, your very next action is to restate the remaining steps (3–7) and continue with step 3 in the same turn. Do not stop, do not end the turn with a simplify summary.
 3. If `git status --short` shows changes, create a single conventional commit.
 4. Push the branch to origin.
 5. Look up the current agent session ID with `bash scripts/find-session-id.sh '<phrase>'`. Pass a distinctive verbatim chunk (≥10 words) from the most recent user message; see the script header for quoting constraints. On success the script prints `<agent> <id>`; otherwise nothing — if empty, omit the session ID line below.

--- a/plugins/core/skills/commit-push-pr/SKILL.md
+++ b/plugins/core/skills/commit-push-pr/SKILL.md
@@ -20,7 +20,7 @@ Before doing any step, output the full 7-step checklist below in your first resp
 
 1. Create a new branch if on main (e.g., `feat/add-user-validation`, `fix/null-check-in-parser`).
 2. Run the `simplify` skill on the full PR diff — `git diff $(git merge-base HEAD origin/HEAD)..HEAD` plus any uncommitted changes. When it returns, your very next action is to restate the remaining steps (3–7) and continue with step 3 in the same turn. Do not stop, do not end the turn with a simplify summary.
-3. If `git status --short` shows changes, create a single conventional commit.
+3. If `git status --short` shows changes, create a single conventional commit with `git commit --no-gpg-sign`.
 4. Push the branch to origin.
 5. Look up the current agent session ID with `bash scripts/find-session-id.sh '<phrase>'`. Pass a distinctive verbatim chunk (≥10 words) from the most recent user message; see the script header for quoting constraints. On success the script prints `<agent> <id>`; otherwise nothing — if empty, omit the session ID line below.
 6. Check for an existing PR with `gh pr view`.


### PR DESCRIPTION
Two fixes to the `commit-push-pr` skill.

**1. Prevent stopping after `simplify`.** Agents using the skill were ending their turn after the `simplify` sub-skill returned its summary, instead of continuing through commit/push/PR. The closing summary line in `simplify` reads like a natural turn boundary, and by the time it returns the original "do not stop" reminder is far away in context. Adds two reinforcements:

- A directive at the top of the task to print the 7-step checklist in the first response, so it stays in recent context across the sub-skill call.
- A stronger step 2 telling the agent to restate the remaining steps (3–7) the moment `simplify` returns.

Both are agent-agnostic (text output, no `TaskCreate`/`update_plan` tool dependency) so the skill keeps working on Claude Code and Codex.

**2. Skip GPG signing in the commit step.** Step 3 now invokes `git commit --no-gpg-sign`.

Agent session ID: claude-code 02218086-a589-4405-a368-04146d479fe3
<!-- commit-push-pr:created v1 -->