### PR TITLE
docs(ai-rules): clarify service test DB manipulation as last resort

### DIFF
--- a/packages/ai-rules/rules/backend/serviceTests.md
+++ b/packages/ai-rules/rules/backend/serviceTests.md
@@ -26,7 +26,7 @@ describe("Documents", () => {
 
 ## Test Data
 
-Arrange test data via the public contract (API calls), not direct database inserts or ORM usage.
+Arrange test data via the public contract (API calls), not direct database inserts or ORM usage. Only fall back to direct database manipulation when no API exists to produce the required state.
 
 ## Bug Handling
 


### PR DESCRIPTION
## Summary
The existing service test rule already stated to arrange test data via API calls, not direct DB inserts. This update adds an explicit fallback clause: direct database manipulation is acceptable **only** when no API exists to produce the required state.

## Review & Testing Checklist for Human
- [ ] Verify the wording in `packages/ai-rules/rules/backend/serviceTests.md` line 29 reads as intended

### Notes
Minor documentation-only change — no code impact.

Link to Devin session: https://app.devin.ai/sessions/6784fc8db2d548f59e8c000f843cde52
Requested by: @shubhsherl