### PR TITLE
chore(groundcrew): allow sourcegraph.clipboardhealth.{com,io}

### DIFF
--- a/packages/groundcrew/clearance-allow-hosts
+++ b/packages/groundcrew/clearance-allow-hosts
@@ -68,5 +68,7 @@ formulae.brew.sh
 hub.docker.com
 index.docker.io
 nx.dev
+sourcegraph.clipboardhealth.com
+sourcegraph.clipboardhealth.io
 sourcegraph.com
 vitest.dev


### PR DESCRIPTION
Self-hosted Sourcegraph instances at `sourcegraph.clipboardhealth.com` and `sourcegraph.clipboardhealth.io` need to be reachable from inside the groundcrew clearance allowlist so agents can search our private code via Sourcegraph just like they can on `sourcegraph.com`.

<!-- commit-push-pr:created v1 core@3.4.0 -->