### PR TITLE
docs(clearance,groundcrew): polish READMEs for OSS release

### DIFF
--- a/packages/clearance/README.md
+++ b/packages/clearance/README.md
@@ -103,8 +103,9 @@ kill "$(cat "${XDG_CACHE_HOME:-$HOME/.cache}/clearance/clearance.pid")"
 
 ## Safehouse integration (macOS)
 
-Safehouse uses macOS sandbox profiles, so this section is for macOS hosts
-only. Safehouse allows network access by default for agent compatibility.
+[Safehouse](https://agent-safehouse.dev/) uses macOS sandbox profiles, so
+this section is for macOS hosts only. Safehouse allows network access by
+default for agent compatibility.
 To force a wrapped agent through this proxy, run the proxy outside
 Safehouse, then append a Safehouse profile that denies direct remote
 egress while leaving `localhost` open for `http://127.0.0.1:19999`.

--- a/packages/clearance/README.md
+++ b/packages/clearance/README.md
@@ -1,6 +1,9 @@
 # @clipboard-health/clearance
 
-HTTP/HTTPS clearance for deny-by-default sandboxes.
+A local HTTP/HTTPS forward proxy that gates network egress against a
+hostname allowlist. Built for deny-by-default sandboxes — coding agents,
+CI workers, isolated build steps — where you want one choke point the
+sandbox can permit, with every other route to the network closed.
 
 The proxy ships with **zero compiled-in opinions** about which hosts to allow.
 Bring your own list — either inline via env or by pointing at one or more

--- a/packages/groundcrew/README.md
+++ b/packages/groundcrew/README.md
@@ -16,16 +16,17 @@ This installs the `crew` binary. `@clipboard-health/clearance` is pulled in tran
 
 2. **Create a Linear project to scope your work.** Any team works — make a project inside it and drop tickets in. The orchestrator polls by project, not by team, so you don't need a dedicated team.
 
-3. **Create your config.** Copy the shipped example into your working directory and edit it:
+3. **Create your config.** Copy the shipped example, edit it, and point `crew` at it via `GROUNDCREW_CONFIG`:
 
    ```bash
    cp "$(npm root -g)/@clipboard-health/groundcrew/configExample.ts" ./config.ts
    $EDITOR ./config.ts
+   export GROUNDCREW_CONFIG="$PWD/config.ts"
    ```
 
    At minimum set `linear.projectSlug` (paste the trailing segment of your Linear project URL, e.g. `ai-strategy-5152195762f3`), `workspace.projectDir`, and `workspace.knownRepositories`. Everything else has a default.
 
-   `crew` loads `./config.ts` from the current directory by default. Override the location with `GROUNDCREW_CONFIG=/path/to/config.ts`.
+   If `GROUNDCREW_CONFIG` is unset, `crew` falls back to a `config.ts` at the installed package root. That's useful when hacking on groundcrew itself; use `GROUNDCREW_CONFIG` for real work.
 
 4. **Provide a Linear API key.** `crew` expects `LINEAR_API_KEY` in its environment. Any mechanism works — shell export, [direnv](https://direnv.net/), a `.env` file you `source`, or piping through `op run` if you store the credential in 1Password:
 
@@ -39,7 +40,7 @@ This installs the `crew` binary. `@clipboard-health/clearance` is pulled in tran
    op run --env-file .env.1password -- crew doctor
    ```
 
-5. **Prepare isolation and agent auth.** With `models.isolation: "auto"`, groundcrew prefers Safehouse on supported hosts. If Safehouse is unavailable and the model has a `sandbox` config, it uses persistent Docker Sandboxes. Set `models.isolation: "none"` only when you intentionally want direct, non-isolated execution.
+5. **Prepare isolation and agent auth.** With `models.isolation: "auto"`, groundcrew prefers Safehouse (Safehouse is macOS-only). When Safehouse is unavailable, it falls back to persistent Docker Sandboxes if the model has a `sandbox` config. Set `models.isolation: "none"` only when you intentionally want direct, non-isolated execution.
 
    If you use Docker Sandboxes, start the daemon and log in before `crew run`:
 
@@ -60,7 +61,23 @@ This installs the `crew` binary. `@clipboard-health/clearance` is pulled in tran
    crew sandbox auth <repo> --model codex
    ```
 
-6. **Run.** Doctor first, then a dry run, then the real thing:
+6. **Set the clearance allowlist (Safehouse only).** When the resolved isolation strategy is Safehouse, groundcrew starts `clearance` from `@clipboard-health/clearance` on `http://127.0.0.1:19999` (skipping the launch if something is already listening) and runs the agent through the bundled `safehouse-clearance` wrapper. Clearance refuses to start without an allowlist — see [its README](../clearance/README.md) for the proxy's env vars, log paths, and DNS rules. The shortest path is to set the env before `crew run`:
+
+   ```bash
+   CLEARANCE_ALLOW_HOSTS="api.openai.com,auth.openai.com,api.anthropic.com,mcp.linear.app,api.linear.app" \
+   crew run --watch
+   ```
+
+   Groundcrew also ships a starter allowlist file covering model APIs, Linear, Notion, Slack, Datadog, GitHub, npm, and common dev tooling at `$(npm root -g)/@clipboard-health/groundcrew/clearance-allow-hosts`. Point clearance at it (and optionally a personal file) via `CLEARANCE_ALLOW_HOSTS_FILES`:
+
+   ```bash
+   CLEARANCE_ALLOW_HOSTS_FILES="$(npm root -g)/@clipboard-health/groundcrew/clearance-allow-hosts:$HOME/.config/clearance/personal-allow-hosts" \
+   crew run --watch
+   ```
+
+   Watch `${XDG_CACHE_HOME:-$HOME/.cache}/clearance/clearance.log` for `DENY` lines and add only the domains your agents actually need.
+
+7. **Run.** Doctor first, then a dry run, then the real thing:
 
    ```bash
    crew doctor
@@ -69,49 +86,33 @@ This installs the `crew` binary. `@clipboard-health/clearance` is pulled in tran
    crew run --watch    # poll forever
    ```
 
-   When groundcrew resolves a model to the `safehouse` isolation strategy, it calls `ensureClearance` from `@clipboard-health/clearance` to start `clearance` on `http://127.0.0.1:19999` if nothing is already listening, then launches the agent through the bundled `safehouse-clearance` wrapper. The default allowlist covers model APIs, Linear, Notion, Slack, and Datadog. Override it before starting groundcrew:
-
-   ```bash
-   CLEARANCE_ALLOW_HOSTS="api.openai.com,auth.openai.com,api.anthropic.com,mcp.linear.app,api.linear.app" \
-   crew run --watch
-   ```
-
-   Or point at one or more allow-host files (groundcrew ships a starter file at `$(npm root -g)/@clipboard-health/groundcrew/clearance-allow-hosts`):
-
-   ```bash
-   CLEARANCE_ALLOW_HOSTS_FILES="$(npm root -g)/@clipboard-health/groundcrew/clearance-allow-hosts:$HOME/.config/clearance/personal-allow-hosts" \
-   crew run --watch
-   ```
-
-   Proxy output is written to `${XDG_CACHE_HOME:-$HOME/.cache}/clearance/clearance.log`, and the PID is written beside it as `clearance.pid`. Watch the proxy's `DENY` log lines and add only the domains your agents actually need.
-
 ## Config reference
 
 Required fields are marked **required**; everything else has a default and can be omitted from `config.ts`.
 
-| Key                                     | Default             | What it does                                                                                                                                                                                                                                                         |
-| --------------------------------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `linear.projectSlug`                    | **required**        | Linear project URL slug (e.g. `ai-strategy-5152195762f3`). The trailing 12-char hex `slugId` is what's matched against Linear's API; the leading name keeps `config.ts` self-documenting and the lookup survives project renames.                                    |
-| `linear.statuses.todo`                  | `"Todo"`            | Status name picked up for new work.                                                                                                                                                                                                                                  |
-| `linear.statuses.inProgress`            | `"In Progress"`     | Status set after a workspace is provisioned; counts toward `maximumInProgress`.                                                                                                                                                                                      |
-| `linear.statuses.done`                  | `"Done"`            | Status that triggers worktree cleanup.                                                                                                                                                                                                                               |
-| `linear.statuses.terminal`              | `["Done"]`          | Additional status names treated as terminal for cleanup, board remaining counts, and blocker checks. The `done` status is always included.                                                                                                                           |
-| `git.remote`                            | `"origin"`          | Remote used for `fetch` and as the worktree base ref.                                                                                                                                                                                                                |
-| `git.defaultBranch`                     | `"main"`            | Branch fetched from `git.remote` and used as the worktree base.                                                                                                                                                                                                      |
-| `workspace.projectDir`                  | **required**        | Parent dir for cloned repos. `$PROJECT_DIR` env var overrides. Sandbox-backed ticket worktrees live under each repo's `.sbx/` directory.                                                                                                                             |
-| `workspace.knownRepositories`           | **required**        | Repos searched for in ticket descriptions to infer where work belongs. Tickets fail fast when no known repo appears.                                                                                                                                                 |
-| `orchestrator.maximumInProgress`        | `4`                 | Cap on tickets in `linear.statuses.inProgress` at once.                                                                                                                                                                                                              |
-| `orchestrator.pollIntervalMilliseconds` | `120_000`           | Poll interval in `--watch` mode.                                                                                                                                                                                                                                     |
-| `orchestrator.sessionLimitPercentage`   | `85`                | Number in `(0, 100]`. A model whose codexbar session window exceeds this percentage is skipped that tick.                                                                                                                                                            |
-| `models.default`                        | `"claude"`          | Agent used when a ticket has no agent label. Must exist in `models.definitions`.                                                                                                                                                                                     |
-| `models.isolation`                      | `"auto"`            | Isolation strategy. `"auto"` picks Safehouse on a supported host, else Docker Sandboxes when the model has a sandbox config. Safehouse support or a model sandbox config is required; if neither is available, setup fails. Set `"none"` explicitly to run directly. |
-| `models.definitions`                    | `{ claude, codex }` | Agent definitions. Additive merge with shipped defaults.                                                                                                                                                                                                             |
-| `models.definitions.<name>.cmd`         | —                   | Shell command launched for the model. For sandbox-backed models this runs inside the persistent sandbox; otherwise it runs in the workspace. `{{worktree}}` and `{{sandbox}}` are replaced before launch.                                                            |
-| `models.definitions.<name>.color`       | —                   | Color for the workspace status pill (cmux only; tmux silently drops it).                                                                                                                                                                                             |
-| `models.definitions.<name>.sandbox`     | `{ agent }`         | Optional Docker Sandboxes backing. Defaults set `claude` → `agent: "claude"` and `codex` → `agent: "codex"`. Set `sandbox: false` on an override to run the command outside Docker Sandboxes.                                                                        |
-| `models.definitions.<name>.usage`       | optional            | If set, codexbar usage is fetched for this model and gated by `sessionLimitPercentage`. Omit to never gate. When `usage.codexbar.source` is omitted, groundcrew uses `auto` on macOS and `cli` elsewhere.                                                            |
-| `prompts.initial`                       | (template)          | First message sent to the agent. Placeholders: `{{ticket}}`, `{{worktree}}`, `{{title}}`, `{{description}}`.                                                                                                                                                         |
-| `workspaceKind`                         | `"auto"`            | Terminal session manager. `"auto"` picks `cmux` when on PATH, else `tmux`. Set to `"cmux"` or `"tmux"` to fail loudly when the chosen backend is missing. tmux windows live in a dedicated `groundcrew` session.                                                     |
+| Key                                     | Default             | What it does                                                                                                                                                                                                                                      |
+| --------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `linear.projectSlug`                    | **required**        | Linear project URL slug (e.g. `ai-strategy-5152195762f3`). The trailing 12-char hex `slugId` is what's matched against Linear's API; the leading name keeps `config.ts` self-documenting and the lookup survives project renames.                 |
+| `linear.statuses.todo`                  | `"Todo"`            | Status name picked up for new work.                                                                                                                                                                                                               |
+| `linear.statuses.inProgress`            | `"In Progress"`     | Status set after a workspace is provisioned; counts toward `maximumInProgress`.                                                                                                                                                                   |
+| `linear.statuses.done`                  | `"Done"`            | Status that triggers worktree cleanup.                                                                                                                                                                                                            |
+| `linear.statuses.terminal`              | `["Done"]`          | Additional status names treated as terminal for cleanup, board remaining counts, and blocker checks. The `done` status is always included.                                                                                                        |
+| `git.remote`                            | `"origin"`          | Remote used for `fetch` and as the worktree base ref.                                                                                                                                                                                             |
+| `git.defaultBranch`                     | `"main"`            | Branch fetched from `git.remote` and used as the worktree base.                                                                                                                                                                                   |
+| `workspace.projectDir`                  | **required**        | Parent dir for cloned repos. `$PROJECT_DIR` env var overrides. Sandbox-backed ticket worktrees live under each repo's `.sbx/` directory.                                                                                                          |
+| `workspace.knownRepositories`           | **required**        | Repos searched for in ticket descriptions to infer where work belongs. Tickets fail fast when no known repo appears.                                                                                                                              |
+| `orchestrator.maximumInProgress`        | `4`                 | Cap on tickets in `linear.statuses.inProgress` at once.                                                                                                                                                                                           |
+| `orchestrator.pollIntervalMilliseconds` | `120_000`           | Poll interval in `--watch` mode.                                                                                                                                                                                                                  |
+| `orchestrator.sessionLimitPercentage`   | `85`                | Number in `(0, 100]`. A model whose codexbar session window exceeds this percentage is skipped that tick.                                                                                                                                         |
+| `models.default`                        | `"claude"`          | Agent used when a ticket has no agent label. Must exist in `models.definitions`.                                                                                                                                                                  |
+| `models.isolation`                      | `"auto"`            | Isolation strategy. `"auto"` picks Safehouse on macOS, else Docker Sandboxes when the model has a sandbox config. Safehouse or a model sandbox config is required; if neither is available, setup fails. Set `"none"` explicitly to run directly. |
+| `models.definitions`                    | `{ claude, codex }` | Agent definitions. Additive merge with shipped defaults.                                                                                                                                                                                          |
+| `models.definitions.<name>.cmd`         | —                   | Shell command launched for the model. For sandbox-backed models this runs inside the persistent sandbox; otherwise it runs in the workspace. `{{worktree}}` and `{{sandbox}}` are replaced before launch.                                         |
+| `models.definitions.<name>.color`       | —                   | Color for the workspace status pill (cmux only; tmux silently drops it).                                                                                                                                                                          |
+| `models.definitions.<name>.sandbox`     | `{ agent }`         | Optional Docker Sandboxes backing. Defaults set `claude` → `agent: "claude"` and `codex` → `agent: "codex"`. Set `sandbox: false` on an override to run the command outside Docker Sandboxes.                                                     |
+| `models.definitions.<name>.usage`       | optional            | If set, codexbar usage is fetched for this model and gated by `sessionLimitPercentage`. Omit to never gate. When `usage.codexbar.source` is omitted, groundcrew uses `auto` on macOS and `cli` elsewhere.                                         |
+| `prompts.initial`                       | (template)          | First message sent to the agent. Placeholders: `{{ticket}}`, `{{worktree}}`, `{{title}}`, `{{description}}`.                                                                                                                                      |
+| `workspaceKind`                         | `"auto"`            | Terminal session manager. `"auto"` picks `cmux` when on PATH, else `tmux`. Set to `"cmux"` or `"tmux"` to fail loudly when the chosen backend is missing. tmux windows live in a dedicated `groundcrew` session.                                  |
 
 The branch prefix (`<prefix>-<TICKET>`) is derived from your OS username (`os.userInfo().username`), not configured. Agent selection looks for a top-level Linear label named `agent-<model>` (e.g. `agent-claude`, `agent-codex`). The reserved label `agent-any` routes the ticket to the configured model with the most available session capacity (lowest codexbar session-used percent), skipping any model already over `sessionLimitPercentage`. With no usage data, `agent-any` resolves to `models.default`. The name `any` cannot be used in `models.definitions`. Todo tickets blocked by Linear issues that are not in `linear.statuses.terminal` are skipped until their blockers reach a terminal status.
 
@@ -128,14 +129,14 @@ crew cleanup <TICKET>
 
 ## Gotchas
 
-- **Auto isolation prefers Safehouse.** The shipped `models.isolation: "auto"` uses Safehouse on supported hosts. When Safehouse is unavailable, shipped models with Docker Sandbox config use a persistent sandbox per repo/model, named `groundcrew-<repo>-<model>`. `crew run --ticket` creates per-ticket `sbx --branch` worktrees inside that sandbox and launches the task with `sbx exec`, so `npm clean-install` and the agent both run inside Docker.
-- **Safehouse uses clearance.** On hosts where `auto` resolves to Safehouse, groundcrew starts `clearance` when needed via `@clipboard-health/clearance`, then runs the `safehouse-clearance` wrapper shipped in that package, which loads the bundled `clearance.env` and appends `clearance-only.sb`. If a model command already starts with `safehouse`, groundcrew assumes that command owns its Safehouse flags and does not add the proxy profile a second time. To inspect blocked requests, run `tail -f "${XDG_CACHE_HOME:-$HOME/.cache}/clearance/clearance.log"`. To change the allowlist, set `CLEARANCE_ALLOW_HOSTS` (or `CLEARANCE_ALLOW_HOSTS_FILES`); if the proxy is already running, stop the PID in `clearance.pid` so the next launch can restart it with the new env.
+- **Auto isolation prefers Safehouse.** The shipped `models.isolation: "auto"` uses Safehouse on macOS. On non-macOS hosts (Linux/WSL), shipped models with Docker Sandbox config use a persistent sandbox per repo/model, named `groundcrew-<repo>-<model>`. `crew run --ticket` creates per-ticket `sbx --branch` worktrees inside that sandbox and launches the task with `sbx exec`, so `npm clean-install` and the agent both run inside Docker.
+- **Safehouse-already-wrapped commands are not re-wrapped.** If a `models.definitions.<name>.cmd` already starts with `safehouse`, groundcrew assumes that command owns its Safehouse flags and does not add the `safehouse-clearance` wrapper a second time. Changing the proxy's allowlist after it's running requires killing the PID in `${XDG_CACHE_HOME:-$HOME/.cache}/clearance/clearance.pid` so the next launch picks up the new env.
 - **Authenticate before first ticket setup.** Run `crew sandbox auth <repo> --model <name>` before `crew run` for a repo/model. That first run carries no ticket prompt, so a required OAuth `/login` cannot consume task context.
 - **Sandbox cleanup is intentionally conservative.** `crew cleanup` removes the per-ticket worktree and branch, but keeps the persistent sandbox so OAuth sessions, installed packages, and agent config survive later tickets. Use `sbx ls` and `sbx rm --force <name>` when you intentionally want to delete that persisted sandbox state.
 - **Usage source defaults are OS-aware.** `codexbar` usage uses `--source auto` on macOS so CodexBar can prefer account/web sources and fall back as it supports. On Linux/WSL it uses `--source cli`, so install the CodexBar Linux CLI and authenticate the provider CLIs inside that environment.
 - **Status names matter.** If your team uses `Started` instead of `In Progress`, set `linear.statuses.inProgress = "Started"`.
 - **Leaf-only.** Parent issues with children are ignored — sub-issues are the work items.
-- **Tickets stay in the in-progress status until externally promoted.** A PR open is the typical signal; whatever your Linear "in review" automation is, the orchestrator does not do that move itself.
+- **Tickets stay in the in-progress status until something else moves them.** Groundcrew sets a ticket to `inProgress` when it provisions a workspace and never advances it. The next transition (typically "in review" when a PR opens) is left to your team's Linear automation rules.
 - **Project must be on a single Linear team in practice.** Cross-team projects work — the orchestrator caches the in-progress state ID per team — but every team in the project must use the same status name for `linear.statuses.inProgress`.
 - **Doctor's command introspection is shallow.** For sandbox-backed models it checks `sbx` plus `sbx diagnose`. For non-sandbox models it tokenizes `cmd` and checks the first two non-flag tokens against PATH (so `safehouse claude --foo` checks both `safehouse` and `claude`). Boolean flags without values, env-var assignments (`FOO=1`), shell pipelines, and subshells are not parsed — verify those manually. In particular, `npx -y claude` and `env FOO=1 claude` only check the wrapper, not the wrapped CLI.
 - **Agent CLI must accept a positional prompt.** The handoff is `<your cmd> "<prompt>"`. `claude`, `codex`, and `cursor-agent` all support this.

--- a/packages/groundcrew/README.md
+++ b/packages/groundcrew/README.md
@@ -40,7 +40,7 @@ This installs the `crew` binary. `@clipboard-health/clearance` is pulled in tran
    op run --env-file .env.1password -- crew doctor
    ```
 
-5. **Prepare isolation and agent auth.** With `models.isolation: "auto"`, groundcrew prefers Safehouse (Safehouse is macOS-only). When Safehouse is unavailable, it falls back to persistent Docker Sandboxes if the model has a `sandbox` config. Set `models.isolation: "none"` only when you intentionally want direct, non-isolated execution.
+5. **Prepare isolation and agent auth.** With `models.isolation: "auto"`, groundcrew prefers Safehouse on macOS. On non-macOS hosts, it falls back to persistent Docker Sandboxes if the model has a `sandbox` config. Set `models.isolation: "none"` only when you intentionally want direct, non-isolated execution.
 
    If you use Docker Sandboxes, start the daemon and log in before `crew run`:
 

--- a/packages/groundcrew/README.md
+++ b/packages/groundcrew/README.md
@@ -12,7 +12,7 @@ This installs the `crew` binary. `@clipboard-health/clearance` is pulled in tran
 
 ## Quickstart
 
-1. **Install prereqs.** Node 24, `git`, `cmux` _or_ `tmux`, and the runtimes you actually want: Docker Sandboxes (`sbx`) for sandbox-backed agents, [Safehouse](https://github.com/anthropics/safehouse) for macOS sandboxing, and the agent CLIs themselves (`claude`, `codex`, `cursor-agent`, ...). Optional: `codexbar` for session-usage gating. The `workspaceKind` config key picks the workspace backend (`auto` resolves to cmux when installed, else tmux).
+1. **Install prereqs.** Node 24, `git`, `cmux` _or_ `tmux`, and the runtimes you actually want: Docker Sandboxes (`sbx`) for sandbox-backed agents, [Safehouse](https://agent-safehouse.dev/) for macOS sandboxing, and the agent CLIs themselves (`claude`, `codex`, `cursor-agent`, ...). Optional: `codexbar` for session-usage gating. The `workspaceKind` config key picks the workspace backend (`auto` resolves to cmux when installed, else tmux).
 
 2. **Create a Linear project to scope your work.** Any team works — make a project inside it and drop tickets in. The orchestrator polls by project, not by team, so you don't need a dedicated team.
 

--- a/packages/groundcrew/README.md
+++ b/packages/groundcrew/README.md
@@ -26,7 +26,7 @@ This installs the `crew` binary. `@clipboard-health/clearance` is pulled in tran
 
    At minimum set `linear.projectSlug` (paste the trailing segment of your Linear project URL, e.g. `ai-strategy-5152195762f3`), `workspace.projectDir`, and `workspace.knownRepositories`. Everything else has a default.
 
-   If `GROUNDCREW_CONFIG` is unset, `crew` falls back to a `config.ts` at the installed package root. That's useful when hacking on groundcrew itself; use `GROUNDCREW_CONFIG` for real work.
+   `GROUNDCREW_CONFIG` is effectively required for npm-installed use. If it's unset, `crew` falls back to a `config.ts` sitting next to its own source files — only useful when running from a local checkout (see [Hacking on groundcrew](#hacking-on-groundcrew)).
 
 4. **Provide a Linear API key.** `crew` expects `LINEAR_API_KEY` in its environment. Any mechanism works — shell export, [direnv](https://direnv.net/), a `.env` file you `source`, or piping through `op run` if you store the credential in 1Password:
 


### PR DESCRIPTION
## Summary

Audited both packages' READMEs against the implementation in prep for open-sourcing them. The READMEs were already largely accurate, but a few claims didn't match the code and a few sections needed sharpening for first-time readers.

## Fixes

**clearance/README.md**

- Rewrote the one-line tagline into a short paragraph that names the use cases (coding agents, CI workers, isolated build steps) and the value (single egress choke point) so the audience is clear at a glance.

**groundcrew/README.md**

- **Config path claim corrected.** README said \`crew\` loads \`./config.ts\` from CWD by default; the code (\`src/lib/config.ts:302\`) resolves the default relative to the installed package root. Updated the quickstart to set \`GROUNDCREW_CONFIG\` explicitly and reframed the unset fallback as a dev-only convenience.
- **Default-allowlist claim corrected.** Step 6 said clearance had a default allowlist covering model APIs / Linear / Notion / Slack / Datadog. It doesn't — \`ensureClearance\` is called with only a logger and clearance refuses to start without an allowlist (\`src/allowlist.ts:23-27\`). Updated to make that explicit and describe the shipped starter file accurately.
- **Quickstart order of operations.** Split the old Step 6 into a Step 6 (\"set the clearance allowlist\") and Step 7 (\"run\"), so users don't hit \`crew doctor\`/\`crew run --dry-run\` before being told an allowlist is required.
- **Platform claims tightened.** Aligned \"supported hosts\" wording with the code (Safehouse is macOS-only per \`src/lib/host.ts:53,66\`). Replaced \"i.e. Linux\" with \"non-macOS hosts (Linux/WSL)\".
- **Reduced overlap.** Step 6 is now the canonical home for the clearance-integration prose; the corresponding gotcha was trimmed to the genuinely surprising bits (already-safehoused commands aren't re-wrapped, restart-PID dance for allowlist changes).
- **Minor prose tightens** for clarity in Step 5 and the in-progress-status gotcha.

## Test plan

- [x] \`node --run verify\` (lint, markdown lint, syncpack, embed checks) — clean.
- [ ] Spot-check on a fresh \`npm install -g\` that the updated quickstart steps work end-to-end (best done by a non-author).

Agent session ID: claude-code 1586be18-5e56-4221-a594-778f2190f459
<!-- commit-push-pr:created v1 core@3.4.0 -->