### PR TITLE
feat(groundcrew): cap each status section to 20 most recent with a truncation hint

### DIFF
--- a/packages/groundcrew/src/commands/orchestrator.test.ts
+++ b/packages/groundcrew/src/commands/orchestrator.test.ts
@@ -688,10 +688,18 @@ describe(orchestrate, () => {
 
     const out = consoleLog.output();
     expect(out).toContain("showing 20 most recent of 25; 5 older hidden");
-    // Most recent (index 24, TEAM-025) is visible.
-    expect(out).toContain("team-025");
-    // Oldest (index 0, TEAM-001) is truncated.
-    expect(out).not.toContain("team-001");
+
+    // Exactly 20 visible rows. With 25 ascending-updatedAt items, sort desc
+    // and slice 20 keeps indices 24..5 (team-025..team-006); 5 oldest hidden.
+    const visibleRows = [...out.matchAll(/team-\d{3}\b/g)].map((match) => match[0]);
+    expect(visibleRows).toHaveLength(20);
+
+    // Newest (team-025) and the boundary (team-006, 20th-newest) are visible.
+    expect(visibleRows).toContain("team-025");
+    expect(visibleRows).toContain("team-006");
+    // team-005 is the first one truncated; oldest (team-001) is also hidden.
+    expect(visibleRows).not.toContain("team-005");
+    expect(visibleRows).not.toContain("team-001");
   });
 
   it("filters out parent issues that have children", async () => {

--- a/packages/groundcrew/src/commands/orchestrator.test.ts
+++ b/packages/groundcrew/src/commands/orchestrator.test.ts
@@ -670,6 +670,30 @@ describe(orchestrate, () => {
     expect(out).toContain("Total: 2");
   });
 
+  it("caps each status section at 20 most recent and prints a truncation hint", async () => {
+    const doneIssues = Array.from({ length: 25 }, (_unused, index) =>
+      issue({
+        identifier: `TEAM-${String(index + 1).padStart(3, "0")}`,
+        id: `uuid-done-${index}`,
+        title: `Done item ${index + 1}`,
+        state: { id: "state-done", name: "Done" },
+        // ascending updatedAt: index 24 is the most recent.
+        updatedAt: `2025-01-${String(index + 1).padStart(2, "0")}T00:00:00.000Z`,
+      }),
+    );
+    const client = makeClient({ pages: [doneIssues] });
+    mockLinearClient(client);
+
+    await orchestrate({ watch: false, dryRun: false });
+
+    const out = consoleLog.output();
+    expect(out).toContain("showing 20 most recent of 25; 5 older hidden");
+    // Most recent (index 24, TEAM-025) is visible.
+    expect(out).toContain("team-025");
+    // Oldest (index 0, TEAM-001) is truncated.
+    expect(out).not.toContain("team-001");
+  });
+
   it("filters out parent issues that have children", async () => {
     const client = makeClient({
       pages: [

--- a/packages/groundcrew/src/commands/orchestrator.ts
+++ b/packages/groundcrew/src/commands/orchestrator.ts
@@ -30,6 +30,7 @@ const RETRY_BASE_DELAY_MS = 1000;
 const RETRY_MAX_ATTEMPTS = 3;
 const STATUS_CARD_TITLE_WIDTH = 42;
 const STATUS_CARD_ID_WIDTH = 8;
+const STATUS_CARD_LIMIT = 20;
 const HEADER_BAR_WIDTH = 70;
 const SECTION_BAR_WIDTH = 50;
 const MS_PER_SECOND = 1000;
@@ -152,7 +153,16 @@ function render(state: BoardState, config: ResolvedConfig, previous?: BoardState
     writeOutput(`${statusIconFor(status, config)} ${status} (${issues.length})${delta}`);
     writeOutput("-".repeat(SECTION_BAR_WIDTH));
 
-    for (const issue of issues) {
+    // Cap each status at the N most recent so a backlog of hundreds of Done
+    // tickets doesn't clog the terminal. Sort only when truncating so smaller
+    // statuses keep whatever order Linear returned.
+    const visible =
+      issues.length > STATUS_CARD_LIMIT
+        ? issues
+            .toSorted((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+            .slice(0, STATUS_CARD_LIMIT)
+        : issues;
+    for (const issue of visible) {
       const previousIssue = previousById?.get(issue.id);
       const changed =
         previousIssue && previousIssue.status !== issue.status
@@ -160,6 +170,11 @@ function render(state: BoardState, config: ResolvedConfig, previous?: BoardState
           : "";
       writeOutput(
         `   ${issue.id.padEnd(STATUS_CARD_ID_WIDTH)}  ${issue.title.slice(0, STATUS_CARD_TITLE_WIDTH).padEnd(STATUS_CARD_TITLE_WIDTH)}  ${issue.assignee}${changed}`,
+      );
+    }
+    if (issues.length > STATUS_CARD_LIMIT) {
+      writeOutput(
+        `   … showing ${STATUS_CARD_LIMIT} most recent of ${issues.length}; ${issues.length - STATUS_CARD_LIMIT} older hidden`,
       );
     }
     writeOutput();


### PR DESCRIPTION
## Why

The status board re-renders every watch tick. A project with hundreds of Done tickets (Rocky hit 116) buries the actionable Todo/In-Progress rows under a wall of completed work on every refresh.

Cap each status section at the 20 most recent (by `updatedAt`) and print a footer so the truncation is visible rather than silent:

```
ok Done (116) (+4)
--------------------------------------------------
   staff-655  …
   …
   staff-636  …
   … showing 20 most recent of 116; 96 older hidden
```

Sort only when a status exceeds the cap, so smaller statuses keep whatever order Linear returned. Hard-coded constant (`STATUS_CARD_LIMIT = 20`) rather than a config knob — happy to make it configurable in a follow-up if anyone wants a different cap.

Agent session ID: claude-code 1a4d34c8-a99d-407b-91bd-4c5a1dc3df7e

<!-- commit-push-pr:created v1 core@3.4.0 -->