### PR TITLE
fix: unblock release publish after tsgo migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
       - run: npx nx run-many --target=build
       - env:
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          # Skip ts-node/esm loader registration; with a workspace-root tsconfig.json,
+          # ts-node@11.0.0-beta.1 + typescript@5.9.3 crashes resolving package-name `extends`.
+          NX_PREFER_NODE_STRIP_TYPES: "true"
         # Re-publishing an existing version is a no-op, so re-running this workflow recovers from transient NPM registry failures
         run: npx nx release publish
       - env:


### PR DESCRIPTION
## Why

Last night's main release CI failed at `npx nx release publish` with:

```
NX   There was an error when resolving the configured changelog renderer at path: node_modules/nx/dist/release/changelog-renderer
```

Failed run: https://github.com/ClipboardHealth/core-utils/actions/runs/25568233073

## Root cause

PR #628 added a workspace-root `tsconfig.json` (for project references). On `nx release publish`, config validation calls `resolveChangelogRenderer` → `registerTsProject(tsconfig.base.json)` → `module.register("ts-node/esm")`.

Without a root `tsconfig.json`, ts-node had nothing to find. Now it finds the new file and walks `extends: "./tsconfig.base.json"` → `extends: ["@tsconfig/node24", "@tsconfig/strictest"]`. Resolving those package-name extends crashes inside TypeScript 5.9.3's `nodeModuleNameResolver`:

```
TypeError: state.conditions.includes is not a function
    at loadModuleFromNearestNodeModulesDirectoryWorker (typescript/lib/typescript.js:46299)
    at Object.getExtendsConfigPath (ts-node/dist/ts-internals.js:37)
    at readConfig (ts-node/dist/configuration.js:127)
    at register (ts-node/dist/index.js:112)
```

This is a latent ts-node@11.0.0-beta.1 / typescript@5.9.3 incompatibility that PR #628 unmasked. ts-node 11 is still in beta with no fix released; typescript 5.9.3 is current.

The earlier `npx tsx scripts/release.ts` step worked because tsx invocation triggers nx's `isInvokedByTsx` shortcut and skips registration. Build/lint/test steps worked because they go through swc-node, not ts-node/esm.

State after the failure: `scripts/release.ts` had already pushed the version bumps and tags (`a21276f37 chore(release): publish [skip actions]`), but the publish step never ran. Re-running this CI workflow with the fix should publish the unpublished versions (the workflow header notes "Re-publishing an existing version is a no-op").

## Fix

Add `NX_PREFER_NODE_STRIP_TYPES=true` to the publish step. With Node 22.6+, nx skips `swc-node`/`ts-node/esm` registration entirely and lets Node strip `.ts` natively. `registerTsConfigPaths` still runs, so paths still resolve.

Verified locally on the failing merge commit: without the env var → same crash; with the env var → publish succeeds.

## Test plan

- [ ] Merge and re-run [the failing workflow](https://github.com/ClipboardHealth/core-utils/actions/runs/25568233073) (or push an empty release-eligible commit) to confirm publish completes
- [ ] Confirm the unpublished package versions land on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)