### PR TITLE
feat(core): add --draft flag to /core:go for draft PRs

### DIFF
--- a/.agents/skills/commit-push-pr/SKILL.md
+++ b/.agents/skills/commit-push-pr/SKILL.md
@@ -12,6 +12,11 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 - Diff summary: !`git diff HEAD --stat`
 - Full diff: !`git diff HEAD`
 
+## Inputs
+
+- If invoked with the argument `draft` — e.g. `/core:commit-push-pr draft`, or by `go` after `--draft` — pass `--draft` to `gh pr create` in step 6.
+- The existing-PR branch in step 6 ("PR exists") is unaffected. Converting an already-open PR from ready to draft requires `gh pr ready --undo` and is out of scope for this skill.
+
 ## Your task
 
 If `Commits ahead of default branch` is `(unknown)`, `origin/HEAD` couldn't be resolved — stop and tell the user to run `git remote set-head origin -a` (or otherwise set the default branch) before retrying, since the simplify step also depends on it. Otherwise, if `Git status`, `Commits ahead of default branch`, and `Existing PR` are all empty/none, stop and reply `nothing to ship.`. Otherwise:
@@ -24,6 +29,6 @@ Before doing any step, output the full 7-step checklist below in your first resp
 4. Push the branch to origin.
 5. Look up the current agent session ID with `bash scripts/find-session-id.sh '<phrase>'`. Pass a distinctive verbatim chunk (≥10 words) from the most recent user message; see the script header for quoting constraints. On success the script prints `<agent> <id>`; otherwise nothing — if empty, omit the session ID line below.
 6. Check for an existing PR with `gh pr view`.
-   - No PR: create with `gh pr create`. Title = commit subject. Description = brief explanation of **why**, not what. Append `Agent session ID: <output of step 5>` (omit if step 5 produced no output) and `<!-- commit-push-pr:created v1 core@3.4.0 -->` on their own lines at the end.
+   - No PR: create with `gh pr create` (add `--draft` if invoked with `draft`). Title = commit subject. Description = brief explanation of **why**, not what. Append `Agent session ID: <output of step 5>` (omit if step 5 produced no output) and `<!-- commit-push-pr:created v1 core@3.4.0 -->` on their own lines at the end.
    - PR exists: refresh the body via `gh pr edit --body` so (a) the new commit's changes are reflected in the prose, (b) `Agent session ID: <output of step 5>` appears in the body — append if missing, never remove or rewrite existing session ID lines so each contributing session is preserved — and (c) any existing `<!-- commit-push-pr:created v1 ... -->` line is preserved verbatim (append `<!-- commit-push-pr:created v1 core@3.4.0 -->` if absent). Then report the URL.
 7. End with one short text response: branch name and the full PR URL (e.g., `https://github.com/clipboardhealth/core-utils/pull/123`). Never use shorthand like `repo#123` — always output the complete URL.

--- a/.agents/skills/go/SKILL.md
+++ b/.agents/skills/go/SKILL.md
@@ -1,5 +1,6 @@
 ---
-description: Implement a plan file or direct request end-to-end, then hand off to commit-push-pr to ship it. Use when the user says 'go', 'execute the plan', 'implement the plan', or gives an implementation request.
+description: Implement a plan file or direct request end-to-end, then hand off to commit-push-pr to ship it. Pass `--draft` to open the resulting PR as a draft (default is ready-for-review); `--ready` is accepted for forward-compat. Use when the user says 'go', 'execute the plan', 'implement the plan', or gives an implementation request.
+argument-hint: "[--draft|--ready] [plan-path-or-request]"
 ---
 
 # Go: Execute Work and Ship It
@@ -9,6 +10,15 @@ Given a plan file or direct implementation request, implement the requested work
 This skill is the bridge between intent and shipping. It does not re-plan or re-design unless the user asked for that. If the request is wrong or cannot be implemented safely, surface that; do not silently improvise.
 
 ## Phase 1: Resolve the Input
