### PR TITLE
feat(packages): restore source-loading for clearance + groundcrew

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -34,7 +34,8 @@
     "**/tsconfig*.json",
     "**/__fixtures__/**",
     "**/vitest.config.ts",
-    "**/vitest.config.mts"
+    "**/vitest.config.mts",
+    "**/bin/runCli.js"
   ],
   "absolute": false,
   "gitignore": true

--- a/.knip.jsonc
+++ b/.knip.jsonc
@@ -24,7 +24,7 @@
       "entry": ["examples/**/*.ts", "src/index.ts"],
     },
     "packages/clearance": {
-      "entry": ["src/index.ts", "src/cli.ts", "src/ensureCli.ts"],
+      "entry": ["src/cli.ts", "src/ensureCli.ts"],
     },
     "packages/config": {
       "entry": ["examples/**/*.ts", "src/index.ts"],
@@ -42,7 +42,7 @@
       "entry": ["examples/**/*.ts", "src/index.ts"],
     },
     "packages/groundcrew": {
-      "entry": ["src/index.ts", "src/cli.ts", "configExample.ts"],
+      "entry": ["src/main.ts", "configExample.ts"],
     },
     "packages/json-api": {
       "entry": ["examples/**/*.ts", "src/index.ts"],

--- a/.rules/common/coreLibraries.md
+++ b/.rules/common/coreLibraries.md
@@ -16,6 +16,7 @@ When a bug traces into a `@clipboard-health/*` library, read the source code in 
 - **ai-rules**: Pre-built AI agent rules for consistent coding standards.
 - **analytics**: Type-safe analytics wrapper around our third-party analytics provider for user identification and event tracking.
 - **background-jobs-adapter**: Minimal adapter interface for background jobs operations supporting Mongo and Postgres implementations.
+- **clearance**: Localhost HTTP/HTTPS egress proxy with hostname allow-listing, plus a macOS Safehouse integration for sandboxed agent processes.
 - **config**: Type-safe static configuration management: a pure function to resolve, validate against a Zod schema, and freeze configuration values.
 - **contract-core**: Shared Zod schemas for Clipboard's contracts.
 - **embedex**: Embed shared text and code snippets from source files into destination files.
@@ -23,6 +24,7 @@ When a bug traces into a `@clipboard-health/*` library, read the source code in 
 - **eslint-plugin**: Clipboard's ESLint Plugin
 - **example-nestjs**: A NestJS application using our libraries, primarily for end-to-end testing.
 - **execution-context**: A lightweight Node.js utility for managing execution contexts and metadata aggregation using AsyncLocalStorage.
+- **groundcrew**: Linear-driven orchestrator that launches AI coding agents in isolated git worktrees, with workspace lifecycle, sandbox auth, and usage tracking.
 - **json-api**: TypeScript-friendly utilities for adhering to the JSON:API specification.
 - **json-api-nestjs**: TypeScript-friendly utilities for adhering to the JSON:API specification with NestJS.
 - **mongo-jobs**: MongoDB-powered background jobs.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "affected": "nx affected --configuration ci --parallel 8 --targets build,lint,test",
     "architecture:check": "depcruise packages/*/src",
     "cpd": "jscpd .",
+    "crew": "node ./packages/groundcrew/bin/run.js",
+    "crew:op": "node ./scripts/crewOp.mjs",
     "docs": "rm -rf docs && typedoc",
     "embed": "tsx packages/embedex/src/bin/cli.ts --sourcesGlob 'packages/*/examples/**/*.{md,ts}'",
     "embed:check": "node --run embed -- --check",

--- a/packages/clearance/README.md
+++ b/packages/clearance/README.md
@@ -217,3 +217,14 @@ safehouse --env="$HOME/.config/agent-safehouse/clearance.env" \
   --append-profile="$HOME/.config/agent-safehouse/clearance-only.sb" \
   -- curl -I https://example.com
 ```
+
+## Hacking on clearance
+
+For developers working on the package itself, the source lives in [`ClipboardHealth/core-utils`](https://github.com/ClipboardHealth/core-utils). After `npm install` in the repo, the bin scripts dispatch through a `runCli` helper that detects no compiled JS and re-execs node with `--conditions @clipboard-health/source`, so the proxy runs straight from TypeScript source — no build step:
+
+```bash
+cd ~/dev/c/core-utils
+CLEARANCE_ALLOW_HOSTS=api.example.com node ./packages/clearance/bin/run.js
+```
+
+Requires Node ≥ 24.3 (native `.ts` type stripping enabled by default).

--- a/packages/clearance/bin/ensure.js
+++ b/packages/clearance/bin/ensure.js
@@ -1,3 +1,7 @@
 #!/usr/bin/env node
 
-import "../src/ensureCli.js";
+import { dirname } from "node:path";
+
+import { runCli } from "./runCli.js";
+
+await runCli(dirname(import.meta.dirname), "ensureCli");

--- a/packages/clearance/bin/run.js
+++ b/packages/clearance/bin/run.js
@@ -1,3 +1,7 @@
 #!/usr/bin/env node
 
-import "../src/cli.js";
+import { dirname } from "node:path";
+
+import { runCli } from "./runCli.js";
+
+await runCli(dirname(import.meta.dirname), "cli");

--- a/packages/clearance/bin/runCli.js
+++ b/packages/clearance/bin/runCli.js
@@ -1,0 +1,42 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { constants as osConstants } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+/**
+ * Load a side-effecting entrypoint by basename. In published/built mode, dynamically
+ * imports the compiled `${name}.js` in-process. In source/dev mode (no compiled output
+ * present), spawns a child node that loads the `.ts` source with
+ * `--conditions @clipboard-health/source` so cross-package bare imports of
+ * `@clipboard-health/*` workspace deps also resolve to source.
+ *
+ * @param {string} packageRoot
+ * @param {string} name
+ */
+export async function runCli(packageRoot, name) {
+  const compiledPath = join(packageRoot, "src", `${name}.js`);
+  if (existsSync(compiledPath)) {
+    await import(pathToFileURL(compiledPath).href);
+    return;
+  }
+
+  const sourcePath = join(packageRoot, "src", `${name}.ts`);
+  const result = spawnSync(
+    process.execPath,
+    ["--conditions", "@clipboard-health/source", sourcePath, ...process.argv.slice(2)],
+    { stdio: "inherit" },
+  );
+
+  if (result.error !== undefined) {
+    throw result.error;
+  }
+
+  if (result.signal !== null) {
+    const signalNumber = osConstants.signals[result.signal];
+    process.exitCode = signalNumber === undefined ? 1 : 128 + signalNumber;
+    return;
+  }
+
+  process.exitCode = result.status ?? 1;
+}

--- a/packages/clearance/package.json
+++ b/packages/clearance/package.json
@@ -24,6 +24,15 @@
   "type": "module",
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@clipboard-health/source": "./src/index.ts",
+      "types": "./src/index.d.ts",
+      "import": "./src/index.js",
+      "default": "./src/index.js"
+    }
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/clearance/src/allowlist.test.ts
+++ b/packages/clearance/src/allowlist.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 
-import { resolveAllowlist } from "./allowlist.js";
+import { resolveAllowlist } from "./allowlist.ts";
 
 type ReadFile = (path: string) => string;
 

--- a/packages/clearance/src/allowlist.ts
+++ b/packages/clearance/src/allowlist.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { delimiter as PATH_DELIMITER } from "node:path";
 
-import { normalizeRule, parseList } from "./hostRule.js";
+import { normalizeRule, parseList } from "./hostRule.ts";
 
 const COMMENT_PREFIX = "#";
 

