### PR TITLE
chore: add root Vitest workspace entry point for STAFF-531

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "spell:check": "cspell --no-summary --no-progress --no-must-find-files",
     "sync-ai-rules": "node scripts/embedPluginVersion.mts && nx build ai-rules && node ./dist/packages/ai-rules/scripts/sync.js common --exclude common/featureFlags",
     "syncpack:lint": "syncpack lint",
+    "test": "for config in packages/*/vitest.config.ts; do vitest run --coverage --config \"$config\" || exit $?; done",
     "verify": "node scripts/verifyAll.mts"
   },
   "dependencies": {

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    projects: ["packages/*/vitest.config.ts"],
+  },
+});


### PR DESCRIPTION
## Why

STAFF-531 adds a root Vitest entry point so core-utils can run package test configs from the repository root without relying only on Nx target discovery.

Vitest 4 uses one root coverage provider for project runs, so the root test script runs each package config directly. That preserves the existing per-package coverage output directories from the package configs while the root workspace config still exposes the narrow packages/*/vitest.config.ts project set and avoids generator templates.

Linear: STAFF-531

## Validation

- `node --run test` fails locally in `packages/mongo-jobs` because MongoDB at `localhost:27017` is unavailable; Docker is also unavailable from this shell, so I could not start `test-mongo`. Packages before `mongo-jobs` passed and wrote coverage under `coverage/packages/<package>`.
- `npx vitest run --coverage --config packages/util-ts/vitest.config.ts` passes: 25 files, 238 tests.
- `NX_WORKSPACE_DATA_DIRECTORY=/Users/rocky/dev/c/core-utils-staff-531/.nx/workspace-data node --run verify` passes. Raw `node --run verify` cannot write the main worktree Nx lock at `/Users/rocky/dev/c/core-utils/.nx/workspace-data/A34A1B84-8C72-56D0-BCB4-262E1CCFF8F1-v2.lock` from this shell.

<!-- commit-push-pr:created v1 core@3.4.0 -->