+
+### Flags
+
+Before resolving the input as a path or request, scan the entire argument string for these flags. They may appear in any position — leading, trailing, or surrounded by other text (including a quoted natural-language request). Strip every match before resolving the remainder.
+
+- `--draft`: open the resulting PR as a draft. Remember this for Phase 4.
+- `--ready`: open the resulting PR as ready-for-review. This is the current default and is accepted as a no-op for forward-compatibility, so a future team-default flip remains reversible per-invocation without re-editing the skill.
+- If both `--draft` and `--ready` appear, stop and ask the user which one to use rather than guessing — mirrors the "default to safer outcome and flag it" pattern used elsewhere.
+- If neither appears, behavior is unchanged (ready-for-review).
 
 The user invokes this skill with either a plan file path/identifier or a direct request like "add a login button."
 
@@ -37,7 +47,7 @@ Fix any failures before handing off. Do not hand off with known failing checks u
 
 ## Phase 4: Hand Off
 
-Invoke the `commit-push-pr` skill. Do not commit, push, or open the PR yourself.
+Invoke the `commit-push-pr` skill, passing `draft` as its argument when `--draft` was set in Phase 1. `--ready` is the current default and does not need to be passed. Do not commit, push, or open the PR yourself.
 
 If `commit-push-pr` reports `nothing to ship.`, surface that.
 

--- a/plugins/core/README.md
+++ b/plugins/core/README.md
@@ -58,7 +58,7 @@ Analyze and fix duplicate Cognito users by comparing against backend data. Usefu
 
 ### commit-push-pr
 
-Commit changes, push to origin, and create a PR in one step. Invoke with `/commit-push-pr`.
+Commit changes, push to origin, and create a PR in one step. Invoke with `/commit-push-pr` (or `/commit-push-pr draft` to open the PR as a draft).
 
 ### datadog-investigate
 

--- a/plugins/core/skills/commit-push-pr/SKILL.md
+++ b/plugins/core/skills/commit-push-pr/SKILL.md
@@ -12,6 +12,11 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 - Diff summary: !`git diff HEAD --stat`
 - Full diff: !`git diff HEAD`
 
+## Inputs
+
+- If invoked with the argument `draft` — e.g. `/core:commit-push-pr draft`, or by `go` after `--draft` — pass `--draft` to `gh pr create` in step 6.
+- The existing-PR branch in step 6 ("PR exists") is unaffected. Converting an already-open PR from ready to draft requires `gh pr ready --undo` and is out of scope for this skill.
+
 ## Your task
 
 If `Commits ahead of default branch` is `(unknown)`, `origin/HEAD` couldn't be resolved — stop and tell the user to run `git remote set-head origin -a` (or otherwise set the default branch) before retrying, since the simplify step also depends on it. Otherwise, if `Git status`, `Commits ahead of default branch`, and `Existing PR` are all empty/none, stop and reply `nothing to ship.`. Otherwise:
@@ -24,6 +29,6 @@ Before doing any step, output the full 7-step checklist below in your first resp
 4. Push the branch to origin.
 5. Look up the current agent session ID with `bash scripts/find-session-id.sh '<phrase>'`. Pass a distinctive verbatim chunk (≥10 words) from the most recent user message; see the script header for quoting constraints. On success the script prints `<agent> <id>`; otherwise nothing — if empty, omit the session ID line below.
 6. Check for an existing PR with `gh pr view`.
