### PR TITLE
chore(staff-535): tighten dependency-cruiser orphan handling

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -1,4 +1,31 @@
 /** @type {import('dependency-cruiser').IConfiguration} */
+// dependency-cruiser runs with tsPreCompilationDeps disabled, so modules only referenced by
+// `import type`/`export type` are intentionally classified here instead of hidden by a broad glob.
+const TYPE_ONLY_ORPHAN_MODULES = [
+  String.raw`^packages/config/src/lib/types\.ts$`,
+  String.raw`^packages/embedex/src/lib/internal/types\.ts$`,
+  String.raw`^packages/embedex/src/lib/types\.ts$`,
+  String.raw`^packages/execution-context/src/types/types\.ts$`,
+  String.raw`^packages/json-api-nestjs/src/lib/types\.ts$`,
+  String.raw`^packages/json-api/src/lib/types\.ts$`,
+  String.raw`^packages/mongo-jobs/src/lib/handler\.ts$`,
+  String.raw`^packages/mongo-jobs/src/lib/internal/logger\.ts$`,
+  String.raw`^packages/mongo-jobs/src/lib/internal/worker/queueConsumer\.ts$`,
+  String.raw`^packages/oxlint-config/src/internal/types\.ts$`,
+  String.raw`^packages/phone-number/src/lib/types\.ts$`,
+  String.raw`^packages/playwright-reporter-llm/src/lib/types\.ts$`,
+  String.raw`^packages/rules-engine/src/lib/rule\.ts$`,
+  String.raw`^packages/util-ts/src/lib/logger\.ts$`,
+  String.raw`^packages/util-ts/src/lib/types\.ts$`,
+];
+
+// Files that are valid package entry/subentry/test-support files without static runtime edges.
+const INTENTIONAL_ORPHAN_MODULES = [
+  String.raw`^packages/eslint-config/src/react\.js$`,
+  String.raw`^packages/mongo-jobs/src/lib/testing\.ts$`,
+  String.raw`^packages/nx-plugin/src/index\.ts$`,
+];
+
 module.exports = {
   forbidden: [
     {
@@ -10,7 +37,7 @@ module.exports = {
     },
     {
       name: "no-orphans",
-      severity: "warn",
+      severity: "error",
       comment: "Modules should be reachable from an entry point",
       from: {
         orphan: true,
@@ -18,6 +45,8 @@ module.exports = {
           String.raw`\.(spec|test)\.ts$`,
           String.raw`\.d\.ts$`,
           String.raw`jest\.config\.ts$`,
+          ...TYPE_ONLY_ORPHAN_MODULES,
+          ...INTENTIONAL_ORPHAN_MODULES,
         ],
       },
       to: {},


### PR DESCRIPTION
## Why
core-utils was treating dependency-cruiser orphan modules as warnings, so new orphan files could stay non-actionable. This PR classifies the current baseline explicitly and promotes the rule to an error so future orphan modules fail architecture checks.

## Validation
- `node --run architecture:check`
- `NX_WORKSPACE_DATA_DIRECTORY=/Users/rocky/dev/c/core-utils-staff-535/.nx/workspace-data NX_CACHE_DIRECTORY=/Users/rocky/dev/c/core-utils-staff-535/.nx/cache node --run verify`

Note: the plain pre-push `node --run verify` initially failed because this worktree cannot write to the main worktree shared Nx cache at `/Users/rocky/dev/c/core-utils/.nx`; rerunning with cache/data pinned to this checkout passed and the push hook passed with the same environment.

Agent session ID: codex 019e03d9-d0bf-7c53-8963-99701ff1b039
<!-- commit-push-pr:created v1 core@3.4.0 -->