### PR TITLE
fix(ai-rules): tighten toErrorMessage comment wording

### DIFF
--- a/packages/ai-rules/scripts/toErrorMessage.ts
+++ b/packages/ai-rules/scripts/toErrorMessage.ts
@@ -1,4 +1,4 @@
-// Prefer stack over message for Error instances to preserve debugging context.
+// Prefer stack over message for Error instances to keep debugging context.
 export function toErrorMessage(error: unknown): string {
   return error instanceof Error ? (error.stack ?? error.message) : String(error);
 }


### PR DESCRIPTION
## Summary

Tiny wording tweak in the `toErrorMessage` comment to ship a `fix:` release of `@clipboard-health/ai-rules` and exercise the publish pipeline.

## Why

Trigger a patch release so the new ai-rules version flows downstream — no behavior change.

Agent session ID: claude-code ea464ae2-7407-4dfc-b741-c8aafe8a39d0
<!-- commit-push-pr:created v1 core@3.4.0 -->