### PR TITLE
feat(contract-core,util-ts): add nonEmptyArray helpers [ATD-409]

### DIFF
--- a/packages/contract-core/README.md
+++ b/packages/contract-core/README.md
@@ -85,6 +85,7 @@ import {
   commaSeparatedArray,
   dateTimeSchema,
   ENUM_FALLBACK,
+  nonEmptyArray,
   nonEmptyString,
   objectId,
   optionalEnum,
@@ -155,6 +156,21 @@ try {
 } catch (error) {
   logError(error);
   // => String must contain at least 1 character(s)
+}
+
+// Non-empty array examples
+// Output type is the tuple [T, ...T[]], so consumers get a type-level
+// non-empty guarantee (unlike nonEmptyString, which is runtime-only).
+const tagsSchema = nonEmptyArray(nonEmptyString);
+const tags = tagsSchema.parse(["red", "blue"]);
+// => ["red", "blue"], typed as [string, ...string[]]
+console.log(tags[0]); // string, not string | undefined
+
+try {
+  tagsSchema.parse([]);
+} catch (error) {
+  logError(error);
+  // => Array must contain at least 1 element(s)
 }
 
 // UUID validation examples

--- a/packages/contract-core/examples/schemas.ts
+++ b/packages/contract-core/examples/schemas.ts
@@ -5,6 +5,7 @@ import {
   commaSeparatedArray,
   dateTimeSchema,
   ENUM_FALLBACK,
+  nonEmptyArray,
   nonEmptyString,
   objectId,
   optionalEnum,
@@ -75,6 +76,21 @@ try {
 } catch (error) {
   logError(error);
   // => String must contain at least 1 character(s)
+}
+
+// Non-empty array examples
+// Output type is the tuple [T, ...T[]], so consumers get a type-level
+// non-empty guarantee (unlike nonEmptyString, which is runtime-only).
+const tagsSchema = nonEmptyArray(nonEmptyString);
+const tags = tagsSchema.parse(["red", "blue"]);
+// => ["red", "blue"], typed as [string, ...string[]]
+console.log(tags[0]); // string, not string | undefined
+
+try {
+  tagsSchema.parse([]);
+} catch (error) {
+  logError(error);
+  // => Array must contain at least 1 element(s)
 }
 
 // UUID validation examples

--- a/packages/contract-core/src/lib/schemas/index.ts
+++ b/packages/contract-core/src/lib/schemas/index.ts
@@ -4,6 +4,7 @@ export * from "./commaSeparatedArray";
 export * from "./dateTime";
 export * from "./enum";
 export * from "./money";
+export * from "./nonEmptyArray";
 export * from "./nonEmptyString";
 export * from "./objectId";
 export * from "./uuid";

--- a/packages/contract-core/src/lib/schemas/nonEmptyArray.test.ts
+++ b/packages/contract-core/src/lib/schemas/nonEmptyArray.test.ts
@@ -1,0 +1,73 @@
+import {
+  expectToBeSafeParseError,
+  expectToBeSafeParseSuccess,
+} from "@clipboard-health/testing-core";
+import { z } from "zod";
+
+import { nonEmptyArray } from "./nonEmptyArray";
+
+describe("nonEmptyArray.safeParse", () => {
+  const schema = nonEmptyArray(z.string());
+
+  describe("success cases", () => {
+    it.each<{ input: string[]; name: string }>([
+      { name: "accepts single-element array", input: ["a"] },
+      { name: "accepts multi-element array", input: ["a", "b", "c"] },
+    ])("$name", ({ input }) => {
+      const actual = schema.safeParse(input);
+
+      expectToBeSafeParseSuccess(actual);
+      expect(actual.data).toStrictEqual(input);
+    });
+  });
+
+  describe("error cases", () => {
+    it.each<{ expectedError: string; input: unknown; name: string }>([
+      {
+        name: "rejects empty array",
+        input: [],
+        expectedError: "Array must contain at least 1 element(s)",
+      },
+      {
+        name: "rejects non-array input (string)",
+        input: "a",
+        expectedError: "Expected array, received string",
+      },
+      {
+        name: "rejects non-array input (number)",
+        input: 1,
+        expectedError: "Expected array, received number",
+      },
+      {
+        name: "rejects non-array input (undefined)",
+        input: undefined,
+        expectedError: "Required",
+      },
+    ])("$name", ({ input, expectedError }) => {
+      const actual = schema.safeParse(input);
+
+      expectToBeSafeParseError(actual);
+      expect(actual.error.message).toContain(expectedError);
+    });
+
+    it("rejects array with element failing inner schema", () => {
+      const actual = schema.safeParse(["a", 1]);
+
+      expectToBeSafeParseError(actual);
+      expect(actual.error.message).toContain("Expected string, received number");
+    });
+  });
+});
+
+describe("nonEmptyArray type", () => {
+  it("infers output as a non-empty tuple", () => {
+    const schema = nonEmptyArray(z.string());
+    type Output = z.output<typeof schema>;
+
+    const value: Output = ["a"];
+    const [first] = value;
+    const firstString: string = first;
+
+    expect(firstString).toBe("a");
+  });
+});

--- a/packages/contract-core/src/lib/schemas/nonEmptyArray.test.ts
+++ b/packages/contract-core/src/lib/schemas/nonEmptyArray.test.ts
@@ -60,12 +60,9 @@ describe("nonEmptyArray.safeParse", () => {
 });
 
 describe("nonEmptyArray type", () => {
-  it("infers output as a non-empty tuple", () => {
-    const schema = nonEmptyArray(z.string());
-    type Output = z.output<typeof schema>;
-
-    const value: Output = ["a"];
-    const [first] = value;
+  it("infers parse output as a non-empty tuple", () => {
+    const parsed = nonEmptyArray(z.string()).parse(["a"]);
+    const [first] = parsed;
     const firstString: string = first;
 
     expect(firstString).toBe("a");

--- a/packages/contract-core/src/lib/schemas/nonEmptyArray.ts
+++ b/packages/contract-core/src/lib/schemas/nonEmptyArray.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+/**
+ * A non-empty array Zod schema.
+ *
+ * Output type resolves to `[z.output<T>, ...Array<z.output<T>>]`, giving consumers a
+ * type-level guarantee that the array contains at least one element.
+ *
+ * Unlike `nonEmptyString`, which is runtime-only (TypeScript has no structural
+ * "non-empty string" type without branding), this helper provides a real
+ * type-level non-empty guarantee that pairs naturally with `isNonEmptyArray`
+ * from `@clipboard-health/util-ts`.
+ *
+ * @example
+ * const tagsSchema = nonEmptyArray(z.string());
+ * type Tags = z.output<typeof tagsSchema>; // [string, ...string[]]
+ */
+export function nonEmptyArray<T extends z.ZodTypeAny>(schema: T) {
+  return z.array(schema).nonempty();
+}

--- a/packages/contract-core/src/lib/schemas/nonEmptyString.ts
+++ b/packages/contract-core/src/lib/schemas/nonEmptyString.ts
@@ -2,5 +2,10 @@ import { z } from "zod";
 
 /**
  * A non-empty string Zod schema.
+ *
+ * Runtime-only: the output type remains `string`. TypeScript has no structural
+ * "non-empty string" type without branding, so non-emptiness cannot be carried
+ * through the type system. Contrast with `nonEmptyArray`, which produces a
+ * tuple type `[T, ...T[]]` that does encode non-emptiness.
  */
 export const nonEmptyString = z.string().min(1);

--- a/packages/util-ts/src/lib/arrays/nonEmptyArray.test.ts
+++ b/packages/util-ts/src/lib/arrays/nonEmptyArray.test.ts
@@ -1,6 +1,6 @@
 import { type NonEmptyArray, type OneOrNonEmptyArray, toNonEmptyArray } from "./nonEmptyArray";
 
-describe("[deprecated] NonEmptyArray", () => {
+describe("NonEmptyArray type", () => {
   it("should allow creation of a non-empty array", () => {
     const array: NonEmptyArray<number> = [1, 2, 3];
     expect(array).toStrictEqual([1, 2, 3]);
@@ -19,7 +19,7 @@ describe("[deprecated] OneOrNonEmptyArray", () => {
   });
 });
 
-describe("[deprecated] toNonEmptyArray", () => {
+describe(toNonEmptyArray, () => {
   it("should convert a single value to a non-empty array", () => {
     const result = toNonEmptyArray(5);
     expect(result).toStrictEqual([5]);

--- a/packages/util-ts/src/lib/arrays/nonEmptyArray.ts
+++ b/packages/util-ts/src/lib/arrays/nonEmptyArray.ts
@@ -1,16 +1,36 @@
 /**
- * @deprecated Use standard Array<T> instead.
+ * A tuple type that guarantees at least one element at the type level.
+ *
+ * Use when callers need a type-level non-empty guarantee — for example, after
+ * narrowing with `isNonEmptyArray`, TypeScript will type the first element as
+ * `T` rather than `T | undefined`.
+ *
+ * Unlike `nonEmptyString` in `@clipboard-health/contract-core`, which is
+ * runtime-only because TypeScript has no structural "non-empty string" type
+ * without branding, `NonEmptyArray` does encode non-emptiness in the type
+ * system as `[T, ...T[]]`.
+ *
+ * @example
+ * if (!isNonEmptyArray(items)) {
+ *   return;
+ * }
+ * // items is now NonEmptyArray<T>, and items[0] is T (not T | undefined)
  */
 export type NonEmptyArray<T> = [T, ...T[]];
 
 /**
- * @deprecated Use @{link OneOrArray} instead.
+ * @deprecated Use `OneOrArray<T>` from "./head" instead. The "loose input"
+ * pattern (`T | T[]`) is the common use case; if a non-empty guarantee is
+ * required on the array branch, prefer `T | NonEmptyArray<T>` inline.
  */
 export type OneOrNonEmptyArray<T> = T | NonEmptyArray<T>;
 
 /**
- * @deprecated Use standard Array<T> instead.
+ * Normalizes a single value or an array into a `NonEmptyArray<T>`.
+ *
+ * Useful when accepting loose input (`T | T[]`) at an API boundary and needing
+ * to hand downstream code a value typed as non-empty.
  */
-export function toNonEmptyArray<T>(value: OneOrNonEmptyArray<T>): NonEmptyArray<T> {
+export function toNonEmptyArray<T>(value: T | NonEmptyArray<T>): NonEmptyArray<T> {
   return Array.isArray(value) ? value : [value];
 }


### PR DESCRIPTION
## Summary

- Add `nonEmptyArray(schema)` to `@clipboard-health/contract-core`, returning `z.array(schema).nonempty()` so the output type is the tuple `[T, ...T[]]` and consumers get a real type-level non-empty guarantee.
- Un-deprecate `NonEmptyArray<T>` and `toNonEmptyArray` in `@clipboard-health/util-ts`. The `@deprecated` markers were ported in from a prior package without any documented technical justification and were already getting in the way (PR #360 hit exactly the problem `NonEmptyArray<T>` was designed to solve). `OneOrNonEmptyArray<T>` stays deprecated — `OneOrArray<T>` covers the "accept loose input" pattern, and callers needing non-emptiness on the array branch can write `T | NonEmptyArray<T>` inline.
- Added a JSDoc note on `nonEmptyString` explaining the asymmetry: there's no equivalent type-level trick for non-empty strings (no structural "non-empty string" type in TS without branding).

Linear: [ATD-409](https://linear.app/clipboardhealth/issue/ATD-409/add-nonemptyarray-zod-schema-to-contract-core-and-nonemptyarray) (parent: ATD-179 contract consolidation)

## Test plan

- [x] `node --run verify` passes
- [x] `nx test contract-core` passes — new `nonEmptyArray.test.ts` covers single/multi-element accept, empty/non-array reject, inner-schema failure, and a type-level tuple assertion
- [x] `nx test util-ts` passes — `nonEmptyArray.test.ts` updated to drop `[deprecated]` prefixes on un-deprecated entries; `OneOrNonEmptyArray` block keeps its `[deprecated]` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)