### PR TITLE
refactor(groundcrew): persist logs and trim env-var surface to GROUNDCREW_CONFIG

### DIFF
--- a/packages/groundcrew/README.md
+++ b/packages/groundcrew/README.md
@@ -16,17 +16,18 @@ This installs the `crew` binary. `@clipboard-health/clearance` is pulled in tran
 
 2. **Create a Linear project to scope your work.** Any team works — make a project inside it and drop tickets in. The orchestrator polls by project, not by team, so you don't need a dedicated team.
 
-3. **Create your config.** Copy the shipped example, edit it, and point `crew` at it via `GROUNDCREW_CONFIG`:
+3. **Create your config.** Copy the shipped example into the XDG config path and edit it:
 
    ```bash
-   cp "$(npm root -g)/@clipboard-health/groundcrew/configExample.ts" ./config.ts
-   $EDITOR ./config.ts
-   export GROUNDCREW_CONFIG="$PWD/config.ts"
+   mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew"
+   cp "$(npm root -g)/@clipboard-health/groundcrew/configExample.ts" \
+      "${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/config.ts"
+   $EDITOR "${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/config.ts"
    ```
 
    At minimum set `linear.projectSlug` (paste the trailing segment of your Linear project URL, e.g. `ai-strategy-5152195762f3`), `workspace.projectDir`, and `workspace.knownRepositories`. Everything else has a default.
 
