### PR TITLE
refactor: move nx affected from verify to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
           start_services: "true"
       # Don't use the read-write NX_CLOUD_ACCESS_TOKEN when not on `main`, see https://nx.dev/ci/concepts/cache-security#use-a-readwrite-token-in-ci
       - run: node --run verify
+      - run: node --run affected
       - run: docker compose down --volumes
         if: always()
 

--- a/scripts/verifyAll.mts
+++ b/scripts/verifyAll.mts
@@ -12,7 +12,6 @@ interface CheckResult {
 
 // These run a pre-push hook and should not modify files
 const CHECKS = [
-  { cmd: "node --run affected", name: "affected" },
   { cmd: "node --run architecture:check", name: "architecture:check" },
   { cmd: "node --run cpd", name: "cpd" },
   { cmd: "node --run embed:check", name: "embed:check" },


### PR DESCRIPTION
## Why

`node --run verify` (and the `hook:pre-push` hook that runs it) should be
focused on fast, file-modifying-free static checks. Running
`nx affected --targets build,lint,test` inside it conflated two layers:

- Local pre-push gate (fast, local, no network/cache token)
- CI integration test (Nx Cloud cache + read-write token)

CI's `pull-request` job already calls `node --run verify`; this PR adds an
explicit `node --run affected` step after it so the build/lint/test coverage
on PRs is preserved. The `main` job already invokes `nx affected` directly,
so no change there.

## Side effect

The `hook:pre-push` hook no longer runs `nx affected` locally before push.
CI still catches it. If we want pre-push to keep running it, add it directly
to the husky pre-push hook.

Agent session ID: claude-code 77b86643-81b5-4bce-b9e4-d825735591dd
<!-- commit-push-pr:created v1 core@3.4.0 -->