--- a/packages/clearance/src/cli.ts
+++ b/packages/clearance/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { startClearanceFromEnv } from "./index.js";
+import { startClearanceFromEnv } from "./index.ts";
 
 startClearanceFromEnv({ env: process.env }).catch((error: unknown) => {
   const message = error instanceof Error ? error.message : String(error);

--- a/packages/clearance/src/ensureCli.ts
+++ b/packages/clearance/src/ensureCli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { ensureClearance } from "./launcher.js";
+import { ensureClearance } from "./launcher.ts";
 
 ensureClearance({
   logger: (message) => {

--- a/packages/clearance/src/index.test.ts
+++ b/packages/clearance/src/index.test.ts
@@ -10,7 +10,7 @@ import {
   createClearanceServer,
   resolveClearanceConfig,
   startClearanceFromEnv,
-} from "./index.js";
+} from "./index.ts";
 
 const servers: (http.Server | net.Server)[] = [];
 

--- a/packages/clearance/src/index.ts
+++ b/packages/clearance/src/index.ts
@@ -5,10 +5,10 @@ import * as http from "node:http";
 import * as net from "node:net";
 import type { Duplex } from "node:stream";
 
-import { resolveAllowlist } from "./allowlist.js";
-import { normalizeHost, normalizeRules, parseList } from "./hostRule.js";
+import { resolveAllowlist } from "./allowlist.ts";
+import { normalizeHost, normalizeRules, parseList } from "./hostRule.ts";
 
-export { resolveAllowlist, type ResolveAllowlistInput } from "./allowlist.js";
+export { resolveAllowlist, type ResolveAllowlistInput } from "./allowlist.ts";
 export {
   type ClearanceCheckInput,
   type ClearanceListenerCheck,
@@ -19,7 +19,7 @@ export {
   isClearanceListening,
   spawnClearance,
   type SpawnClearanceInput,
-} from "./launcher.js";
+} from "./launcher.ts";
 
 export const CLEARANCE_PACKAGE_NAME = "@clipboard-health/clearance";
 

--- a/packages/clearance/src/launcher.test.ts
+++ b/packages/clearance/src/launcher.test.ts
@@ -10,7 +10,7 @@ import {
   isClearanceListening,
   spawnClearance,
   type SpawnClearanceInput,
-} from "./launcher.js";
+} from "./launcher.ts";
 
 function createTempCacheDir(): string {
   return mkdtempSync(join(tmpdir(), "clearance-"));

--- a/packages/clearance/src/launcher.ts
+++ b/packages/clearance/src/launcher.ts
@@ -4,7 +4,7 @@ import * as net from "node:net";
 import { homedir } from "node:os";
 import { join, resolve as resolvePath } from "node:path";
 
-import { resolveAllowlist } from "./allowlist.js";
+import { resolveAllowlist } from "./allowlist.ts";
 
 const CLEARANCE_HOST = "127.0.0.1";
 const CLEARANCE_PORT = 19_999;

--- a/packages/clearance/tsconfig.lint.json
+++ b/packages/clearance/tsconfig.lint.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../tsconfig.lint.json",
   "compilerOptions": {
-    "allowJs": true
+    "allowImportingTsExtensions": true,
+    "allowJs": true,
+    "noEmit": true
   },
   "include": ["."]
 }

--- a/packages/groundcrew/README.md
+++ b/packages/groundcrew/README.md
@@ -139,3 +139,19 @@ crew cleanup <TICKET>
 - **Project must be on a single Linear team in practice.** Cross-team projects work — the orchestrator caches the in-progress state ID per team — but every team in the project must use the same status name for `linear.statuses.inProgress`.
 - **Doctor's command introspection is shallow.** For sandbox-backed models it checks `sbx` plus `sbx diagnose`. For non-sandbox models it tokenizes `cmd` and checks the first two non-flag tokens against PATH (so `safehouse claude --foo` checks both `safehouse` and `claude`). Boolean flags without values, env-var assignments (`FOO=1`), shell pipelines, and subshells are not parsed — verify those manually. In particular, `npx -y claude` and `env FOO=1 claude` only check the wrapper, not the wrapped CLI.
 - **Agent CLI must accept a positional prompt.** The handoff is `<your cmd> "<prompt>"`. `claude`, `codex`, and `cursor-agent` all support this.
+
+## Hacking on groundcrew
+
+For developers working on the package itself, the source lives in [`ClipboardHealth/core-utils`](https://github.com/ClipboardHealth/core-utils). Clone it, run `npm install`, and the repo's `crew` / `crew:op` scripts execute groundcrew straight from TypeScript source — no build step. The bin's `runCli` helper re-execs node with `--conditions @clipboard-health/source` so `@clipboard-health/clearance` also resolves to source.
+
+```bash
+cd ~/dev/c/core-utils
+GROUNDCREW_CONFIG=~/.config/groundcrew/config.ts node --run crew -- doctor
+
+# With 1Password for LINEAR_API_KEY:
+GROUNDCREW_OP_ENV_FILE=~/.config/groundcrew/op.env \
+GROUNDCREW_CONFIG=~/.config/groundcrew/config.ts \
+node --run crew:op -- run --watch
+```
+
+`GROUNDCREW_OP_ENV_FILE` defaults to `.crew.1password.env` at the repo root. Source edits in `packages/{clearance,groundcrew}/src/**` are picked up on the next invocation. Requires Node ≥ 24.3 (the version with native `.ts` type stripping enabled by default).

--- a/packages/groundcrew/bin/run.js
+++ b/packages/groundcrew/bin/run.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
-import { run } from "../src/cli.js";
+import { dirname } from "node:path";
 
-await run(process.argv.slice(2));
+import { runCli } from "./runCli.js";
+
+await runCli(dirname(import.meta.dirname), "main");

--- a/packages/groundcrew/bin/runCli.js
+++ b/packages/groundcrew/bin/runCli.js
@@ -1,0 +1,42 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { constants as osConstants } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+/**
+ * Load a side-effecting entrypoint by basename. In published/built mode, dynamically
+ * imports the compiled `${name}.js` in-process. In source/dev mode (no compiled output
+ * present), spawns a child node that loads the `.ts` source with
+ * `--conditions @clipboard-health/source` so cross-package bare imports of
+ * `@clipboard-health/*` workspace deps also resolve to source.
+ *
+ * @param {string} packageRoot
+ * @param {string} name
+ */
+export async function runCli(packageRoot, name) {
+  const compiledPath = join(packageRoot, "src", `${name}.js`);
+  if (existsSync(compiledPath)) {
+    await import(pathToFileURL(compiledPath).href);
+    return;
+  }
+
+  const sourcePath = join(packageRoot, "src", `${name}.ts`);
+  const result = spawnSync(
+    process.execPath,
+    ["--conditions", "@clipboard-health/source", sourcePath, ...process.argv.slice(2)],
+    { stdio: "inherit" },
+  );
+
+  if (result.error !== undefined) {
+    throw result.error;
+  }
+
+  if (result.signal !== null) {
+    const signalNumber = osConstants.signals[result.signal];
+    process.exitCode = signalNumber === undefined ? 1 : 128 + signalNumber;
+    return;
+  }
+
+  process.exitCode = result.status ?? 1;
+}

--- a/packages/groundcrew/package.json
+++ b/packages/groundcrew/package.json
@@ -24,6 +24,15 @@
   "type": "module",
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@clipboard-health/source": "./src/index.ts",
+      "types": "./src/index.d.ts",
+      "import": "./src/index.js",
+      "default": "./src/index.js"
+    }
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/groundcrew/src/cli.test.ts
+++ b/packages/groundcrew/src/cli.test.ts
@@ -1,24 +1,24 @@
-import { run } from "./cli.js";
-import { cleanupWorkspaceCli } from "./commands/cleanupWorkspace.js";
-import { doctor } from "./commands/doctor.js";
-import { orchestrate } from "./commands/orchestrator.js";
-import { setupWorkspaceCli } from "./commands/setupWorkspace.js";
+import { run } from "./cli.ts";
+import { cleanupWorkspaceCli } from "./commands/cleanupWorkspace.ts";
+import { doctor } from "./commands/doctor.ts";
+import { orchestrate } from "./commands/orchestrator.ts";
+import { setupWorkspaceCli } from "./commands/setupWorkspace.ts";
 import {
   captureConsoleError,
   captureConsoleLog,
   type ConsoleCapture,
-} from "./testHelpers/consoleCapture.js";
+} from "./testHelpers/consoleCapture.ts";
 
-vi.mock(import("./commands/cleanupWorkspace.js"), () => ({
+vi.mock(import("./commands/cleanupWorkspace.ts"), () => ({
   cleanupWorkspaceCli: vi.fn<typeof cleanupWorkspaceCli>(),
 }));
-vi.mock(import("./commands/doctor.js"), () => ({
+vi.mock(import("./commands/doctor.ts"), () => ({
   doctor: vi.fn<typeof doctor>(),
 }));
-vi.mock(import("./commands/orchestrator.js"), () => ({
+vi.mock(import("./commands/orchestrator.ts"), () => ({
   orchestrate: vi.fn<typeof orchestrate>(),
 }));
-vi.mock(import("./commands/setupWorkspace.js"), () => ({
+vi.mock(import("./commands/setupWorkspace.ts"), () => ({
   setupWorkspaceCli: vi.fn<typeof setupWorkspaceCli>(),
 }));
 

--- a/packages/groundcrew/src/cli.ts
+++ b/packages/groundcrew/src/cli.ts
@@ -1,9 +1,9 @@
-import { cleanupWorkspaceCli } from "./commands/cleanupWorkspace.js";
-import { doctor } from "./commands/doctor.js";
-import { orchestrate } from "./commands/orchestrator.js";
-import { sandboxAuthCli } from "./commands/sandboxAuth.js";
-import { setupWorkspaceCli } from "./commands/setupWorkspace.js";
-import { errorMessage, writeError, writeOutput } from "./lib/util.js";
+import { cleanupWorkspaceCli } from "./commands/cleanupWorkspace.ts";
+import { doctor } from "./commands/doctor.ts";
+import { orchestrate } from "./commands/orchestrator.ts";
+import { sandboxAuthCli } from "./commands/sandboxAuth.ts";
+import { setupWorkspaceCli } from "./commands/setupWorkspace.ts";
+import { errorMessage, writeError, writeOutput } from "./lib/util.ts";
 
 interface Subcommand {
   summary: string;

--- a/packages/groundcrew/src/commands/cleaner.test.ts
+++ b/packages/groundcrew/src/commands/cleaner.test.ts
@@ -1,12 +1,12 @@
-import type { BoardState, Issue } from "../lib/boardSource.js";
-import type { ResolvedConfig } from "../lib/config.js";
-import { sandboxNameFor } from "../lib/sandbox.js";
-import { type WorktreeEntry, worktrees } from "../lib/worktrees.js";
-import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.js";
-import { emptyTeardownResult } from "../testHelpers/teardownResult.js";
-import { createCleaner } from "./cleaner.js";
+import type { BoardState, Issue } from "../lib/boardSource.ts";
+import type { ResolvedConfig } from "../lib/config.ts";
+import { sandboxNameFor } from "../lib/sandbox.ts";
+import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
+import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
+import { emptyTeardownResult } from "../testHelpers/teardownResult.ts";
+import { createCleaner } from "./cleaner.ts";
 
-vi.mock(import("../lib/worktrees.js"), async (importOriginal) => {
+vi.mock(import("../lib/worktrees.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,

--- a/packages/groundcrew/src/commands/cleaner.ts
+++ b/packages/groundcrew/src/commands/cleaner.ts
@@ -4,11 +4,11 @@
  * invocation; stateless across iterations. Mirrors `Dispatcher`.
  */
 
-import { type BoardState, isTerminalStatus } from "../lib/boardSource.js";
-import type { ResolvedConfig } from "../lib/config.js";
-import { log, logEvent } from "../lib/util.js";
-import { type WorktreeEntry, worktrees } from "../lib/worktrees.js";
-import { logTeardown, recordTeardownEvents } from "./teardownReporter.js";
+import { type BoardState, isTerminalStatus } from "../lib/boardSource.ts";
+import type { ResolvedConfig } from "../lib/config.ts";
+import { log, logEvent } from "../lib/util.ts";
+import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
+import { logTeardown, recordTeardownEvents } from "./teardownReporter.ts";
 
 interface CleanerDeps {
   config: ResolvedConfig;

--- a/packages/groundcrew/src/commands/cleanupWorkspace.test.ts
+++ b/packages/groundcrew/src/commands/cleanupWorkspace.test.ts
@@ -1,14 +1,14 @@
-import { loadConfig, type ResolvedConfig } from "../lib/config.js";
-import { type WorktreeEntry, worktrees } from "../lib/worktrees.js";
-import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.js";
-import { emptyTeardownResult } from "../testHelpers/teardownResult.js";
-import { cleanupWorkspace, cleanupWorkspaceCli } from "./cleanupWorkspace.js";
+import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
+import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
+import { emptyTeardownResult } from "../testHelpers/teardownResult.ts";
+import { cleanupWorkspace, cleanupWorkspaceCli } from "./cleanupWorkspace.ts";
 
-vi.mock(import("../lib/config.js"), async (importOriginal) => {
+vi.mock(import("../lib/config.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, loadConfig: vi.fn<typeof loadConfig>() };
 });
-vi.mock(import("../lib/worktrees.js"), async (importOriginal) => {
+vi.mock(import("../lib/worktrees.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,

--- a/packages/groundcrew/src/commands/cleanupWorkspace.ts
+++ b/packages/groundcrew/src/commands/cleanupWorkspace.ts
@@ -1,7 +1,7 @@
-import { loadConfig, type ResolvedConfig } from "../lib/config.js";
-import { log } from "../lib/util.js";
-import { worktrees } from "../lib/worktrees.js";
-import { logTeardown } from "./teardownReporter.js";
+import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { log } from "../lib/util.ts";
+import { worktrees } from "../lib/worktrees.ts";
+import { logTeardown } from "./teardownReporter.ts";
 
 export interface CleanupWorkspaceOptions {
   ticket: string;

--- a/packages/groundcrew/src/commands/dispatcher.test.ts
+++ b/packages/groundcrew/src/commands/dispatcher.test.ts
@@ -1,19 +1,19 @@
 import type { LinearClient } from "@linear/sdk";
 
-import type { BoardState, Issue } from "../lib/boardSource.js";
-import type { ResolvedConfig } from "../lib/config.js";
-import { EXHAUSTED_USAGE } from "../lib/usage.js";
-import { workspaces } from "../lib/workspaces.js";
-import type { WorktreeEntry } from "../lib/worktrees.js";
-import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.js";
-import { createDispatcher } from "./dispatcher.js";
-import { setupWorkspace } from "./setupWorkspace.js";
+import type { BoardState, Issue } from "../lib/boardSource.ts";
+import type { ResolvedConfig } from "../lib/config.ts";
+import { EXHAUSTED_USAGE } from "../lib/usage.ts";
+import { workspaces } from "../lib/workspaces.ts";
+import type { WorktreeEntry } from "../lib/worktrees.ts";
+import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
+import { createDispatcher } from "./dispatcher.ts";
+import { setupWorkspace } from "./setupWorkspace.ts";
 
-vi.mock(import("./setupWorkspace.js"), async (importOriginal) => {
+vi.mock(import("./setupWorkspace.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, setupWorkspace: vi.fn<typeof setupWorkspace>() };
 });
-vi.mock(import("../lib/workspaces.js"), async (importOriginal) => {
+vi.mock(import("../lib/workspaces.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,

--- a/packages/groundcrew/src/commands/dispatcher.ts
+++ b/packages/groundcrew/src/commands/dispatcher.ts
@@ -9,19 +9,19 @@
 
 import type { LinearClient } from "@linear/sdk";
 
-import type { BoardState, Issue } from "../lib/boardSource.js";
-import type { ResolvedConfig } from "../lib/config.js";
-import type { UsageByModel } from "../lib/usage.js";
-import { errorMessage, log, logEvent } from "../lib/util.js";
-import { type WorkspaceProbe, workspaces } from "../lib/workspaces.js";
-import type { WorktreeEntry } from "../lib/worktrees.js";
+import type { BoardState, Issue } from "../lib/boardSource.ts";
+import type { ResolvedConfig } from "../lib/config.ts";
+import type { UsageByModel } from "../lib/usage.ts";
+import { errorMessage, log, logEvent } from "../lib/util.ts";
+import { type WorkspaceProbe, workspaces } from "../lib/workspaces.ts";
+import type { WorktreeEntry } from "../lib/worktrees.ts";
 import {
   classifyBlockers,
   classifyEligibility,
   type SkipVerdict,
   type StartVerdict,
-} from "./eligibility.js";
-import { setupWorkspace } from "./setupWorkspace.js";
+} from "./eligibility.ts";
+import { setupWorkspace } from "./setupWorkspace.ts";
 
 const PERCENT_FRACTION_DIVISOR = 100;
 const DAYS_PER_WEEK = 7;

--- a/packages/groundcrew/src/commands/doctor.test.ts
+++ b/packages/groundcrew/src/commands/doctor.test.ts
@@ -1,23 +1,23 @@
 import { existsSync, statSync } from "node:fs";
 
-import type { RunCommandOptions } from "../lib/commandRunner.js";
-import { loadConfig, type ResolvedConfig } from "../lib/config.js";
-import { detectHostCapabilities } from "../lib/host.js";
-import { readEnvironmentVariable } from "../lib/util.js";
-import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.js";
-import { deleteEnvironmentVariable, setEnvironmentVariable } from "../testHelpers/env.js";
-import { doctor } from "./doctor.js";
+import type { RunCommandOptions } from "../lib/commandRunner.ts";
+import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { detectHostCapabilities } from "../lib/host.ts";
+import { readEnvironmentVariable } from "../lib/util.ts";
+import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
+import { deleteEnvironmentVariable, setEnvironmentVariable } from "../testHelpers/env.ts";
+import { doctor } from "./doctor.ts";
 
 // oxlint-disable-next-line jest/no-untyped-mock-factory -- typed dynamic imports conflict with Node builtin module typings
 vi.mock("node:fs", () => ({
   existsSync: vi.fn<typeof existsSync>(),
   statSync: vi.fn<typeof statSync>(),
 }));
-vi.mock(import("../lib/config.js"), async (importOriginal) => {
+vi.mock(import("../lib/config.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, loadConfig: vi.fn<typeof loadConfig>() };
 });
-vi.mock(import("../lib/host.js"), async (importOriginal) => {
+vi.mock(import("../lib/host.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, detectHostCapabilities: vi.fn<typeof detectHostCapabilities>() };
 });
@@ -29,7 +29,7 @@ type RunCommandMock = (
 
 const runCommandMock = vi.hoisted(() => vi.fn<RunCommandMock>());
 
-vi.mock(import("../lib/commandRunner.js"), async (importOriginal) => {
+vi.mock(import("../lib/commandRunner.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,

--- a/packages/groundcrew/src/commands/doctor.ts
+++ b/packages/groundcrew/src/commands/doctor.ts
@@ -5,12 +5,12 @@
 
 import { existsSync, statSync } from "node:fs";
 
-import { runCommandAsync } from "../lib/commandRunner.js";
-import { loadConfig, type ResolvedConfig } from "../lib/config.js";
-import { detectHostCapabilities, type HostCapabilities, which } from "../lib/host.js";
-import { resolveIsolationStrategy, type StrategyResolution } from "../lib/isolation.js";
-import { errorMessage, readEnvironmentVariable, writeOutput } from "../lib/util.js";
-import { resolveWorkspaceKind, type WorkspaceResolution } from "../lib/workspaces.js";
+import { runCommandAsync } from "../lib/commandRunner.ts";
+import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { detectHostCapabilities, type HostCapabilities, which } from "../lib/host.ts";
+import { resolveIsolationStrategy, type StrategyResolution } from "../lib/isolation.ts";
+import { errorMessage, readEnvironmentVariable, writeOutput } from "../lib/util.ts";
+import { resolveWorkspaceKind, type WorkspaceResolution } from "../lib/workspaces.ts";
 
 // Tokenization stops after this many non-flag tokens. Two is enough to
 // catch wrapper + wrapped CLI commands like `safehouse claude --foo`.

--- a/packages/groundcrew/src/commands/eligibility.test.ts
+++ b/packages/groundcrew/src/commands/eligibility.test.ts
@@ -1,13 +1,13 @@
-import type { Issue } from "../lib/boardSource.js";
-import type { ResolvedConfig } from "../lib/config.js";
-import type { UsageByModel } from "../lib/usage.js";
-import type { WorktreeEntry } from "../lib/worktrees.js";
+import type { Issue } from "../lib/boardSource.ts";
+import type { ResolvedConfig } from "../lib/config.ts";
+import type { UsageByModel } from "../lib/usage.ts";
+import type { WorktreeEntry } from "../lib/worktrees.ts";
 import {
   type ClassifyArguments,
   classifyBlockers,
   classifyEligibility,
   pickBestModel,
-} from "./eligibility.js";
+} from "./eligibility.ts";
 
 function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
   return {

--- a/packages/groundcrew/src/commands/eligibility.ts
+++ b/packages/groundcrew/src/commands/eligibility.ts
@@ -7,11 +7,11 @@
  * effects.
  */
 
-import { type Blocker, type Issue, isTerminalStatus } from "../lib/boardSource.js";
-import { AGENT_ANY_MODEL, type ResolvedConfig } from "../lib/config.js";
-import type { UsageByModel } from "../lib/usage.js";
-import type { WorkspaceProbe } from "../lib/workspaces.js";
-import type { WorktreeEntry } from "../lib/worktrees.js";
+import { type Blocker, type Issue, isTerminalStatus } from "../lib/boardSource.ts";
+import { AGENT_ANY_MODEL, type ResolvedConfig } from "../lib/config.ts";
+import type { UsageByModel } from "../lib/usage.ts";
+import type { WorkspaceProbe } from "../lib/workspaces.ts";
+import type { WorktreeEntry } from "../lib/worktrees.ts";
 
 type SkipReason =
   | "blocked"

--- a/packages/groundcrew/src/commands/orchestrator.test.ts
+++ b/packages/groundcrew/src/commands/orchestrator.test.ts
@@ -1,26 +1,26 @@
 import type { LinearClient } from "@linear/sdk";
 
-import type * as configModule from "../lib/config.js";
-import { loadConfig, type ResolvedConfig } from "../lib/config.js";
-import { getUsageByModel } from "../lib/usage.js";
-import type * as utilModule from "../lib/util.js";
-import { getLinearClient, sleep } from "../lib/util.js";
-import { workspaces } from "../lib/workspaces.js";
-import { type WorktreeEntry, worktrees } from "../lib/worktrees.js";
+import type * as configModule from "../lib/config.ts";
+import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { getUsageByModel } from "../lib/usage.ts";
+import type * as utilModule from "../lib/util.ts";
+import { getLinearClient, sleep } from "../lib/util.ts";
+import { workspaces } from "../lib/workspaces.ts";
+import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import {
   captureConsoleClear,
   captureConsoleLog,
   type ConsoleCapture,
-} from "../testHelpers/consoleCapture.js";
-import { emptyTeardownResult } from "../testHelpers/teardownResult.js";
-import { orchestrate } from "./orchestrator.js";
-import { setupWorkspace } from "./setupWorkspace.js";
+} from "../testHelpers/consoleCapture.ts";
+import { emptyTeardownResult } from "../testHelpers/teardownResult.ts";
+import { orchestrate } from "./orchestrator.ts";
+import { setupWorkspace } from "./setupWorkspace.ts";
 
-vi.mock(import("../lib/config.js"), async (importOriginal) => {
+vi.mock(import("../lib/config.ts"), async (importOriginal) => {
   const actual = await importOriginal<typeof configModule>();
   return { ...actual, loadConfig: vi.fn<typeof loadConfig>() };
 });
-vi.mock(import("../lib/util.js"), async (importOriginal) => {
+vi.mock(import("../lib/util.ts"), async (importOriginal) => {
   const actual = await importOriginal<typeof utilModule>();
   return {
     ...actual,
@@ -33,7 +33,7 @@ vi.mock(import("../lib/util.js"), async (importOriginal) => {
     }),
   };
 });
-vi.mock(import("../lib/workspaces.js"), async (importOriginal) => {
+vi.mock(import("../lib/workspaces.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,
@@ -44,7 +44,7 @@ vi.mock(import("../lib/workspaces.js"), async (importOriginal) => {
     },
   };
 });
-vi.mock(import("../lib/worktrees.js"), async (importOriginal) => {
+vi.mock(import("../lib/worktrees.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,
@@ -55,11 +55,11 @@ vi.mock(import("../lib/worktrees.js"), async (importOriginal) => {
     },
   };
 });
-vi.mock(import("../lib/usage.js"), async (importOriginal) => {
+vi.mock(import("../lib/usage.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, getUsageByModel: vi.fn<typeof getUsageByModel>() };
 });
-vi.mock(import("./setupWorkspace.js"), async (importOriginal) => {
+vi.mock(import("./setupWorkspace.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, setupWorkspace: vi.fn<typeof setupWorkspace>() };
 });

--- a/packages/groundcrew/src/commands/orchestrator.ts
+++ b/packages/groundcrew/src/commands/orchestrator.ts
@@ -10,9 +10,9 @@ import {
   type Issue,
   isTerminalStatus,
   RepositoryResolutionError,
-} from "../lib/boardSource.js";
-import { loadConfig, type ResolvedConfig } from "../lib/config.js";
-import { getUsageByModel, type UsageByModel } from "../lib/usage.js";
+} from "../lib/boardSource.ts";
+import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { getUsageByModel, type UsageByModel } from "../lib/usage.ts";
 import {
   clearOutput,
   errorMessage,
@@ -20,10 +20,10 @@ import {
   log,
   sleep,
   writeOutput,
-} from "../lib/util.js";
-import { worktrees } from "../lib/worktrees.js";
-import { type Cleaner, createCleaner } from "./cleaner.js";
-import { createDispatcher, type Dispatcher } from "./dispatcher.js";
+} from "../lib/util.ts";
+import { worktrees } from "../lib/worktrees.ts";
+import { type Cleaner, createCleaner } from "./cleaner.ts";
+import { createDispatcher, type Dispatcher } from "./dispatcher.ts";
 
 const RATE_LIMIT_DELAY_MS = 60_000;
 const RETRY_BASE_DELAY_MS = 1000;

--- a/packages/groundcrew/src/commands/sandboxAuth.test.ts
+++ b/packages/groundcrew/src/commands/sandboxAuth.test.ts
@@ -1,7 +1,7 @@
-import type { RunCommandOptions } from "../lib/commandRunner.js";
-import { loadConfig, type ResolvedConfig } from "../lib/config.js";
-import { repoDirFor } from "../lib/worktrees.js";
-import { authSandbox, sandboxAuthCli } from "./sandboxAuth.js";
+import type { RunCommandOptions } from "../lib/commandRunner.ts";
+import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { repoDirFor } from "../lib/worktrees.ts";
+import { authSandbox, sandboxAuthCli } from "./sandboxAuth.ts";
 
 type RunCommandMock = (
   command: string,
@@ -11,7 +11,7 @@ type RunCommandMock = (
 
 const runCommandMock = vi.hoisted(() => vi.fn<RunCommandMock>());
 
-vi.mock(import("../lib/commandRunner.js"), async (importOriginal) => {
+vi.mock(import("../lib/commandRunner.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,
@@ -20,11 +20,11 @@ vi.mock(import("../lib/commandRunner.js"), async (importOriginal) => {
     runCommandAsync: runCommandMock as unknown as typeof actual.runCommandAsync,
   };
 });
-vi.mock(import("../lib/config.js"), async (importOriginal) => {
+vi.mock(import("../lib/config.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, loadConfig: vi.fn<typeof loadConfig>() };
 });
-vi.mock(import("../lib/worktrees.js"), async (importOriginal) => {
+vi.mock(import("../lib/worktrees.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, repoDirFor: vi.fn<typeof repoDirFor>() };
 });

--- a/packages/groundcrew/src/commands/sandboxAuth.ts
+++ b/packages/groundcrew/src/commands/sandboxAuth.ts
@@ -1,8 +1,8 @@
-import { runCommandAsync } from "../lib/commandRunner.js";
-import { loadConfig, type ResolvedConfig, type SandboxDefinition } from "../lib/config.js";
-import { sandboxExists, sandboxNameFor } from "../lib/sandbox.js";
-import { log } from "../lib/util.js";
-import { repoDirFor } from "../lib/worktrees.js";
+import { runCommandAsync } from "../lib/commandRunner.ts";
+import { loadConfig, type ResolvedConfig, type SandboxDefinition } from "../lib/config.ts";
+import { sandboxExists, sandboxNameFor } from "../lib/sandbox.ts";
+import { log } from "../lib/util.ts";
+import { repoDirFor } from "../lib/worktrees.ts";
 
 interface SandboxAuthOptions {
   repository: string;

--- a/packages/groundcrew/src/commands/setupWorkspace.test.ts
+++ b/packages/groundcrew/src/commands/setupWorkspace.test.ts
@@ -2,15 +2,15 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 
 import { ensureClearance } from "@clipboard-health/clearance";
 
-import type { RunCommandOptions } from "../lib/commandRunner.js";
-import { loadConfig, type ResolvedConfig } from "../lib/config.js";
-import { detectHostCapabilities } from "../lib/host.js";
-import type * as utilModule from "../lib/util.js";
-import { getLinearClient, log } from "../lib/util.js";
-import { type WorktreeEntry, worktrees, type WorktreeSpec } from "../lib/worktrees.js";
-import { deleteEnvironmentVariable, setEnvironmentVariable } from "../testHelpers/env.js";
-import { emptyTeardownResult } from "../testHelpers/teardownResult.js";
-import { setupWorkspace, setupWorkspaceCli } from "./setupWorkspace.js";
+import type { RunCommandOptions } from "../lib/commandRunner.ts";
+import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { detectHostCapabilities } from "../lib/host.ts";
+import type * as utilModule from "../lib/util.ts";
+import { getLinearClient, log } from "../lib/util.ts";
+import { type WorktreeEntry, worktrees, type WorktreeSpec } from "../lib/worktrees.ts";
+import { deleteEnvironmentVariable, setEnvironmentVariable } from "../testHelpers/env.ts";
+import { emptyTeardownResult } from "../testHelpers/teardownResult.ts";
+import { setupWorkspace, setupWorkspaceCli } from "./setupWorkspace.ts";
 
 // oxlint-disable-next-line jest/no-untyped-mock-factory -- typed dynamic imports conflict with Node builtin module typings
 vi.mock("node:fs", () => ({
@@ -18,11 +18,11 @@ vi.mock("node:fs", () => ({
   rmSync: vi.fn<typeof rmSync>(),
   writeFileSync: vi.fn<typeof writeFileSync>(),
 }));
-vi.mock(import("../lib/config.js"), async (importOriginal) => {
+vi.mock(import("../lib/config.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, loadConfig: vi.fn<typeof loadConfig>() };
 });
-vi.mock(import("../lib/host.js"), async (importOriginal) => {
+vi.mock(import("../lib/host.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, detectHostCapabilities: vi.fn<typeof detectHostCapabilities>() };
 });
@@ -41,7 +41,7 @@ type RunCommandMock = (
 
 const runCommandMock = vi.hoisted(() => vi.fn<RunCommandMock>());
 
-vi.mock(import("../lib/commandRunner.js"), async (importOriginal) => {
+vi.mock(import("../lib/commandRunner.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,
@@ -50,7 +50,7 @@ vi.mock(import("../lib/commandRunner.js"), async (importOriginal) => {
     runCommandAsync: runCommandMock as unknown as typeof actual.runCommandAsync,
   };
 });
-vi.mock(import("../lib/util.js"), async (importOriginal) => {
+vi.mock(import("../lib/util.ts"), async (importOriginal) => {
   const actual = await importOriginal<typeof utilModule>();
   return {
     ...actual,
@@ -58,7 +58,7 @@ vi.mock(import("../lib/util.js"), async (importOriginal) => {
     log: vi.fn<typeof actual.log>(),
   };
 });
-vi.mock(import("../lib/worktrees.js"), async (importOriginal) => {
+vi.mock(import("../lib/worktrees.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,

--- a/packages/groundcrew/src/commands/setupWorkspace.ts
+++ b/packages/groundcrew/src/commands/setupWorkspace.ts
@@ -4,14 +4,14 @@ import { join } from "node:path";
 
 import { ensureClearance } from "@clipboard-health/clearance";
 
-import { fetchResolvedIssue } from "../lib/boardSource.js";
-import { loadConfig, type ResolvedConfig } from "../lib/config.js";
-import { detectHostCapabilities } from "../lib/host.js";
-import { resolveIsolationStrategy } from "../lib/isolation.js";
-import { BUILD_SECRET_NAMES, buildLaunchCommand, shellSingleQuote } from "../lib/launchCommand.js";
-import { errorMessage, getLinearClient, log, readEnvironmentVariable } from "../lib/util.js";
-import { workspaces } from "../lib/workspaces.js";
-import { type WorktreeEntry, worktrees } from "../lib/worktrees.js";
+import { fetchResolvedIssue } from "../lib/boardSource.ts";
+import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { detectHostCapabilities } from "../lib/host.ts";
+import { resolveIsolationStrategy } from "../lib/isolation.ts";
+import { BUILD_SECRET_NAMES, buildLaunchCommand, shellSingleQuote } from "../lib/launchCommand.ts";
+import { errorMessage, getLinearClient, log, readEnvironmentVariable } from "../lib/util.ts";
+import { workspaces } from "../lib/workspaces.ts";
+import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 
 interface TicketDetails {
   title: string;

--- a/packages/groundcrew/src/commands/teardownReporter.test.ts
+++ b/packages/groundcrew/src/commands/teardownReporter.test.ts
@@ -1,7 +1,7 @@
-import type { TeardownResult, WorktreeEntry } from "../lib/worktrees.js";
-import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.js";
-import { emptyTeardownResult } from "../testHelpers/teardownResult.js";
-import { logTeardown, recordTeardownEvents } from "./teardownReporter.js";
+import type { TeardownResult, WorktreeEntry } from "../lib/worktrees.ts";
+import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
+import { emptyTeardownResult } from "../testHelpers/teardownResult.ts";
+import { logTeardown, recordTeardownEvents } from "./teardownReporter.ts";
 
 function hostEntry(ticket: string): WorktreeEntry {
   return {

--- a/packages/groundcrew/src/commands/teardownReporter.ts
+++ b/packages/groundcrew/src/commands/teardownReporter.ts
@@ -1,5 +1,5 @@
-import { errorMessage, log, logEvent } from "../lib/util.js";
-import type { TeardownResult } from "../lib/worktrees.js";
+import { errorMessage, log, logEvent } from "../lib/util.ts";
+import type { TeardownResult } from "../lib/worktrees.ts";
 
 export function logTeardown(result: TeardownResult): void {
   if (result.workspaceProbe.kind === "unavailable" && result.workspaceProbe.error !== undefined) {

--- a/packages/groundcrew/src/index.ts
+++ b/packages/groundcrew/src/index.ts
@@ -1,8 +1,8 @@
-export { run } from "./cli.js";
-export { cleanupWorkspace, type CleanupWorkspaceOptions } from "./commands/cleanupWorkspace.js";
-export { doctor } from "./commands/doctor.js";
-export { orchestrate, type OrchestratorOptions } from "./commands/orchestrator.js";
-export { setupWorkspace, type SetupWorkspaceOptions } from "./commands/setupWorkspace.js";
-export type { Config, ModelDefinition, ResolvedConfig } from "./lib/config.js";
-export { loadConfig } from "./lib/config.js";
-export { getUsageByModel, type UsageByModel } from "./lib/usage.js";
+export { run } from "./cli.ts";
+export { cleanupWorkspace, type CleanupWorkspaceOptions } from "./commands/cleanupWorkspace.ts";
+export { doctor } from "./commands/doctor.ts";
+export { orchestrate, type OrchestratorOptions } from "./commands/orchestrator.ts";
+export { setupWorkspace, type SetupWorkspaceOptions } from "./commands/setupWorkspace.ts";
+export type { Config, ModelDefinition, ResolvedConfig } from "./lib/config.ts";
+export { loadConfig } from "./lib/config.ts";
+export { getUsageByModel, type UsageByModel } from "./lib/usage.ts";

--- a/packages/groundcrew/src/lib/boardSource.test.ts
+++ b/packages/groundcrew/src/lib/boardSource.test.ts
@@ -1,8 +1,8 @@
 import type { LinearClient } from "@linear/sdk";
 
-import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.js";
-import { createBoardSource, isTerminalStatus } from "./boardSource.js";
-import type { ResolvedConfig } from "./config.js";
+import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
+import { createBoardSource, isTerminalStatus } from "./boardSource.ts";
+import type { ResolvedConfig } from "./config.ts";
 
 interface IssueNodeStub {
   id: string;

--- a/packages/groundcrew/src/lib/boardSource.ts
+++ b/packages/groundcrew/src/lib/boardSource.ts
@@ -6,8 +6,8 @@
 
 import type { LinearClient } from "@linear/sdk";
 
-import { AGENT_ANY_MODEL, type ResolvedConfig } from "./config.js";
-import { log } from "./util.js";
+import { AGENT_ANY_MODEL, type ResolvedConfig } from "./config.ts";
+import { log } from "./util.ts";
 
 const AGENT_LABEL_PREFIX = "agent-";
 const ISSUES_PAGE_SIZE = 250;

--- a/packages/groundcrew/src/lib/commandRunner.test.ts
+++ b/packages/groundcrew/src/lib/commandRunner.test.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { EventEmitter } from "node:events";
 
-import { runCommand, runCommandAsync } from "./commandRunner.js";
+import { runCommand, runCommandAsync } from "./commandRunner.ts";
 
 const spawnMock = vi.hoisted(() =>
   vi.fn<(command: string, arguments_: readonly string[], options: unknown) => FakeChildProcess>(),

--- a/packages/groundcrew/src/lib/config.test.ts
+++ b/packages/groundcrew/src/lib/config.test.ts
@@ -6,8 +6,8 @@ import {
   deleteEnvironmentVariable,
   setEnvironmentVariable,
   snapshotEnvironmentVariables,
-} from "../testHelpers/env.js";
-import type { Config, ResolvedConfig } from "./config.js";
+} from "../testHelpers/env.ts";
+import type { Config, ResolvedConfig } from "./config.ts";
 
 const PACKAGE_ROOT = resolve(import.meta.dirname, "..", "..");
 const PACKAGE_CONFIG_PATH = join(PACKAGE_ROOT, "config.ts");
@@ -18,7 +18,7 @@ interface ConfigModule {
 
 async function loadFreshConfig(): Promise<ConfigModule> {
   vi.resetModules();
-  return await import("./config.js");
+  return await import("./config.ts");
 }
 
 const VALID_LINEAR = {

--- a/packages/groundcrew/src/lib/config.ts
+++ b/packages/groundcrew/src/lib/config.ts
@@ -3,7 +3,7 @@ import { homedir } from "node:os";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
-import { readEnvironmentVariable } from "./util.js";
+import { readEnvironmentVariable } from "./util.ts";
 
 /**
  * Reserved model name. A ticket labeled `agent-any` resolves at runtime

--- a/packages/groundcrew/src/lib/host.test.ts
+++ b/packages/groundcrew/src/lib/host.test.ts
@@ -1,7 +1,7 @@
 import { platform } from "node:process";
 
-import type { RunCommandOptions } from "./commandRunner.js";
-import { detectHostCapabilities, which } from "./host.js";
+import type { RunCommandOptions } from "./commandRunner.ts";
+import { detectHostCapabilities, which } from "./host.ts";
 
 type RunCommandMock = (
   command: string,
@@ -11,7 +11,7 @@ type RunCommandMock = (
 
 const runCommandMock = vi.hoisted(() => vi.fn<RunCommandMock>());
 
-vi.mock(import("./commandRunner.js"), async (importOriginal) => {
+vi.mock(import("./commandRunner.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,

--- a/packages/groundcrew/src/lib/host.ts
+++ b/packages/groundcrew/src/lib/host.ts
@@ -6,7 +6,7 @@
 
 import { platform } from "node:process";
 
-import { runCommandAsync } from "./commandRunner.js";
+import { runCommandAsync } from "./commandRunner.ts";
 
 export interface HostCapabilities {
   /** True when the `safehouse` binary is on PATH. */

--- a/packages/groundcrew/src/lib/isolation.test.ts
+++ b/packages/groundcrew/src/lib/isolation.test.ts
@@ -1,6 +1,6 @@
-import type { IsolationStrategy, ResolvedConfig } from "./config.js";
-import type { HostCapabilities } from "./host.js";
-import { resolveIsolationStrategy } from "./isolation.js";
+import type { IsolationStrategy, ResolvedConfig } from "./config.ts";
+import type { HostCapabilities } from "./host.ts";
+import { resolveIsolationStrategy } from "./isolation.ts";
 
 const SUPPORTED_HOST: HostCapabilities = {
   hasSafehouse: true,

--- a/packages/groundcrew/src/lib/isolation.ts
+++ b/packages/groundcrew/src/lib/isolation.ts
@@ -4,8 +4,8 @@
  * it needs as arguments so callers can test without touching the host.
  */
 
-import type { IsolationStrategy, ModelDefinition, ResolvedConfig } from "./config.js";
-import type { HostCapabilities } from "./host.js";
+import type { IsolationStrategy, ModelDefinition, ResolvedConfig } from "./config.ts";
+import type { HostCapabilities } from "./host.ts";
 
 /**
  * The concrete strategy that will run a model. `auto` is never returned —

--- a/packages/groundcrew/src/lib/launchCommand.test.ts
+++ b/packages/groundcrew/src/lib/launchCommand.test.ts
@@ -1,5 +1,5 @@
-import type { ModelDefinition } from "./config.js";
-import { buildLaunchCommand } from "./launchCommand.js";
+import type { ModelDefinition } from "./config.ts";
+import { buildLaunchCommand } from "./launchCommand.ts";
 
 function arguments_(
   overrides: Partial<Parameters<typeof buildLaunchCommand>[0]> = {},

--- a/packages/groundcrew/src/lib/launchCommand.ts
+++ b/packages/groundcrew/src/lib/launchCommand.ts
@@ -4,8 +4,8 @@ import {
   DEFAULT_HOST_SETUP_COMMAND,
   DEFAULT_SANDBOX_SETUP_COMMAND,
   type ModelDefinition,
-} from "./config.js";
-import type { ResolvedIsolationStrategy } from "./isolation.js";
+} from "./config.ts";
+import type { ResolvedIsolationStrategy } from "./isolation.ts";
 
 /**
  * Build-time secrets we shuttle from groundcrew's process env into the

--- a/packages/groundcrew/src/lib/sandbox.ts
+++ b/packages/groundcrew/src/lib/sandbox.ts
@@ -1,6 +1,6 @@
 import { resolve } from "node:path";
 
-import { runCommandAsync } from "./commandRunner.js";
+import { runCommandAsync } from "./commandRunner.ts";
 
 export function sandboxNameFor(arguments_: { repository: string; model: string }): string {
   const raw = `groundcrew-${arguments_.repository}-${arguments_.model}`.toLowerCase();

--- a/packages/groundcrew/src/lib/usage.test.ts
+++ b/packages/groundcrew/src/lib/usage.test.ts
@@ -1,7 +1,7 @@
-import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.js";
-import type { RunCommandOptions } from "./commandRunner.js";
-import type { ResolvedConfig } from "./config.js";
-import { EXHAUSTED_USAGE, getUsageByModel } from "./usage.js";
+import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
+import type { RunCommandOptions } from "./commandRunner.ts";
+import type { ResolvedConfig } from "./config.ts";
+import { EXHAUSTED_USAGE, getUsageByModel } from "./usage.ts";
 
 type RunCommandMock = (
   command: string,
@@ -11,7 +11,7 @@ type RunCommandMock = (
 
 const runCommandMock = vi.hoisted(() => vi.fn<RunCommandMock>());
 
-vi.mock(import("./commandRunner.js"), async (importOriginal) => {
+vi.mock(import("./commandRunner.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,

--- a/packages/groundcrew/src/lib/usage.ts
+++ b/packages/groundcrew/src/lib/usage.ts
@@ -6,9 +6,9 @@
  * `codexbar` itself is the user-facing inspection tool.
  */
 
-import { runCommandAsync } from "./commandRunner.js";
-import type { ModelDefinition, ResolvedConfig } from "./config.js";
-import { errorMessage, log } from "./util.js";
+import { runCommandAsync } from "./commandRunner.ts";
+import type { ModelDefinition, ResolvedConfig } from "./config.ts";
+import { errorMessage, log } from "./util.ts";
 
 interface UsageWindow {
   usedPercent: number;

--- a/packages/groundcrew/src/lib/util.test.ts
+++ b/packages/groundcrew/src/lib/util.test.ts
@@ -1,7 +1,7 @@
 import { LinearClient } from "@linear/sdk";
 
-import { captureConsoleLog } from "../testHelpers/consoleCapture.js";
-import { deleteEnvironmentVariable, setEnvironmentVariable } from "../testHelpers/env.js";
+import { captureConsoleLog } from "../testHelpers/consoleCapture.ts";
+import { deleteEnvironmentVariable, setEnvironmentVariable } from "../testHelpers/env.ts";
 import {
   errorMessage,
   getLinearClient,
@@ -9,7 +9,7 @@ import {
   logEvent,
   readEnvironmentVariable,
   sleep,
-} from "./util.js";
+} from "./util.ts";
 
 describe(sleep, () => {
   beforeEach(() => {

--- a/packages/groundcrew/src/lib/workspaces.test.ts
+++ b/packages/groundcrew/src/lib/workspaces.test.ts
@@ -1,10 +1,10 @@
-import { probeError } from "../testHelpers/workspaceProbe.js";
-import type { RunCommandOptions } from "./commandRunner.js";
-import type { ResolvedConfig, WorkspaceKindSetting } from "./config.js";
-import type * as hostModule from "./host.js";
-import { detectHostCapabilities, type HostCapabilities } from "./host.js";
-import type * as utilModule from "./util.js";
-import { resolveWorkspaceKind, workspaces } from "./workspaces.js";
+import { probeError } from "../testHelpers/workspaceProbe.ts";
+import type { RunCommandOptions } from "./commandRunner.ts";
+import type { ResolvedConfig, WorkspaceKindSetting } from "./config.ts";
+import type * as hostModule from "./host.ts";
+import { detectHostCapabilities, type HostCapabilities } from "./host.ts";
+import type * as utilModule from "./util.ts";
+import { resolveWorkspaceKind, workspaces } from "./workspaces.ts";
 
 type RunCommandMock = (
   command: string,
@@ -14,7 +14,7 @@ type RunCommandMock = (
 
 const runMock = vi.hoisted(() => vi.fn<RunCommandMock>());
 
-vi.mock(import("./commandRunner.js"), async (importOriginal) => {
+vi.mock(import("./commandRunner.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,
@@ -23,14 +23,14 @@ vi.mock(import("./commandRunner.js"), async (importOriginal) => {
     runCommandAsync: runMock as unknown as typeof actual.runCommandAsync,
   };
 });
-vi.mock(import("./util.js"), async (importOriginal) => {
+vi.mock(import("./util.ts"), async (importOriginal) => {
   const actual = await importOriginal<typeof utilModule>();
   return {
     ...actual,
     log: vi.fn<typeof actual.log>(),
   };
 });
-vi.mock(import("./host.js"), async (importOriginal) => {
+vi.mock(import("./host.ts"), async (importOriginal) => {
   const actual = await importOriginal<typeof hostModule>();
   return {
     ...actual,

--- a/packages/groundcrew/src/lib/workspaces.ts
+++ b/packages/groundcrew/src/lib/workspaces.ts
@@ -5,10 +5,10 @@
  * backend uses opaque refs.
  */
 
-import { runCommandAsync } from "./commandRunner.js";
-import type { ResolvedConfig, WorkspaceKindSetting } from "./config.js";
-import { detectHostCapabilities, type HostCapabilities } from "./host.js";
-import { errorMessage, log } from "./util.js";
+import { runCommandAsync } from "./commandRunner.ts";
+import type { ResolvedConfig, WorkspaceKindSetting } from "./config.ts";
+import { detectHostCapabilities, type HostCapabilities } from "./host.ts";
+import { errorMessage, log } from "./util.ts";
 
 export type WorkspaceKind = "cmux" | "tmux";
 

--- a/packages/groundcrew/src/lib/worktrees.test.ts
+++ b/packages/groundcrew/src/lib/worktrees.test.ts
@@ -3,11 +3,11 @@ import type * as nodeOs from "node:os";
 import { tmpdir, userInfo } from "node:os";
 import { join, sep } from "node:path";
 
-import { probeError } from "../testHelpers/workspaceProbe.js";
-import type { RunCommandOptions } from "./commandRunner.js";
-import type { ResolvedConfig } from "./config.js";
-import { workspaces } from "./workspaces.js";
-import { type WorktreeEntry, worktrees } from "./worktrees.js";
+import { probeError } from "../testHelpers/workspaceProbe.ts";
+import type { RunCommandOptions } from "./commandRunner.ts";
+import type { ResolvedConfig } from "./config.ts";
+import { workspaces } from "./workspaces.ts";
+import { type WorktreeEntry, worktrees } from "./worktrees.ts";
 
 const { create, findByBranch, findByTicket, list, remove, teardown } = worktrees;
 
@@ -19,7 +19,7 @@ type RunCommandMock = (
 
 const runCommandMock = vi.hoisted(() => vi.fn<RunCommandMock>());
 
-vi.mock(import("./commandRunner.js"), async (importOriginal) => {
+vi.mock(import("./commandRunner.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,
@@ -28,7 +28,7 @@ vi.mock(import("./commandRunner.js"), async (importOriginal) => {
     runCommandAsync: runCommandMock as unknown as typeof actual.runCommandAsync,
   };
 });
-vi.mock(import("./workspaces.js"), async (importOriginal) => {
+vi.mock(import("./workspaces.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,

--- a/packages/groundcrew/src/lib/worktrees.ts
+++ b/packages/groundcrew/src/lib/worktrees.ts
@@ -18,12 +18,12 @@ import { type Dirent, existsSync, readdirSync } from "node:fs";
 import { userInfo } from "node:os";
 import { relative, resolve, sep } from "node:path";
 
-import { runCommandAsync, type RunCommandOptions } from "./commandRunner.js";
-import type { ResolvedConfig } from "./config.js";
-import type { ResolvedIsolationStrategy } from "./isolation.js";
-import { sandboxExists, sandboxNameFor, sandboxWorktreeDirFor } from "./sandbox.js";
-import { errorMessage, log } from "./util.js";
-import { type WorkspaceProbe, workspaces } from "./workspaces.js";
+import { runCommandAsync, type RunCommandOptions } from "./commandRunner.ts";
+import type { ResolvedConfig } from "./config.ts";
+import type { ResolvedIsolationStrategy } from "./isolation.ts";
+import { sandboxExists, sandboxNameFor, sandboxWorktreeDirFor } from "./sandbox.ts";
+import { errorMessage, log } from "./util.ts";
+import { type WorkspaceProbe, workspaces } from "./workspaces.ts";
 
 const LONG_RUNNING_COMMAND_OPTIONS = { stdio: "inherit", timeoutMs: 0 } as const;
 

--- a/packages/groundcrew/src/main.ts
+++ b/packages/groundcrew/src/main.ts
@@ -1,0 +1,3 @@
+import { run } from "./cli.ts";
+
+await run(process.argv.slice(2));

--- a/packages/groundcrew/src/main.ts
+++ b/packages/groundcrew/src/main.ts
@@ -1,3 +1,7 @@
 import { run } from "./cli.ts";
 
-await run(process.argv.slice(2));
+run(process.argv.slice(2)).catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+});

--- a/packages/groundcrew/src/main.ts
+++ b/packages/groundcrew/src/main.ts
@@ -1,7 +1,9 @@
 import { run } from "./cli.ts";
 
-run(process.argv.slice(2)).catch((error: unknown) => {
+try {
+  await run(process.argv.slice(2));
+} catch (error: unknown) {
   const message = error instanceof Error ? error.message : String(error);
   process.stderr.write(`${message}\n`);
   process.exitCode = 1;
-});
+}

--- a/packages/groundcrew/src/testHelpers/teardownResult.ts
+++ b/packages/groundcrew/src/testHelpers/teardownResult.ts
@@ -1,4 +1,4 @@
-import type { TeardownResult } from "../lib/worktrees.js";
+import type { TeardownResult } from "../lib/worktrees.ts";
 
 export function emptyTeardownResult(overrides: Partial<TeardownResult> = {}): TeardownResult {
   return {

--- a/packages/groundcrew/src/testHelpers/workspaceProbe.ts
+++ b/packages/groundcrew/src/testHelpers/workspaceProbe.ts
@@ -1,4 +1,4 @@
-import type { WorkspaceProbe } from "../lib/workspaces.js";
+import type { WorkspaceProbe } from "../lib/workspaces.ts";
 
 export function probeError(probe: WorkspaceProbe): unknown {
   return probe.kind === "unavailable" ? probe.error : undefined;

--- a/packages/groundcrew/tsconfig.lint.json
+++ b/packages/groundcrew/tsconfig.lint.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../tsconfig.lint.json",
   "compilerOptions": {
-    "allowJs": true
+    "allowImportingTsExtensions": true,
+    "allowJs": true,
+    "noEmit": true
   },
   "include": ["."]
 }

--- a/packages/groundcrew/vitest.config.ts
+++ b/packages/groundcrew/vitest.config.ts
@@ -3,5 +3,5 @@ import { definePackageVitestConfig } from "../../vitest.preset";
 export default definePackageVitestConfig({
   name: "groundcrew",
   reportsDirectory: "../../coverage/packages/groundcrew",
-  coverageExclude: ["src/testHelpers/**"],
+  coverageExclude: ["src/main.ts", "src/testHelpers/**"],
 });

--- a/scripts/crewOp.mjs
+++ b/scripts/crewOp.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/// <reference types="node" />
+
+// Dev-mode `crew` runner: wraps `op run --env-file <file>` around a node
+// invocation of `packages/groundcrew/bin/run.js`. That bin script's runCli
+// helper detects no compiled `src/main.js` in this monorepo and re-execs
+// with `--conditions @clipboard-health/source`, so cross-package
+// `@clipboard-health/*` imports resolve to TypeScript source.
+//
+// Override the env-file location via `CREW_OP_ENV_FILE` (default
+// `.crew.1password.env` at the repo root).
+
+import { spawn } from "node:child_process";
+
+const SHUTDOWN_EXIT_CODE = 130;
+const SIGTERM_EXIT_CODE = 143;
+const FORCE_KILL_SIGNAL = "SIGKILL";
+const FORCE_KILL_DELAY_MS = 5000;
+
+// oxlint-disable-next-line node/no-process-env -- the CLI is configured through env vars
+const envFile = process.env.CREW_OP_ENV_FILE ?? ".crew.1password.env";
+const args = process.argv.slice(2);
+const shouldUseProcessGroup = process.platform !== "win32" && args.includes("--watch");
+
+const child = spawn(
+  "op",
+  [
+    "run",
+    "--env-file",
+    envFile,
+    "--",
+    process.execPath,
+    "./packages/groundcrew/bin/run.js",
+    ...args,
+  ],
+  {
+    detached: shouldUseProcessGroup,
+    stdio: "inherit",
+  },
+);
+
+let shutdownRequested = false;
+/** @type {NodeJS.Timeout | undefined} */
+let forceKillTimer;
+
+/**
+ * @param {NodeJS.Signals} signal
+ * @returns {number}
+ */
+function signalExitCode(signal) {
+  if (signal === "SIGINT") {
+    return SHUTDOWN_EXIT_CODE;
+  }
+  if (signal === "SIGTERM") {
+    return SIGTERM_EXIT_CODE;
+  }
+  return 1;
+}
+
+/** @param {NodeJS.Signals} signal */
+function killChild(signal) {
+  if (shouldUseProcessGroup && child.pid !== undefined) {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch {
+      // Child already exited — fall through to child.kill.
+    }
+  }
+  child.kill(signal);
+}
+
+/** @param {NodeJS.Signals} signal */
+function requestShutdown(signal) {
+  if (shutdownRequested) {
+    if (forceKillTimer !== undefined) {
+      clearTimeout(forceKillTimer);
+    }
+    killChild(FORCE_KILL_SIGNAL);
+    process.exit(signalExitCode(signal));
+  }
+  shutdownRequested = true;
+  killChild(signal);
+  forceKillTimer = setTimeout(() => {
+    killChild(FORCE_KILL_SIGNAL);
+    process.exit(signalExitCode(signal));
+  }, FORCE_KILL_DELAY_MS);
+}
+
+process.on("SIGINT", requestShutdown);
+process.on("SIGTERM", requestShutdown);
+
+child.on("error", (error) => {
+  if (forceKillTimer !== undefined) {
+    clearTimeout(forceKillTimer);
+  }
+  process.off("SIGINT", requestShutdown);
+  process.off("SIGTERM", requestShutdown);
+  process.stderr.write(`${error.message}\n`);
+  process.exit(1);
+});
+
+child.on("exit", (status, signal) => {
+  if (forceKillTimer !== undefined) {
+    clearTimeout(forceKillTimer);
+  }
+  process.off("SIGINT", requestShutdown);
+  process.off("SIGTERM", requestShutdown);
+  if (status !== null) {
+    process.exit(status);
+  }
+  process.exit(signal === null ? 1 : signalExitCode(signal));
+});

--- a/scripts/crewOp.mjs
+++ b/scripts/crewOp.mjs
@@ -7,7 +7,7 @@
 // with `--conditions @clipboard-health/source`, so cross-package
 // `@clipboard-health/*` imports resolve to TypeScript source.
 //
-// Override the env-file location via `CREW_OP_ENV_FILE` (default
+// Override the env-file location via `GROUNDCREW_OP_ENV_FILE` (default
 // `.crew.1password.env` at the repo root).
 
 import { spawn } from "node:child_process";
@@ -18,7 +18,7 @@ const FORCE_KILL_SIGNAL = "SIGKILL";
 const FORCE_KILL_DELAY_MS = 5000;
 
 // oxlint-disable-next-line node/no-process-env -- the CLI is configured through env vars
-const envFile = process.env.CREW_OP_ENV_FILE ?? ".crew.1password.env";
+const envFile = process.env.GROUNDCREW_OP_ENV_FILE ?? ".crew.1password.env";
 const args = process.argv.slice(2);
 const shouldUseProcessGroup = process.platform !== "win32" && args.includes("--watch");
 


### PR DESCRIPTION
## Why

The initial port did a mechanical `.ts → .js` sed on every relative import in `packages/{clearance,groundcrew}/src/` so the code would survive tsgo + oxlint without further config. That regressed the clipboard-monorepo workflow — `crew:op` ran source directly through node-24's built-in TypeScript stripping, and after the sed there was no way to do that without a build step or a custom loader.

This PR restores source-loading end-to-end so `node --run crew:op` works the same way in core-utils as it did in clipboard.

## What changed

- **Imports**: 197 relative imports across both packages flip back from `.js` → `.ts`. `allowImportingTsExtensions` already lives in `tsconfig.lib.json`; added to each package's `tsconfig.lint.json` so oxlint's tsgolint pass stops emitting TS5097.
- **Bins**: each `bin/run.js` (and clearance's `bin/ensure.js`) now delegates to a per-package `bin/runCli.js` helper. It dynamic-imports `src/<name>.js` in-process when the compiled output exists; otherwise it re-execs `node --conditions @clipboard-health/source <src>/<name>.ts ...` so cross-package `@clipboard-health/*` imports also resolve to source via the new exports condition.
- **groundcrew gains `src/main.ts`** — a side-effecting entry that calls `run(argv)`. This matches clearance's `cli.ts`/`ensureCli.ts` shape so both packages can use the same `runCli` helper signature.
- **Exports condition**: both `package.json`s add `exports[".@clipboard-health/source"] = "./src/index.ts"`, with `default`/`import` still pointing at `./src/index.js` for published consumers (verified by inspecting `dist/.../package.json`).
- **Repo-level scripts**: `crew:op` wraps `op run --env-file` (overridable via `CREW_OP_ENV_FILE`) around the bin, mirroring clipboard's flow. Plus `crew` for the no-1Password path.
- **Duplicated `runCli.js`** is intentional (each package self-contained in its tarball); `.jscpd.json` ignores the pair. `.knip.jsonc` entries updated to the new entrypoints.

## Verified

- `nx run-many -t build -p clearance,groundcrew` clean.
- 569 tests pass (61 + 508).
- `node --run verify` clean across all 9 checks.
- With `dist/` deleted, `node ./packages/groundcrew/bin/run.js doctor` runs the full `doctor` command end-to-end via type-stripping — confirms cross-package source resolution works.
- Built `dist/packages/{clearance,groundcrew}/package.json` preserves the `exports` map; consumer mode hits `./src/index.js` via the `default` condition.

## Developer workflow

```bash
# Inside core-utils:
CREW_OP_ENV_FILE=~/.config/groundcrew/op.env GROUNDCREW_CONFIG=~/.config/groundcrew/config.ts \
  node --run crew:op -- run --watch
```

Source edits in `packages/{clearance,groundcrew}/src/**` are picked up on the next invocation — no build, no `tsx`, no link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)