-   `GROUNDCREW_CONFIG` is effectively required for npm-installed use. If it's unset, `crew` falls back to a `config.ts` sitting next to its own source files — only useful when running from a local checkout (see [Hacking on groundcrew](#hacking-on-groundcrew)).
+   `crew` resolves the config path as: `GROUNDCREW_CONFIG` if set → `${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/config.ts` if it exists → a `config.ts` sitting next to `crew`'s own source files (only useful from a local checkout; see [Hacking on groundcrew](#hacking-on-groundcrew)). Set `GROUNDCREW_CONFIG` only when you want to override the XDG location.
 
 4. **Provide a Linear API key.** `crew` expects `LINEAR_API_KEY` in its environment. Any mechanism works — shell export, [direnv](https://direnv.net/), a `.env` file you `source`, or piping through `op run` if you store the credential in 1Password:
 
@@ -99,7 +100,7 @@ Required fields are marked **required**; everything else has a default and can b
 | `linear.statuses.terminal`              | `["Done"]`          | Additional status names treated as terminal for cleanup, board remaining counts, and blocker checks. The `done` status is always included.                                                                                                        |
 | `git.remote`                            | `"origin"`          | Remote used for `fetch` and as the worktree base ref.                                                                                                                                                                                             |
 | `git.defaultBranch`                     | `"main"`            | Branch fetched from `git.remote` and used as the worktree base.                                                                                                                                                                                   |
-| `workspace.projectDir`                  | **required**        | Parent dir for cloned repos. `$PROJECT_DIR` env var overrides. Sandbox-backed ticket worktrees live under each repo's `.sbx/` directory.                                                                                                          |
+| `workspace.projectDir`                  | **required**        | Parent dir for cloned repos. Sandbox-backed ticket worktrees live under each repo's `.sbx/` directory.                                                                                                                                            |
 | `workspace.knownRepositories`           | **required**        | Repos searched for in ticket descriptions to infer where work belongs. Tickets fail fast when no known repo appears.                                                                                                                              |
 | `orchestrator.maximumInProgress`        | `4`                 | Cap on tickets in `linear.statuses.inProgress` at once.                                                                                                                                                                                           |
 | `orchestrator.pollIntervalMilliseconds` | `120_000`           | Poll interval in `--watch` mode.                                                                                                                                                                                                                  |
@@ -113,6 +114,7 @@ Required fields are marked **required**; everything else has a default and can b
 | `models.definitions.<name>.usage`       | optional            | If set, codexbar usage is fetched for this model and gated by `sessionLimitPercentage`. Omit to never gate. When `usage.codexbar.source` is omitted, groundcrew uses `auto` on macOS and `cli` elsewhere.                                         |
 | `prompts.initial`                       | (template)          | First message sent to the agent. Placeholders: `{{ticket}}`, `{{worktree}}`, `{{title}}`, `{{description}}`.                                                                                                                                      |
 | `workspaceKind`                         | `"auto"`            | Terminal session manager. `"auto"` picks `cmux` when on PATH, else `tmux`. Set to `"cmux"` or `"tmux"` to fail loudly when the chosen backend is missing. tmux windows live in a dedicated `groundcrew` session.                                  |
+| `logging.file`                          | XDG state path      | Append-mode log file destination. `log()` / `logEvent()` tee here in addition to stdout, so a vanished workspace doesn't take the evidence with it. Defaults to `${XDG_STATE_HOME:-$HOME/.local/state}/groundcrew/groundcrew.log`.                |
 
 The branch prefix (`<prefix>-<TICKET>`) is derived from your OS username (`os.userInfo().username`), not configured. Agent selection looks for a top-level Linear label named `agent-<model>` (e.g. `agent-claude`, `agent-codex`). The reserved label `agent-any` routes the ticket to the configured model with the most available session capacity (lowest codexbar session-used percent), skipping any model already over `sessionLimitPercentage`. With no usage data, `agent-any` resolves to `models.default`. The name `any` cannot be used in `models.definitions`. Todo tickets blocked by Linear issues that are not in `linear.statuses.terminal` are skipped until their blockers reach a terminal status.
 
@@ -147,12 +149,14 @@ For developers working on the package itself, the source lives in [`ClipboardHea
 
 ```bash
 cd ~/dev/c/core-utils
-GROUNDCREW_CONFIG=~/.config/groundcrew/config.ts node --run crew -- doctor
+node --run crew -- doctor
 
 # With 1Password for LINEAR_API_KEY:
-GROUNDCREW_OP_ENV_FILE=~/.config/groundcrew/op.env \
-GROUNDCREW_CONFIG=~/.config/groundcrew/config.ts \
 node --run crew:op -- run --watch
 ```
 
-`GROUNDCREW_OP_ENV_FILE` defaults to `.crew.1password.env` at the repo root. Source edits in `packages/{clearance,groundcrew}/src/**` are picked up on the next invocation. Requires Node ≥ 24.3 (the version with native `.ts` type stripping enabled by default).
+Both forms read `${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/config.ts` by default; set `GROUNDCREW_CONFIG` to point elsewhere. The `crew:op` wrapper additionally reads `${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/op.env` (1Password env-file with `op://` references resolved at launch) — symlink it there if you keep yours elsewhere; the path is not configurable.
+
+Logs land in `${XDG_STATE_HOME:-$HOME/.local/state}/groundcrew/groundcrew.log` by default (override via `logging.file` in your config). The "Loaded config from …" line at startup tells you which config won.
+
+Source edits in `packages/{clearance,groundcrew}/src/**` are picked up on the next invocation. Requires Node ≥ 24.3 (the version with native `.ts` type stripping enabled by default).

--- a/packages/groundcrew/configExample.ts
+++ b/packages/groundcrew/configExample.ts
@@ -76,4 +76,11 @@ export const config: Config = {
   // // backend is missing. tmux windows live in a dedicated `groundcrew`
   // // session and lose status-pill painting (cmux-only feature).
   // workspaceKind: "auto",
+  //
+  // logging: {
+  //   // Append-mode log file destination. `log()` / `logEvent()` tee here
+  //   // in addition to stdout, so a vanished workspace doesn't take the
+  //   // evidence with it. Default: `${XDG_STATE_HOME:-~/.local/state}/groundcrew/groundcrew.log`.
+  //   file: "~/Library/Logs/groundcrew/groundcrew.log",
+  // },
 };

--- a/packages/groundcrew/src/commands/cleaner.test.ts
+++ b/packages/groundcrew/src/commands/cleaner.test.ts
@@ -47,6 +47,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     },
     prompts: { initial: "x", ...overrides.prompts },
     workspaceKind: overrides.workspaceKind ?? "auto",
+    logging: { file: "/tmp/groundcrew-test.log", ...overrides.logging },
   };
 }
 

--- a/packages/groundcrew/src/commands/cleanupWorkspace.test.ts
+++ b/packages/groundcrew/src/commands/cleanupWorkspace.test.ts
@@ -64,6 +64,7 @@ const config: ResolvedConfig = {
   },
   prompts: { initial: "x" },
   workspaceKind: "auto",
+  logging: { file: "/tmp/groundcrew-test.log" },
 };
 
 describe(cleanupWorkspace, () => {

--- a/packages/groundcrew/src/commands/dispatcher.test.ts
+++ b/packages/groundcrew/src/commands/dispatcher.test.ts
@@ -59,6 +59,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     },
     prompts: { initial: "x", ...overrides.prompts },
     workspaceKind: overrides.workspaceKind ?? "auto",
+    logging: { file: "/tmp/groundcrew-test.log", ...overrides.logging },
   };
 }
 

--- a/packages/groundcrew/src/commands/doctor.test.ts
+++ b/packages/groundcrew/src/commands/doctor.test.ts
@@ -71,6 +71,7 @@ function makeConfig(overrides: Partial<ResolvedConfig["models"]> = {}): Resolved
     },
     prompts: { initial: "x" },
     workspaceKind: "auto",
+    logging: { file: "/tmp/groundcrew-test.log" },
   };
 }
 

--- a/packages/groundcrew/src/commands/eligibility.test.ts
+++ b/packages/groundcrew/src/commands/eligibility.test.ts
@@ -40,6 +40,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     },
     prompts: { initial: "x", ...overrides.prompts },
     workspaceKind: overrides.workspaceKind ?? "auto",
+    logging: { file: "/tmp/groundcrew-test.log", ...overrides.logging },
   };
 }
 

--- a/packages/groundcrew/src/commands/orchestrator.test.ts
+++ b/packages/groundcrew/src/commands/orchestrator.test.ts
@@ -109,6 +109,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     },
     prompts: { initial: "x", ...overrides.prompts },
     workspaceKind: overrides.workspaceKind ?? "auto",
+    logging: { file: "/tmp/groundcrew-test.log", ...overrides.logging },
   };
 }
 

--- a/packages/groundcrew/src/commands/sandboxAuth.test.ts
+++ b/packages/groundcrew/src/commands/sandboxAuth.test.ts
@@ -59,6 +59,7 @@ const config: ResolvedConfig = {
   },
   prompts: { initial: "x" },
   workspaceKind: "auto",
+  logging: { file: "/tmp/groundcrew-test.log" },
 };
 
 function mockMissingSandbox(): void {

--- a/packages/groundcrew/src/commands/setupWorkspace.test.ts
+++ b/packages/groundcrew/src/commands/setupWorkspace.test.ts
@@ -169,6 +169,7 @@ function makeConfig(overrides: Partial<ResolvedConfig["models"]> = {}): Resolved
       initial: "Begin {{ticket}} ({{title}}) in {{worktree}}\n{{description}}",
     },
     workspaceKind: "auto",
+    logging: { file: "/tmp/groundcrew-test.log" },
   };
 }
 

--- a/packages/groundcrew/src/lib/boardSource.test.ts
+++ b/packages/groundcrew/src/lib/boardSource.test.ts
@@ -59,6 +59,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     },
     prompts: { initial: "x", ...overrides.prompts },
     workspaceKind: overrides.workspaceKind ?? "auto",
+    logging: { file: "/tmp/groundcrew-test.log", ...overrides.logging },
   };
 }
 

--- a/packages/groundcrew/src/lib/config.test.ts
+++ b/packages/groundcrew/src/lib/config.test.ts
@@ -1,6 +1,6 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 import {
   deleteEnvironmentVariable,
@@ -57,18 +57,24 @@ function restorePackageConfig(original: string | undefined): void {
 
 describe("loadConfig", () => {
   const originalEnvironment = snapshotEnvironmentVariables();
+  const ENV_KEYS = ["GROUNDCREW_CONFIG", "HOME", "XDG_CONFIG_HOME", "XDG_STATE_HOME"] as const;
   let temporary: string;
 
   beforeEach(() => {
     temporary = mkdtempSync(join(tmpdir(), "groundcrew-config-"));
-    deleteEnvironmentVariable("GROUNDCREW_CONFIG");
-    deleteEnvironmentVariable("PROJECT_DIR");
-    deleteEnvironmentVariable("HOME");
+    for (const key of ENV_KEYS) {
+      deleteEnvironmentVariable(key);
+    }
+    // Point XDG away from the host's real ~/.config/groundcrew so the
+    // fallback resolver doesn't accidentally pick up a developer's
+    // actual config.ts during test runs.
+    setEnvironmentVariable("XDG_CONFIG_HOME", join(temporary, "xdg-config"));
+    setEnvironmentVariable("XDG_STATE_HOME", join(temporary, "xdg-state"));
   });
 
   afterEach(() => {
     rmSync(temporary, { recursive: true, force: true });
-    for (const key of ["GROUNDCREW_CONFIG", "PROJECT_DIR", "HOME"]) {
+    for (const key of ENV_KEYS) {
       const original = originalEnvironment[key];
       if (original === undefined) {
         deleteEnvironmentVariable(key);
@@ -712,25 +718,8 @@ describe("loadConfig", () => {
     expect(actual.workspace.projectDir).toBe(temporary);
   });
 
-  it("uses PROJECT_DIR override when it is non-empty", async () => {
-    setEnvironmentVariable("PROJECT_DIR", temporary);
-    const path = writeConfigFile(
-      temporary,
-      configSource({
-        linear: { ...VALID_LINEAR },
-        workspace: { ...VALID_WORKSPACE(temporary), projectDir: "/should/be/ignored" },
-      }),
-    );
-    setEnvironmentVariable("GROUNDCREW_CONFIG", path);
-
-    const { loadConfig } = await loadFreshConfig();
-    const actual = await loadConfig();
-
-    expect(actual.workspace.projectDir).toBe(temporary);
-  });
-
-  it("ignores empty PROJECT_DIR override", async () => {
-    setEnvironmentVariable("PROJECT_DIR", "");
+  it("defaults logging.file to the XDG state path", async () => {
+    setEnvironmentVariable("XDG_STATE_HOME", join(temporary, "state"));
     const path = writeConfigFile(
       temporary,
       configSource({
@@ -743,7 +732,99 @@ describe("loadConfig", () => {
     const { loadConfig } = await loadFreshConfig();
     const actual = await loadConfig();
 
-    expect(actual.workspace.projectDir).toBe(temporary);
+    expect(actual.logging.file).toBe(join(temporary, "state", "groundcrew", "groundcrew.log"));
+  });
+
+  it("uses HOME when XDG_STATE_HOME is unset", async () => {
+    deleteEnvironmentVariable("XDG_STATE_HOME");
+    setEnvironmentVariable("HOME", temporary);
+    const path = writeConfigFile(
+      temporary,
+      configSource({
+        linear: { ...VALID_LINEAR },
+        workspace: VALID_WORKSPACE(temporary),
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", path);
+
+    const { loadConfig } = await loadFreshConfig();
+    const actual = await loadConfig();
+
+    expect(actual.logging.file).toBe(
+      join(temporary, ".local", "state", "groundcrew", "groundcrew.log"),
+    );
+  });
+
+  it("respects a user-supplied logging.file", async () => {
+    const overridePath = join(temporary, "custom", "crew.log");
+    const path = writeConfigFile(
+      temporary,
+      configSource({
+        linear: { ...VALID_LINEAR },
+        workspace: VALID_WORKSPACE(temporary),
+        logging: { file: overridePath },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", path);
+
+    const { loadConfig } = await loadFreshConfig();
+    const actual = await loadConfig();
+
+    expect(actual.logging.file).toBe(overridePath);
+  });
+
+  it("expands a leading ~ in logging.file", async () => {
+    setEnvironmentVariable("HOME", temporary);
+    const path = writeConfigFile(
+      temporary,
+      configSource({
+        linear: { ...VALID_LINEAR },
+        workspace: VALID_WORKSPACE(temporary),
+        logging: { file: "~/logs/crew.log" },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", path);
+
+    const { loadConfig } = await loadFreshConfig();
+    const actual = await loadConfig();
+
+    expect(actual.logging.file).toBe(join(temporary, "logs", "crew.log"));
+  });
+
+  it("rejects an empty logging.file", async () => {
+    const path = writeConfigFile(
+      temporary,
+      configSource({
+        linear: { ...VALID_LINEAR },
+        workspace: VALID_WORKSPACE(temporary),
+        logging: { file: "   " },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", path);
+
+    const { loadConfig } = await loadFreshConfig();
+
+    await expect(loadConfig()).rejects.toThrow(/logging.file/);
+  });
+
+  it("falls back to the XDG config path when GROUNDCREW_CONFIG is unset", async () => {
+    const xdgConfigHome = join(temporary, "xdg-config");
+    setEnvironmentVariable("XDG_CONFIG_HOME", xdgConfigHome);
+    const xdgConfigPath = join(xdgConfigHome, "groundcrew", "config.ts");
+    mkdirSync(dirname(xdgConfigPath), { recursive: true });
+    writeFileSync(
+      xdgConfigPath,
+      configSource({
+        linear: { ...VALID_LINEAR },
+        workspace: VALID_WORKSPACE(temporary),
+      }),
+    );
+    deleteEnvironmentVariable("GROUNDCREW_CONFIG");
+
+    const { loadConfig } = await loadFreshConfig();
+    const actual = await loadConfig();
+
+    expect(actual.linear.slugId).toBe("5152195762f3");
   });
 
   it("fails when the config file does not exist", async () => {

--- a/packages/groundcrew/src/lib/config.ts
+++ b/packages/groundcrew/src/lib/config.ts
@@ -3,7 +3,7 @@ import { homedir } from "node:os";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
-import { readEnvironmentVariable } from "./util.ts";
+import { log, readEnvironmentVariable, setLogFile } from "./util.ts";
 
 /**
  * Reserved model name. A ticket labeled `agent-any` resolves at runtime
@@ -198,6 +198,15 @@ export interface Config {
    * to fail loudly when the chosen backend is missing.
    */
   workspaceKind?: WorkspaceKindSetting;
+  logging?: {
+    /**
+     * Append-mode log file destination. `log()` and `logEvent()` tee here
+     * in addition to stdout, so a vanished workspace doesn't take the
+     * evidence with it. Defaults to
+     * `${XDG_STATE_HOME:-~/.local/state}/groundcrew/groundcrew.log`.
+     */
+    file?: string;
+  };
 }
 
 /**
@@ -246,6 +255,9 @@ export interface ResolvedConfig {
    * `auto` resolves to cmux on macOS when installed, else tmux.
    */
   workspaceKind: WorkspaceKindSetting;
+  logging: {
+    file: string;
+  };
 }
 
 const DEFAULT_STATUSES: ResolvedConfig["linear"]["statuses"] = {
@@ -298,11 +310,44 @@ const ALLOWED_PROMPT_PLACEHOLDERS = new Set([
 const PROMPT_PLACEHOLDER_RE = /{{[^{}]*}}/g;
 
 // import.meta.dirname is `<package>/src/lib`; the user's `config.ts` lives
-// at the package root (gitignored), two levels up.
-const DEFAULT_CONFIG_PATH = resolve(import.meta.dirname, "..", "..", "config.ts");
+// at the package root (gitignored), two levels up. Last-resort fallback
+// when neither GROUNDCREW_CONFIG nor the XDG path resolves to a file.
+const PACKAGE_CONFIG_PATH = resolve(import.meta.dirname, "..", "..", "config.ts");
 
 const PERCENT_MIN_EXCLUSIVE = 0;
 const PERCENT_MAX = 100;
+
+function xdgBase(envName: string, fallbackSegments: readonly string[]): string {
+  const override = readEnvironmentVariable(envName);
+  if (override !== undefined && override.length > 0) {
+    return override;
+  }
+  return resolve(homedir(), ...fallbackSegments);
+}
+
+function xdgConfigPath(...segments: string[]): string {
+  return resolve(xdgBase("XDG_CONFIG_HOME", [".config"]), ...segments);
+}
+
+function xdgStatePath(...segments: string[]): string {
+  return resolve(xdgBase("XDG_STATE_HOME", [".local", "state"]), ...segments);
+}
+
+function defaultLogFile(): string {
+  return xdgStatePath("groundcrew", "groundcrew.log");
+}
+
+function resolveConfigPath(): string {
+  const override = readEnvironmentVariable("GROUNDCREW_CONFIG");
+  if (override !== undefined && override.length > 0) {
+    return resolve(override);
+  }
+  const xdgPath = xdgConfigPath("groundcrew", "config.ts");
+  if (existsSync(xdgPath)) {
+    return xdgPath;
+  }
+  return PACKAGE_CONFIG_PATH;
+}
 
 function expandHome(p: string): string {
   if (p === "~") {
@@ -608,7 +653,7 @@ function applyDefaults(user: Config): ResolvedConfig {
     },
     git: { ...DEFAULT_GIT, ...user.git },
     workspace: {
-      projectDir: user.workspace.projectDir,
+      projectDir: expandHome(user.workspace.projectDir),
       knownRepositories: user.workspace.knownRepositories,
     },
     orchestrator: { ...DEFAULT_ORCHESTRATOR, ...user.orchestrator },
@@ -621,6 +666,11 @@ function applyDefaults(user: Config): ResolvedConfig {
       initial: user.prompts?.initial ?? DEFAULT_PROMPT_INITIAL,
     },
     workspaceKind: normalizeWorkspaceKind(user.workspaceKind, "workspaceKind") ?? "auto",
+    logging: {
+      file: expandHome(
+        normalizeOptionalString(user.logging?.file, "logging.file") ?? defaultLogFile(),
+      ),
+    },
   };
 }
 
@@ -701,6 +751,8 @@ function validate(config: ResolvedConfig): void {
 
   requireString(config.prompts.initial, "prompts.initial");
   validatePromptPlaceholders(config.prompts.initial);
+
+  requireString(config.logging.file, "logging.file");
 }
 
 let cached: Readonly<ResolvedConfig> | undefined;
@@ -710,12 +762,13 @@ export async function loadConfig(): Promise<Readonly<ResolvedConfig>> {
     return cached;
   }
 
-  const path = resolve(readEnvironmentVariable("GROUNDCREW_CONFIG") ?? DEFAULT_CONFIG_PATH);
+  const path = resolveConfigPath();
   if (!existsSync(path)) {
     fail(
-      `${path} not found. Copy configExample.ts to config.ts and edit it (or set GROUNDCREW_CONFIG to a different path).`,
+      `${path} not found. Copy configExample.ts to ${xdgConfigPath("groundcrew", "config.ts")} (or set GROUNDCREW_CONFIG to a different path) and edit it.`,
     );
   }
+  log(`Loaded config from ${path}`);
 
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- user config is TS-typed against Config; runtime fields are validated below
   const module_ = (await import(pathToFileURL(path).href)) as { config?: Config };
@@ -728,14 +781,9 @@ export async function loadConfig(): Promise<Readonly<ResolvedConfig>> {
 
   const resolved = applyDefaults(userConfig);
 
-  const projectDirOverride = readEnvironmentVariable("PROJECT_DIR");
-  resolved.workspace.projectDir = expandHome(
-    projectDirOverride !== undefined && projectDirOverride.length > 0
-      ? projectDirOverride
-      : resolved.workspace.projectDir,
-  );
-
   validate(resolved);
+
+  setLogFile(resolved.logging.file);
 
   cached = Object.freeze(resolved);
   return cached;

--- a/packages/groundcrew/src/lib/isolation.test.ts
+++ b/packages/groundcrew/src/lib/isolation.test.ts
@@ -59,6 +59,7 @@ function makeConfig(
     },
     prompts: { initial: "x" },
     workspaceKind: "auto",
+    logging: { file: "/tmp/groundcrew-test.log" },
   };
 }
 

--- a/packages/groundcrew/src/lib/usage.test.ts
+++ b/packages/groundcrew/src/lib/usage.test.ts
@@ -82,6 +82,7 @@ function makeConfig(
     },
     prompts: { initial: "x" },
     workspaceKind: "auto",
+    logging: { file: "/tmp/groundcrew-test.log" },
   };
 }
 

