### PR TITLE
docs(ai-rules): require feature-scoped exports to include feature in name

### DIFF
--- a/.rules/common/typeScript.md
+++ b/.rules/common/typeScript.md
@@ -4,7 +4,7 @@
 
 - Avoid acronyms and abbreviations; for those widely known, use camelCase: `httpRequest`, `gpsPosition`, `cliArguments`, `apiResponse`
 - File-scoped constants: `MAX_RETRY_COUNT`
-- Exported constants include feature/domain scope: `WORKER_SEARCH_MIN_INPUT_LENGTH`, not `MIN_SEARCH_LENGTH`
+- Feature-scoped exports (constants, types, functions) include the feature in their name to avoid polluting the global scope with generic names: `WORKER_SEARCH_MIN_INPUT_LENGTH`, not `MIN_SEARCH_LENGTH`
 - Instead of `agentRequirement`, `agentReq`, `workerType`, use `qualification`
 - Instead of `agent`, `hcp`, `healthcareProvider`, use `worker`
 - Instead of `facility`, `hcf`, `healthcareFacility`, use `workplace`

--- a/.rules/common/typeScript.md
+++ b/.rules/common/typeScript.md
@@ -4,6 +4,7 @@
 
 - Avoid acronyms and abbreviations; for those widely known, use camelCase: `httpRequest`, `gpsPosition`, `cliArguments`, `apiResponse`
 - File-scoped constants: `MAX_RETRY_COUNT`
+- Exported constants include feature/domain scope: `WORKER_SEARCH_MIN_INPUT_LENGTH`, not `MIN_SEARCH_LENGTH`
 - Instead of `agentRequirement`, `agentReq`, `workerType`, use `qualification`
 - Instead of `agent`, `hcp`, `healthcareProvider`, use `worker`
 - Instead of `facility`, `hcf`, `healthcareFacility`, use `workplace`

--- a/packages/ai-rules/rules/common/typeScript.md
+++ b/packages/ai-rules/rules/common/typeScript.md
@@ -4,7 +4,7 @@
 
 - Avoid acronyms and abbreviations; for those widely known, use camelCase: `httpRequest`, `gpsPosition`, `cliArguments`, `apiResponse`
 - File-scoped constants: `MAX_RETRY_COUNT`
-- Exported constants include feature/domain scope: `WORKER_SEARCH_MIN_INPUT_LENGTH`, not `MIN_SEARCH_LENGTH`
+- Feature-scoped exports (constants, types, functions) include the feature in their name to avoid polluting the global scope with generic names: `WORKER_SEARCH_MIN_INPUT_LENGTH`, not `MIN_SEARCH_LENGTH`
 - Instead of `agentRequirement`, `agentReq`, `workerType`, use `qualification`
 - Instead of `agent`, `hcp`, `healthcareProvider`, use `worker`
 - Instead of `facility`, `hcf`, `healthcareFacility`, use `workplace`

--- a/packages/ai-rules/rules/common/typeScript.md
+++ b/packages/ai-rules/rules/common/typeScript.md
@@ -4,6 +4,7 @@
 
 - Avoid acronyms and abbreviations; for those widely known, use camelCase: `httpRequest`, `gpsPosition`, `cliArguments`, `apiResponse`
 - File-scoped constants: `MAX_RETRY_COUNT`
+- Exported constants include feature/domain scope: `WORKER_SEARCH_MIN_INPUT_LENGTH`, not `MIN_SEARCH_LENGTH`
 - Instead of `agentRequirement`, `agentReq`, `workerType`, use `qualification`
 - Instead of `agent`, `hcp`, `healthcareProvider`, use `worker`
 - Instead of `facility`, `hcf`, `healthcareFacility`, use `workplace`


### PR DESCRIPTION
## Summary
Adds one bullet to the TypeScript naming-conventions rule so agents stop giving feature-scoped exports (constants, types, functions) generic, app-wide-sounding names that pollute the global scope.

> Feature-scoped exports (constants, types, functions) include the feature in their name to avoid polluting the global scope with generic names: `WORKER_SEARCH_MIN_INPUT_LENGTH`, not `MIN_SEARCH_LENGTH`

Example mistake from [cbh-admin-frontend#6018 review](https://github.com/ClipboardHealth/cbh-admin-frontend/pull/6018#discussion_r3200379841): a `MIN_SEARCH_LENGTH` constant exported from a Home-Health WorkerView feature folder. Reviewer flagged that it was very generic for something exported to the entire app. The new bullet codifies that for any feature-scoped export.

Diff is two lines (source + synced copy):
- `packages/ai-rules/rules/common/typeScript.md` — source
- `.rules/common/typeScript.md` — regenerated via `node --run sync-ai-rules`

## Review & Testing Checklist for Human
- [ ] Wording reads well next to the existing `File-scoped constants: MAX_RETRY_COUNT` bullet
- [ ] Example pair (`WORKER_SEARCH_MIN_INPUT_LENGTH` vs `MIN_SEARCH_LENGTH`) is clear enough that agents will apply it to types and functions too, not only constants

### Notes
Risk: green — docs-only, single bullet, no code paths affected. `node --run verify` passed locally.


Link to Devin session: https://app.devin.ai/sessions/374e8788e5cd4e3bb470c087b0c50a4a
Requested by: @artur99