### PR TITLE
fix: align renovate policy for nx action updates

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -22,7 +22,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4.4.0
+    - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
 
     - name: Validate repo configuration files
       shell: bash

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,32 +2,25 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices",
-    ":combinePatchMinorReleases",
     ":enableVulnerabilityAlertsWithLabel(SECURITY)",
     ":preserveSemverRanges",
     "config:js-lib",
     "docker:enableMajor",
-    "schedule:automergeDaily",
-    "schedule:daily"
+    "schedule:daily",
+    "schedule:automergeDaily"
   ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true,
+    "automergeType": "branch"
+  },
   "packageRules": [
     {
-      "automerge": true,
-      "automergeType": "branch",
-      "matchDepTypes": ["devDependencies"]
+      "matchDepTypes": ["peerDependencies", "provider", "required_provider", "required_version"],
+      "rangeStrategy": "widen"
     },
     {
-      "automerge": true,
-      "automergeType": "branch",
-      "matchUpdateTypes": ["patch", "minor"]
-    },
-    {
-      "automerge": true,
-      "automergeType": "branch",
-      "matchUpdateTypes": ["lockFileMaintenance"]
-    },
-    {
-      "groupName": "Clipboard",
+      "groupName": "Clipboard Health",
       "matchPackageNames": ["/^@clipboard-health/"]
     },
     {
@@ -35,29 +28,49 @@
       "matchPackageNames": ["/^@ts-rest/"]
     },
     {
-      "matchDepTypes": ["peerDependencies", "provider", "required_provider", "required_version"],
-      "rangeStrategy": "widen"
+      "matchPackageNames": ["node", "npm"],
+      "enabled": false
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
+      "automerge": true,
+      "automergeType": "branch",
+      "matchDepTypes": ["devDependencies"]
+    },
+    {
+      "automerge": false,
+      "matchUpdateTypes": ["major"]
+    },
+    {
+      "matchUpdateTypes": ["security"],
+      "commitMessagePrefix": "fix(deps): ",
+      "commitMessageTopic": "{{depName}}"
     },
     {
       "enabled": false,
+      "matchManagers": ["npm"],
       "matchPackageNames": [
-        "/@types/jest/",
-        "/^@nx/",
-        "/^@typescript-eslint/",
+        "/^@types\\/jest$/",
+        "/^@typescript-eslint\\//",
         "/^eslint/",
-        "/decamelize/",
-        "/jest/",
-        "/nx/",
-        "/ts-jest/",
-        "/tslib/"
+        "decamelize",
+        "jest",
+        "ts-jest",
+        "tslib"
       ]
     },
     {
-      "matchPackageNames": ["node", "npm"],
-      "enabled": false
+      "enabled": false,
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["/^@nx\\//", "nx"]
     }
   ],
   "prBodyTemplate": "{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{controls}}}",
   "prConcurrentLimit": 15,
-  "prHourlyLimit": 5
+  "prHourlyLimit": 5,
+  "separateMinorPatch": true
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,10 +20,6 @@
       "rangeStrategy": "widen"
     },
     {
-      "groupName": "Clipboard Health",
-      "matchPackageNames": ["/^@clipboard-health/"]
-    },
-    {
       "groupName": "ts-rest",
       "matchPackageNames": ["/^@ts-rest/"]
     },
@@ -46,22 +42,9 @@
       "matchUpdateTypes": ["major"]
     },
     {
-      "matchUpdateTypes": ["security"],
-      "commitMessagePrefix": "fix(deps): ",
-      "commitMessageTopic": "{{depName}}"
-    },
-    {
       "enabled": false,
       "matchManagers": ["npm"],
-      "matchPackageNames": [
-        "/^@types\\/jest$/",
-        "/^@typescript-eslint\\//",
-        "/^eslint/",
-        "decamelize",
-        "jest",
-        "ts-jest",
-        "tslib"
-      ]
+      "matchPackageNames": ["/^@typescript-eslint\\//", "/^eslint/", "decamelize", "tslib"]
     },
     {
       "enabled": false,


### PR DESCRIPTION
core-utils is public and cannot extend the private shared Renovate preset, so its local Renovate policy needs to stay aligned without suppressing GitHub Action updates that do not require Nx migrations. This keeps npm Nx package upgrades blocked while allowing Renovate to update nrwl/nx-set-shas, and removes stale package rules for dependencies or groups that no longer need repo-specific handling.

Validation:
- npm exec --yes --package renovate -- renovate-config-validator .github/renovate.json
- NX_WORKSPACE_DATA_DIRECTORY="$PWD/.nx/workspace-data" NX_CACHE_DIRECTORY="$PWD/.nx/cache" node --run verify

<!-- commit-push-pr:created v1 core@3.4.0 -->