--- a/packages/groundcrew/src/lib/util.test.ts
+++ b/packages/groundcrew/src/lib/util.test.ts
@@ -1,6 +1,10 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { LinearClient } from "@linear/sdk";
 
-import { captureConsoleLog } from "../testHelpers/consoleCapture.ts";
+import { captureConsoleError, captureConsoleLog } from "../testHelpers/consoleCapture.ts";
 import { deleteEnvironmentVariable, setEnvironmentVariable } from "../testHelpers/env.ts";
 import {
   errorMessage,
@@ -8,6 +12,7 @@ import {
   log,
   logEvent,
   readEnvironmentVariable,
+  setLogFile,
   sleep,
 } from "./util.ts";
 
@@ -85,6 +90,85 @@ describe(logEvent, () => {
       'event=dispatch outcome=skipped reason=blocked blockers="TEAM-1:In Progress"',
     );
     consoleLog.restore();
+  });
+});
+
+describe(setLogFile, () => {
+  let temporary: string;
+
+  beforeEach(() => {
+    temporary = mkdtempSync(join(tmpdir(), "groundcrew-log-file-"));
+  });
+
+  afterEach(() => {
+    setLogFile(undefined);
+    rmSync(temporary, { recursive: true, force: true });
+  });
+
+  it("tees log() output to the configured file, creating the parent dir", () => {
+    const consoleLog = captureConsoleLog();
+    const path = join(temporary, "nested", "groundcrew.log");
+    setLogFile(path);
+
+    log("hello world");
+
+    expect(consoleLog.output()).toMatch(/^\[.+] hello world$/);
+    expect(readFileSync(path, "utf8")).toMatch(/^\[.+] hello world\n$/);
+    consoleLog.restore();
+  });
+
+  it("tees logEvent() output to the configured file", () => {
+    const consoleLog = captureConsoleLog();
+    const path = join(temporary, "events.log");
+    setLogFile(path);
+
+    logEvent("dispatch", { outcome: "started", ticket: "TEAM-1" });
+
+    expect(readFileSync(path, "utf8")).toBe("event=dispatch outcome=started ticket=TEAM-1\n");
+    consoleLog.restore();
+  });
+
+  it("appends successive writes to the same file", () => {
+    const consoleLog = captureConsoleLog();
+    const path = join(temporary, "events.log");
+    setLogFile(path);
+
+    logEvent("dispatch", { outcome: "started" });
+    logEvent("cleanup", { outcome: "workspace_closed" });
+
+    expect(readFileSync(path, "utf8")).toBe(
+      "event=dispatch outcome=started\nevent=cleanup outcome=workspace_closed\n",
+    );
+    consoleLog.restore();
+  });
+
+  it("does not write to disk when no log file has been set", () => {
+    const consoleLog = captureConsoleLog();
+    const path = join(temporary, "events.log");
+
+    logEvent("dispatch", { outcome: "started" });
+
+    expect(existsSync(path)).toBe(false);
+    consoleLog.restore();
+  });
+
+  it("disables file logging after a broken destination, warning once", () => {
+    const consoleLog = captureConsoleLog();
+    const consoleError = captureConsoleError();
+    // A path whose parent is an existing regular file — mkdir will throw.
+    const path = join(temporary, "events.log");
+    setLogFile(path);
+    logEvent("first", {});
+    setLogFile(join(path, "trapped.log"));
+
+    logEvent("second", {});
+    logEvent("third", {});
+
+    expect(consoleError.output()).toMatch(/disabling file logging/);
+    expect(consoleError.calls).toHaveLength(1);
+    expect(readFileSync(path, "utf8")).toBe("event=first\n");
+    consoleLog.restore();
+    consoleError.restore();
   });
 });
 

