### PR TITLE
chore(groundcrew): allow sourcegraph.com in clearance allowlist

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -142,6 +142,7 @@
     "smhd",
     "sonarcloud",
     "sourceable",
+    "sourcegraph",
     "subshells",
     "stringifying",
     "Stringly",

--- a/packages/groundcrew/clearance-allow-hosts
+++ b/packages/groundcrew/clearance-allow-hosts
@@ -68,4 +68,5 @@ formulae.brew.sh
 hub.docker.com
 index.docker.io
 nx.dev
+sourcegraph.com
 vitest.dev


### PR DESCRIPTION
Sourcegraph (code search) is a developer-tooling host agents may reach during runs, so add it to the starter egress allowlist alongside the other dev tools.

<!-- commit-push-pr:created v1 core@3.4.0 -->