### PR TITLE
chore: discover vitest projects via root config glob

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -95,7 +95,12 @@
       ]
     },
     "@nx/vitest:test": {
-      "inputs": ["default", "^production", "{workspaceRoot}/vitest.preset.ts"],
+      "inputs": [
+        "default",
+        "^production",
+        "{workspaceRoot}/vitest.preset.ts",
+        "{workspaceRoot}/vitest.config.ts"
+      ],
       "cache": true,
       "configurations": {
         "ci": {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    projects: ["packages/*/vitest.config.ts"],
+  },
+});


### PR DESCRIPTION
## Why

STAFF-553 — align with the clipboard repo's vitest setup: a single root config drives package discovery via glob, so adding or removing a package no longer requires editing a workspace-level list.

The ticket asked for `vitest.workspace.ts`, but vitest 4.0 (this repo runs 4.1.5) removed both `defineWorkspace` and `vitest.workspace.ts` auto-discovery. The supported v4 equivalent is `test.projects` in a root `vitest.config.ts` — same intent, current API.

Per-package configs are unchanged: they already call into the shared `definePackageVitestConfig` factory, which is the "minimal calls into a shared factory" half of the source pattern. Nx still discovers all 21 projects with no behavior change for `nx run-many --target=test`.

## Verification

- `nx show projects --with-target test` — 21 projects, unchanged.
- `nx run-many --target=test --skip-nx-cache` — all 21 ran; only `mongo-jobs:test` failed, with a pre-existing `mongoose.connect` error from no local Mongo (Docker isn't running).
- `vitest run` from workspace root via the new glob — 1184 tests across 18 projects with tests; same `mongo-jobs` env failures, all other 1135 pass.
- `node --run verify` — all checks pass except `affected` due to the same `mongo-jobs:test:ci` env issue.

Agent session ID: claude-code f70d61e8-d8de-49e7-b958-61e20d9bee8d
<!-- commit-push-pr:created v1 core@3.4.0 -->