--- a/packages/groundcrew/src/lib/util.ts
+++ b/packages/groundcrew/src/lib/util.ts
@@ -1,3 +1,6 @@
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
 import { LinearClient } from "@linear/sdk";
 
 export async function sleep(ms: number, signal?: AbortSignal): Promise<void> {
@@ -38,9 +41,36 @@ export function clearOutput(): void {
   console.clear();
 }
 
+// Module-scoped sink for tee-ing log()/logEvent() to disk. Unset by default
+// so tests don't write to the host filesystem; the CLI arms it after
+// loadConfig() resolves `logging.file`.
+let logFilePath: string | undefined;
+
+export function setLogFile(path: string | undefined): void {
+  logFilePath = path;
+}
+
+function appendLogLine(line: string): void {
+  if (logFilePath === undefined) {
+    return;
+  }
+  try {
+    mkdirSync(dirname(logFilePath), { recursive: true });
+    appendFileSync(logFilePath, `${line}\n`);
+  } catch {
+    // A broken log destination must not crash the CLI. Stdout still has
+    // the line; surface the failure once so the user notices.
+    const broken = logFilePath;
+    logFilePath = undefined;
+    writeError(`groundcrew: disabling file logging — could not write to ${broken}`);
+  }
+}
+
 export function log(message: string): void {
   const timestamp = new Date().toLocaleTimeString();
-  writeOutput(`[${timestamp}] ${message}`);
+  const line = `[${timestamp}] ${message}`;
+  writeOutput(line);
+  appendLogLine(line);
 }
 
 type LogEventFieldValue = boolean | number | string | readonly string[] | undefined;
@@ -61,7 +91,9 @@ export function logEvent(event: string, fields: Record<string, LogEventFieldValu
     }
     parts.push(`${key}=${formatLogEventFieldValue(value)}`);
   }