-   - No PR: create with `gh pr create`. Title = commit subject. Description = brief explanation of **why**, not what. Append `Agent session ID: <output of step 5>` (omit if step 5 produced no output) and `<!-- commit-push-pr:created v1 core@3.4.0 -->` on their own lines at the end.
+   - No PR: create with `gh pr create` (add `--draft` if invoked with `draft`). Title = commit subject. Description = brief explanation of **why**, not what. Append `Agent session ID: <output of step 5>` (omit if step 5 produced no output) and `<!-- commit-push-pr:created v1 core@3.4.0 -->` on their own lines at the end.
    - PR exists: refresh the body via `gh pr edit --body` so (a) the new commit's changes are reflected in the prose, (b) `Agent session ID: <output of step 5>` appears in the body — append if missing, never remove or rewrite existing session ID lines so each contributing session is preserved — and (c) any existing `<!-- commit-push-pr:created v1 ... -->` line is preserved verbatim (append `<!-- commit-push-pr:created v1 core@3.4.0 -->` if absent). Then report the URL.
 7. End with one short text response: branch name and the full PR URL (e.g., `https://github.com/clipboardhealth/core-utils/pull/123`). Never use shorthand like `repo#123` — always output the complete URL.

--- a/plugins/core/skills/go/SKILL.md
+++ b/plugins/core/skills/go/SKILL.md
@@ -1,5 +1,6 @@
 ---
-description: Implement a plan file or direct request end-to-end, then hand off to commit-push-pr to ship it. Use when the user says 'go', 'execute the plan', 'implement the plan', or gives an implementation request.
+description: Implement a plan file or direct request end-to-end, then hand off to commit-push-pr to ship it. Pass `--draft` to open the resulting PR as a draft (default is ready-for-review); `--ready` is accepted for forward-compat. Use when the user says 'go', 'execute the plan', 'implement the plan', or gives an implementation request.
+argument-hint: "[--draft|--ready] [plan-path-or-request]"
 ---
 
 # Go: Execute Work and Ship It
@@ -9,6 +10,15 @@ Given a plan file or direct implementation request, implement the requested work
 This skill is the bridge between intent and shipping. It does not re-plan or re-design unless the user asked for that. If the request is wrong or cannot be implemented safely, surface that; do not silently improvise.
 
 ## Phase 1: Resolve the Input
+
+### Flags
+
+Before resolving the input as a path or request, scan the entire argument string for these flags. They may appear in any position — leading, trailing, or surrounded by other text (including a quoted natural-language request). Strip every match before resolving the remainder.
+
+- `--draft`: open the resulting PR as a draft. Remember this for Phase 4.
+- `--ready`: open the resulting PR as ready-for-review. This is the current default and is accepted as a no-op for forward-compatibility, so a future team-default flip remains reversible per-invocation without re-editing the skill.
+- If both `--draft` and `--ready` appear, stop and ask the user which one to use rather than guessing — mirrors the "default to safer outcome and flag it" pattern used elsewhere.
+- If neither appears, behavior is unchanged (ready-for-review).
 
 The user invokes this skill with either a plan file path/identifier or a direct request like "add a login button."
 
@@ -37,7 +47,7 @@ Fix any failures before handing off. Do not hand off with known failing checks u
 
 ## Phase 4: Hand Off
 
-Invoke the `commit-push-pr` skill. Do not commit, push, or open the PR yourself.
+Invoke the `commit-push-pr` skill, passing `draft` as its argument when `--draft` was set in Phase 1. `--ready` is the current default and does not need to be passed. Do not commit, push, or open the PR yourself.
 
 If `commit-push-pr` reports `nothing to ship.`, surface that.
 


### PR DESCRIPTION
Lets users opt a single `/core:go` invocation into a draft PR without changing the team-wide ready-for-review default. `--ready` is accepted as a no-op so a future default flip stays reversible per-invocation.

The flag is parsed by `go` (any position, before/after the plan path or quoted request) and propagated to `commit-push-pr` as a `draft` argument, which adds `--draft` to `gh pr create` only in the no-PR branch — converting an already-open PR is out of scope. This PR itself was opened with the new flag as the end-to-end self-test.

Default behavior with no flag is unchanged.

Agent session ID: claude-code 5f1fbffe-9563-498f-9148-0b31ab0ce58d
<!-- commit-push-pr:created v1 core@3.4.0 -->