### PR TITLE
chore(core): apply config hygiene cleanups for STAFF-536

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -8,5 +8,7 @@
     "MD037": false,
     "MD041": false,
   },
-  "ignores": ["**/node_modules", "**/dist", "**/coverage", ".nx", "**/test-results/**"],
+  "gitignore": true,
+  "globs": ["**/*.{md,mdx}"],
+  "ignores": [".nx/**"],
 }

--- a/.syncpackrc.ts
+++ b/.syncpackrc.ts
@@ -1,7 +1,4 @@
-// @ts-check
-
-/** @type {import("syncpack").RcFile} */
-module.exports = {
+export default {
   semverGroups: [
     {
       dependencyTypes: ["dev", "prod", "resolutions"],
@@ -39,4 +36,5 @@ module.exports = {
       label: "@types packages should only be under devDependencies.",
     },
   ],
-};
+  // oxlint-disable-next-line typescript/consistent-type-imports
+} satisfies import("syncpack").RcFile;

--- a/cspell.json
+++ b/cspell.json
@@ -1,18 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
   "version": "0.2",
-  "ignorePaths": [
-    ".github/CODEOWNERS",
-    ".serena",
-    ".vscode",
-    "coverage",
-    "default.json",
-    "dist",
-    "docs",
-    "node_modules",
-    "prompts",
-    "tmp"
-  ],
+  "useGitignore": true,
+  "ignorePaths": [".github/CODEOWNERS", ".serena", "default.json", "docs", "prompts"],
   "words": [
     "agentprofile",
     "airbyte",


### PR DESCRIPTION
Linear: STAFF-536

## Why

This applies the low-risk configuration hygiene cleanup set from the core-utils audit against Clipboard, keeping spellcheck, markdownlint, and SyncPack behavior aligned while preserving the existing SyncPack rules. The SyncPack config is converted to TypeScript so the repo exercises the required config loader path.

## Validation

- `node --run spell:check -- .`
- `node --run markdown:lint`
- `node --run syncpack:lint`
- `node --run format:check`
- `node --run verify` attempted locally; the default run is blocked by this worktree environment because Nx cannot write `/Users/rocky/dev/c/core-utils/.nx/workspace-data/...lock`. With local Nx cache/workspace-data env vars, verification progresses into affected tasks but `mongo-jobs:test:ci` needs MongoDB on `localhost:27017`; Docker/Colima are not accessible in this session. CI should run the full checks.

Agent session ID: codex 019e0416-a736-7fb2-a6a4-041eb1a01929
<!-- commit-push-pr:created v1 core@3.4.0 -->