### PR TITLE
feat(notifications): add isClientError helper for non-retryable failures

### DIFF
--- a/packages/notifications/README.md
+++ b/packages/notifications/README.md
@@ -28,6 +28,7 @@ Send notifications through third-party providers.
    import type { BaseHandler } from "@clipboard-health/background-jobs-adapter";
    import {
      ERROR_CODES,
+     isClientError,
      type NotificationClient,
      type SerializableTriggerChunkedRequest,
      toTriggerChunkedRequest,
@@ -103,10 +104,10 @@ Send notifications through third-party providers.
              return;
            }
 
-           // Non-429 4xx from the provider means the request itself is broken (validation error,
-           // missing recipient, etc.). Retrying won't help — log at ERROR so it pages and we can
-           // fix the caller.
-           if (code === ERROR_CODES.clientError) {
+           // The request itself is broken (empty/over-max recipients, invalid expiresAt or
+           // idempotency key, missing signing key, or a non-429 4xx from the provider).
+           // Retrying won't help — log at ERROR so it pages and we can fix the caller.
+           if (isClientError(code)) {
              this.logger.error("TriggerNotificationJob skipped due to client error", {
                ...metadata,
                error: result.error,

--- a/packages/notifications/examples/triggerNotification.job.ts
+++ b/packages/notifications/examples/triggerNotification.job.ts
@@ -3,6 +3,7 @@
 import type { BaseHandler } from "@clipboard-health/background-jobs-adapter";
 import {
   ERROR_CODES,
+  isClientError,
   type NotificationClient,
   type SerializableTriggerChunkedRequest,
   toTriggerChunkedRequest,
@@ -78,10 +79,10 @@ export class TriggerNotificationJob implements BaseHandler<SerializableTriggerCh
           return;
         }
 
-        // Non-429 4xx from the provider means the request itself is broken (validation error,
-        // missing recipient, etc.). Retrying won't help — log at ERROR so it pages and we can
-        // fix the caller.
-        if (code === ERROR_CODES.clientError) {
+        // The request itself is broken (empty/over-max recipients, invalid expiresAt or
+        // idempotency key, missing signing key, or a non-429 4xx from the provider).
+        // Retrying won't help — log at ERROR so it pages and we can fix the caller.
+        if (isClientError(code)) {
           this.logger.error("TriggerNotificationJob skipped due to client error", {
             ...metadata,
             error: result.error,

--- a/packages/notifications/examples/usage.md
+++ b/packages/notifications/examples/usage.md
@@ -22,6 +22,7 @@
    import type { BaseHandler } from "@clipboard-health/background-jobs-adapter";
    import {
      ERROR_CODES,
+     isClientError,
      type NotificationClient,
      type SerializableTriggerChunkedRequest,
      toTriggerChunkedRequest,
@@ -97,10 +98,10 @@
              return;
            }
 
-           // Non-429 4xx from the provider means the request itself is broken (validation error,
-           // missing recipient, etc.). Retrying won't help — log at ERROR so it pages and we can
-           // fix the caller.
-           if (code === ERROR_CODES.clientError) {
+           // The request itself is broken (empty/over-max recipients, invalid expiresAt or
+           // idempotency key, missing signing key, or a non-429 4xx from the provider).
+           // Retrying won't help — log at ERROR so it pages and we can fix the caller.
+           if (isClientError(code)) {
              this.logger.error("TriggerNotificationJob skipped due to client error", {
                ...metadata,
                error: result.error,

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./lib/errorCodes";
 export * from "./lib/errorsInResult";
+export * from "./lib/isClientError";
 export * from "./lib/notificationClient";
 export * from "./lib/notificationJobEnqueuer";
 export * from "./lib/toTriggerChunkedRequest";

--- a/packages/notifications/src/lib/isClientError.test.ts
+++ b/packages/notifications/src/lib/isClientError.test.ts
@@ -1,0 +1,40 @@
+import { ERROR_CODES } from "./errorCodes";
+import { isClientError } from "./isClientError";
+
+describe(isClientError, () => {
+  it.each([
+    [ERROR_CODES.clientError],
+    [ERROR_CODES.invalidExpiresAt],
+    [ERROR_CODES.invalidIdempotencyKey],
+    [ERROR_CODES.missingSigningKey],
+    [ERROR_CODES.recipientCountAboveMaximum],
+    [ERROR_CODES.recipientCountBelowMinimum],
+  ])("returns true for non-retryable client error code %s", (code) => {
+    const actual = isClientError(code);
+
+    expect(actual).toBe(true);
+  });
+
+  it.each([[ERROR_CODES.expired], [ERROR_CODES.rateLimited], [ERROR_CODES.unknown]])(
+    "returns false for retryable or expiry code %s",
+    (code) => {
+      const actual = isClientError(code);
+
+      expect(actual).toBe(false);
+    },
+  );
+
+  it("returns false when code is undefined", () => {
+    const undefinedCode: string | undefined = undefined;
+
+    const actual = isClientError(undefinedCode);
+
+    expect(actual).toBe(false);
+  });
+
+  it("returns false for unknown string codes", () => {
+    const actual = isClientError("someUnrelatedCode");
+
+    expect(actual).toBe(false);
+  });
+});

--- a/packages/notifications/src/lib/isClientError.ts
+++ b/packages/notifications/src/lib/isClientError.ts
@@ -1,0 +1,48 @@
+import { ERROR_CODES } from "./errorCodes";
+
+/**
+ * Error codes whose failures are caused by a broken request rather than a transient
+ * provider/infrastructure problem. Retrying without changing the request will not help.
+ *
+ * Consumers (e.g. a background job that wraps {@link NotificationClient.triggerChunked})
+ * should short-circuit on these to avoid wasted retries — log loudly and stop, rather than
+ * letting the retry framework exhaust its budget.
+ *
+ * Excludes:
+ * - `expired`: handle separately; the request was once valid and is now stale.
+ * - `rateLimited`: transient; retry with backoff.
+ * - `unknown`: assume transient (network blip, 5xx, etc.) and retry.
+ */
+const CLIENT_ERROR_CODES = new Set<string>([
+  ERROR_CODES.clientError,
+  ERROR_CODES.invalidExpiresAt,
+  ERROR_CODES.invalidIdempotencyKey,
+  ERROR_CODES.missingSigningKey,
+  ERROR_CODES.recipientCountAboveMaximum,
+  ERROR_CODES.recipientCountBelowMinimum,
+]);
+
+/**
+ * Returns `true` when `code` indicates the request itself is broken and retrying without
+ * changes is unlikely to succeed. Consumers should treat these as non-retryable: log at
+ * ERROR and stop, rather than rethrowing into a retry framework.
+ *
+ * @example
+ * ```ts
+ * if (isFailure(result)) {
+ *   const code = result.error.issues[0]?.code;
+ *   if (isClientError(code)) {
+ *     logger.error("Notification failed with client error; not retrying", { code });
+ *     return;
+ *   }
+ *   throw result.error;
+ * }
+ * ```
+ */
+export function isClientError(code: string | undefined): boolean {
+  if (code === undefined) {
+    return false;
+  }
+
+  return CLIENT_ERROR_CODES.has(code);
+}

--- a/packages/notifications/src/lib/notificationClient.test.ts
+++ b/packages/notifications/src/lib/notificationClient.test.ts
@@ -6,6 +6,7 @@ import type { Mocked } from "vitest";
 import { ERROR_CODES } from "./errorCodes";
 import { MAXIMUM_RECIPIENTS_COUNT } from "./internal/chunkRecipients";
 import { IdempotentKnock } from "./internal/idempotentKnock";
+import { isClientError } from "./isClientError";
 import { NotificationClient } from "./notificationClient";
 import {
   DO_NOT_CALL_THIS_OUTSIDE_OF_TESTS,
@@ -533,6 +534,8 @@ describe(NotificationClient, () => {
 
       expectToBeFailure(actual);
       expect(actual.error.message).toContain("Got 0 recipients; must be > 0");
+      expect(actual.error.issues[0]?.code).toBe(ERROR_CODES.recipientCountBelowMinimum);
+      expect(isClientError(actual.error.issues[0]?.code)).toBe(true);
     });
 
     it("rejects request with too many recipients", async () => {
@@ -555,6 +558,8 @@ describe(NotificationClient, () => {
       expect(actual.error.message).toContain(
         `Got ${MAXIMUM_RECIPIENTS_COUNT + 1} recipients; must be <= ${MAXIMUM_RECIPIENTS_COUNT}`,
       );
+      expect(actual.error.issues[0]?.code).toBe(ERROR_CODES.recipientCountAboveMaximum);
+      expect(isClientError(actual.error.issues[0]?.code)).toBe(true);
     });
 
     it("handles trigger request without keysToRedact", async () => {
@@ -912,6 +917,8 @@ describe(NotificationClient, () => {
 
       expectToBeFailure(actual);
       expect(actual.error.message).toContain("Got 0 recipients; must be > 0");
+      expect(actual.error.issues[0]?.code).toBe(ERROR_CODES.recipientCountBelowMinimum);
+      expect(isClientError(actual.error.issues[0]?.code)).toBe(true);
       expect(triggerSpy).not.toHaveBeenCalled();
     });
 

--- a/packages/notifications/src/lib/notificationClient.ts
+++ b/packages/notifications/src/lib/notificationClient.ts
@@ -188,6 +188,7 @@ export class NotificationClient {
    * import type { BaseHandler } from "@clipboard-health/background-jobs-adapter";
    * import {
    *   ERROR_CODES,
+   *   isClientError,
    *   type NotificationClient,
    *   type SerializableTriggerChunkedRequest,
    *   toTriggerChunkedRequest,
@@ -263,10 +264,10 @@ export class NotificationClient {
    *           return;
    *         }
    *
-   *         // Non-429 4xx from the provider means the request itself is broken (validation error,
-   *         // missing recipient, etc.). Retrying won't help — log at ERROR so it pages and we can
-   *         // fix the caller.
-   *         if (code === ERROR_CODES.clientError) {
+   *         // The request itself is broken (empty/over-max recipients, invalid expiresAt or
+   *         // idempotency key, missing signing key, or a non-429 4xx from the provider).
+   *         // Retrying won't help — log at ERROR so it pages and we can fix the caller.
+   *         if (isClientError(code)) {
    *           this.logger.error("TriggerNotificationJob skipped due to client error", {
    *             ...metadata,
    *             error: result.error,


### PR DESCRIPTION
## What

Adds a small `isClientError(code)` helper exported from `@clipboard-health/notifications` that returns `true` for every error code meaning *"the request itself is broken; retrying without changing it won't help."* That set today is:

- `clientError` (existing, non-429 4xx from the provider)
- `recipientCountBelowMinimum`
- `recipientCountAboveMaximum`
- `invalidExpiresAt`
- `invalidIdempotencyKey`
- `missingSigningKey`

Excludes `expired` (consumers handle separately — log + drop), `rateLimited` (retry with backoff), and `unknown` (assume transient).

The README/TypeDoc example for `TriggerNotificationJob` is updated to use it.

## Why

Consumers like clipboard-health's `TriggerNotificationJob` only match on `ERROR_CODES.clientError` when deciding whether to short-circuit a failed notification. So today, a job that hits one of the four library-side validation failures (e.g. an empty `recipients` array — DEVOP-5251) gets retried up to mongo-jobs' default 10 attempts (~17 min cumulative delay), zero of which can succeed. That's wasted compute, noisy alerts, and a permanently red follow-up queue.

This is the **library-side typed-failure** ("Option C") from the parent DEVOP-5257 investigation: signal non-retryable failures explicitly so wrappers can short-circuit cleanly, without every consumer needing to enumerate the full list of "broken-request" codes locally.

### Design choice

Three options were on the table:

1. Change the recipient-count failure codes themselves to `clientError` — breaking, loses the precise reason in the code.
2. Add a categorization helper — non-breaking, mirrors the README's existing pattern.
3. Extend the failure schema with a `nonRetryable: true` flag — more invasive, touches the public type shape.

Went with **Option 2**: non-breaking (anyone matching on the specific codes today keeps working), keeps the existing `failure(...)` return contract intact, and the consumer migration is a one-line swap.

## Refs

- DEVOP-5251
- DEVOP-5257

🤖 Generated with [Claude Code](https://claude.com/claude-code)