### PR TITLE
chore(groundcrew): tighten clearance allowlist

### DIFF
--- a/packages/groundcrew/clearance-allow-hosts
+++ b/packages/groundcrew/clearance-allow-hosts
@@ -11,7 +11,6 @@
 ab.chatgpt.com
 api.anthropic.com
 api.openai.com
-auth.openai.com
 chatgpt.com
 platform.claude.com
 
@@ -19,20 +18,19 @@ platform.claude.com
 api.linear.app
 api.notion.com
 api.slack.com
+developers.notion.com
 linear.app
 mcp.linear.app
 mcp.notion.com
 mcp.slack.com
 slack.com
 
-# Datadog (logs/metrics queries)
-*.datadoghq.com
+# Datadog (logs/metrics queries). No wildcard — blocks http-intake.logs.*.
 api.datadoghq.com
 app.datadoghq.com
 datadoghq.com
 
 # GitHub + GHA artifact storage (Azure blobs)
-*.githubusercontent.com
 api.github.com
 cafe.github.com
 github.com
@@ -56,6 +54,8 @@ productionresultssa16.blob.core.windows.net
 productionresultssa17.blob.core.windows.net
 productionresultssa18.blob.core.windows.net
 productionresultssa19.blob.core.windows.net
+raw.githubusercontent.com
+results-receiver.actions.githubusercontent.com
 
 # npm registry
 api.npmjs.org


### PR DESCRIPTION
## Why

The egress allowlist had two wildcards (`*.datadoghq.com`, `*.githubusercontent.com`) and several unused entries that broadened the agents' reach with no observed need. Audited every entry against `~/.cache/clearance/clearance.log` and tightened to what's actually used.

Concrete changes:
- `*.datadoghq.com` → keep specific hosts only. Blocks `http-intake.logs.us5.datadoghq.com` (which was the only non-API Datadog host being hit) while preserving `api.datadoghq.com` queries.
- `*.githubusercontent.com` → replaced with the two observed subdomains (`raw.`, `results-receiver.actions.`). Defense in depth; other GHC subdomains will DENY visibly and can be re-added.
- Removed `auth.openai.com` — never observed; agents authenticate via API keys, not the ChatGPT OAuth flow.
- Added `developers.notion.com` for Notion API docs lookups.

If anything legitimate gets denied post-merge it will show up in `clearance.log` for a one-line re-add.

Agent session ID: claude-code 85c872ec-fc58-4a2f-88d8-0a70b40a3ac4
<!-- commit-push-pr:created v1 core@3.4.0 -->