-  writeOutput(parts.join(" "));
+  const line = parts.join(" ");
+  writeOutput(line);
+  appendLogLine(line);
 }
 
 export function readEnvironmentVariable(name: string): string | undefined {

--- a/packages/groundcrew/src/lib/workspaces.test.ts
+++ b/packages/groundcrew/src/lib/workspaces.test.ts
@@ -78,6 +78,7 @@ function makeConfig(workspaceKind: WorkspaceKindSetting = "auto"): ResolvedConfi
     },
     prompts: { initial: "x" },
     workspaceKind,
+    logging: { file: "/tmp/groundcrew-test.log" },
   };
 }
 

--- a/packages/groundcrew/src/lib/worktrees.test.ts
+++ b/packages/groundcrew/src/lib/worktrees.test.ts
@@ -73,6 +73,7 @@ function makeConfig(overrides: {
     models: { default: "claude", isolation: "auto", definitions: models },
     prompts: { initial: "x" },
     workspaceKind: "auto",
+    logging: { file: "/tmp/groundcrew-test.log" },
   };
 }
 

--- a/scripts/crewOp.mjs
+++ b/scripts/crewOp.mjs
@@ -7,18 +7,26 @@
 // with `--conditions @clipboard-health/source`, so cross-package
 // `@clipboard-health/*` imports resolve to TypeScript source.
 //
-// Override the env-file location via `GROUNDCREW_OP_ENV_FILE` (default
-// `.crew.1password.env` at the repo root).
+// The 1Password env-file path is fixed at
+// `${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/op.env`. Symlink there if
+// you keep yours elsewhere.
 
 import { spawn } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 const SHUTDOWN_EXIT_CODE = 130;
 const SIGTERM_EXIT_CODE = 143;
 const FORCE_KILL_SIGNAL = "SIGKILL";
 const FORCE_KILL_DELAY_MS = 5000;
 
-// oxlint-disable-next-line node/no-process-env -- the CLI is configured through env vars
-const envFile = process.env.GROUNDCREW_OP_ENV_FILE ?? ".crew.1password.env";
+// oxlint-disable-next-line node/no-process-env -- XDG base-directory lookup
+const xdgConfigHome = process.env.XDG_CONFIG_HOME;
+const configBase =
+  xdgConfigHome !== undefined && xdgConfigHome.length > 0
+    ? xdgConfigHome
+    : join(homedir(), ".config");
+const envFile = join(configBase, "groundcrew", "op.env");
 const args = process.argv.slice(2);
 const shouldUseProcessGroup = process.platform !== "win32" && args.includes("--watch");
 


### PR DESCRIPTION
## Why

A vanished `cmux` workspace was taking the log evidence with it because `log()` / `logEvent()` only wrote to stdout. The cleaner reaps a ticket's workspace as soon as the ticket hits a terminal status in Linear, so any failure that flips the ticket to Done/Cancelled (e.g., a setup error that the agent reports out) erases the only copy of the diagnostic output.

Now `log()` and `logEvent()` tee to `${XDG_STATE_HOME:-~/.local/state}/groundcrew/groundcrew.log` (override via `logging.file` in config) so the next "workspace vanished" is debuggable from the host.

While here, trimmed the env-var surface area:

- `GROUNDCREW_OP_ENV_FILE` (dev-only `crew:op` wrapper) — removed; path is hardcoded to `${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/op.env`. Symlink there if you keep yours elsewhere.
- `PROJECT_DIR` — removed. `workspace.projectDir` already lives in `config.ts`; the env shadow was dead weight.
- `GROUNDCREW_CONFIG` — kept as an override, but the new default looks up `${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/config.ts` before falling back to the package-root `config.ts`. Resolved path is logged on startup.

`LINEAR_API_KEY` stays as an env var — it's a secret, not configuration.

## Test plan

- [x] `node --run verify` — green (lint, format, knip, spell, markdown, syncpack, etc.)
- [x] `nx test groundcrew` — 538 tests pass; new coverage for setLogFile / file-tee, XDG config fallback, logging.file default + override + ~/ expansion
- [ ] Smoke-test on `rocky/groundcrew-log-persistence-and-xdg` worktree: run `node --run crew -- doctor` with the new XDG defaults; confirm logs land in `~/.local/state/groundcrew/groundcrew.log`

Agent session ID: claude-code 756be5b2-9497-4b88-abb6-266f50ddf9e7
<!-- commit-push-pr:created v1 core@3.4.0 -->