### PR TITLE
fix(groundcrew): list nested worktrees when knownRepositories contains a slash

### DIFF
--- a/packages/groundcrew/src/lib/worktrees.test.ts
+++ b/packages/groundcrew/src/lib/worktrees.test.ts
@@ -167,6 +167,54 @@ describe(list, () => {
     expect(list(config)).toStrictEqual([]);
   });
 
+  it("finds nested host worktrees when knownRepositories contains <owner>/<repo>", () => {
+    // `resolve(projectDir, "owner/repo-team-1")` produces a path one level
+    // deeper than `projectDir`, so the worktree lives at
+    // `projectDir/owner/repo-team-1`. list() has to scan the parent dir,
+    // not the project root, to find it.
+    mkdirSync(join(projectDir, "owner", "repo"), { recursive: true });
+    mkdirSync(join(projectDir, "owner", "repo-team-1"));
+    const config = makeConfig({ projectDir, knownRepositories: ["owner/repo"] });
+
+    expect(list(config)).toStrictEqual([
+      {
+        repository: "owner/repo",
+        ticket: "team-1",
+        branchName: "rocky-team-1",
+        dir: join(projectDir, "owner", "repo-team-1"),
+        kind: "host",
+      },
+    ]);
+  });
+
+  it("disambiguates same-basename repos across owners by parent dir", () => {
+    // Two owners with a same-named repo. The worktree at
+    // owner1/repo-team-1 must resolve to owner1/repo, not owner2/repo.
+    mkdirSync(join(projectDir, "owner1", "repo-team-1"), { recursive: true });
+    mkdirSync(join(projectDir, "owner2", "repo-team-2"), { recursive: true });
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["owner1/repo", "owner2/repo"],
+    });
+
+    expect(list(config).toSorted((a, b) => a.ticket.localeCompare(b.ticket))).toStrictEqual([
+      {
+        repository: "owner1/repo",
+        ticket: "team-1",
+        branchName: "rocky-team-1",
+        dir: join(projectDir, "owner1", "repo-team-1"),
+        kind: "host",
+      },
+      {
+        repository: "owner2/repo",
+        ticket: "team-2",
+        branchName: "rocky-team-2",
+        dir: join(projectDir, "owner2", "repo-team-2"),
+        kind: "host",
+      },
+    ]);
+  });
+
   it("ignores legacy .sbx worktree directories", () => {
     const repoDir = join(projectDir, "repo-a");
     const sandboxRoot = join(repoDir, ".sbx", "groundcrew-repo-a-claude-worktrees");

--- a/packages/groundcrew/src/lib/worktrees.ts
+++ b/packages/groundcrew/src/lib/worktrees.ts
@@ -187,35 +187,57 @@ const hostWorktreeAdapter: WorktreeAdapter = {
     const projectDir = resolve(config.workspace.projectDir);
     const entries: WorktreeEntry[] = [];
 
-    let projectChildren: Dirent[];
-    try {
-      projectChildren = readdirSync(projectDir, { withFileTypes: true });
-    } catch {
-      projectChildren = [];
+    // Worktrees live at `projectDir/<repository>-<ticket>`. When `repository`
+    // contains a slash (e.g. "owner/repo"), `resolve()` nests one level
+    // deeper, so the worktree path is `projectDir/owner/repo-<ticket>`.
+    // Scan each known repository's parent directory rather than the project
+    // root, so nested worktrees are discovered alongside bare ones.
+    const reposByParent = new Map<string, Map<string, string>>();
+    for (const repository of config.workspace.knownRepositories) {
+      const lastSlash = repository.lastIndexOf("/");
+      const parentDir =
+        lastSlash === -1 ? projectDir : resolve(projectDir, repository.slice(0, lastSlash));
+      const basename = lastSlash === -1 ? repository : repository.slice(lastSlash + 1);
+      let repoByBasename = reposByParent.get(parentDir);
+      if (repoByBasename === undefined) {
+        repoByBasename = new Map();
+        reposByParent.set(parentDir, repoByBasename);
+      }
+      repoByBasename.set(basename, repository);
     }
-    for (const entry of projectChildren) {
-      if (!entry.isDirectory()) {
-        continue;
+
+    for (const [parentDir, repoByBasename] of reposByParent) {
+      let children: Dirent[];
+      try {
+        children = readdirSync(parentDir, { withFileTypes: true });
+      } catch {
+        children = [];
       }
-      const match = TICKET_DIR_RE.exec(entry.name);
-      if (!match) {
-        continue;
+      for (const entry of children) {
+        if (!entry.isDirectory()) {
+          continue;
+        }
+        const match = TICKET_DIR_RE.exec(entry.name);
+        if (!match) {
+          continue;
+        }
+        const [, repoBasename, ticket] = match;
+        /* v8 ignore next 3 @preserve -- TICKET_DIR_RE always captures both groups when it matches */
+        if (repoBasename === undefined || ticket === undefined) {
+          continue;
+        }
+        const repository = repoByBasename.get(repoBasename);
+        if (repository === undefined) {
+          continue;
+        }
+        entries.push({
+          repository,
+          ticket,
+          branchName: branchNameForTicket(ticket),
+          dir: resolve(parentDir, entry.name),
+          kind: "host",
+        });
       }
-      const [, repository, ticket] = match;
-      /* v8 ignore next 3 @preserve -- TICKET_DIR_RE always captures both groups when it matches */
-      if (repository === undefined || ticket === undefined) {
-        continue;
-      }
-      if (!config.workspace.knownRepositories.includes(repository)) {
-        continue;
-      }
-      entries.push({
-        repository,
-        ticket,
-        branchName: branchNameForTicket(ticket),
-        dir: resolve(projectDir, entry.name),
-        kind: "host",
-      });
     }
 
     return entries;


### PR DESCRIPTION
## Summary

`crew cleanup <ticket>` reports "No worktree found" and the orchestrator can't detect existing worktrees when a `workspace.knownRepositories` entry contains a slash (e.g. `"owner/repo"`).

## Why this happens

`hostWorktreeAdapter.create()` resolves the worktree path as:

```ts
const hostWorktreeName = `${repository}-${ticket}`;
const hostWorktreeDir = resolve(projectDir, hostWorktreeName);
```

When `repository` contains a slash, `resolve()` produces a **nested** path — for `repository = "owner/repo"` and `ticket = "team-1"`, the worktree lands at `projectDir/owner/repo-team-1`.

But `hostWorktreeAdapter.list()` did a **non-recursive** `readdirSync(projectDir)`, so it only ever saw the top-level `owner/` directory (which doesn't match `TICKET_DIR_RE`). The nested worktree was invisible to:

- `crew cleanup` — "No worktree found, nothing to clean up"
- The dispatcher's existing-worktree detection on subsequent ticks
- Any code that iterates `worktrees.list(config)`

## Fix

Rewrite `list()` to enumerate based on `knownRepositories` rather than blindly walking `projectDir`:

1. Group known repositories by their parent dir under `projectDir`:
   - `"owner/repo"` → parent `projectDir/owner`, expected basename `repo`
   - `"bare-repo"` → parent `projectDir`, expected basename `bare-repo`
2. Scan each parent dir once for `<basename>-<ticket>` matches.
3. Map back to the full repository entry when constructing the `WorktreeEntry`.

Bare-repo behavior is unchanged; slashed-repo nested worktrees are now discovered.

## Tests

Two new test cases in `worktrees.test.ts` (`describe(list)`):

- **"finds nested host worktrees when knownRepositories contains <owner>/<repo>"** — direct regression for the bug.
- **"disambiguates same-basename repos across owners by parent dir"** — confirms `owner1/repo` and `owner2/repo` are correctly attributed.

Full package test suite: 545/545 passing. `node --run verify` clean.

## How I hit this

Triggered while running `crew run` against a Linear project with `knownRepositories: ["herds-social/herds"]`. groundcrew created the worktree successfully, the dispatch failed downstream for an unrelated reason (missing global `@clipboard-health/clearance` install — separate issue), and `crew cleanup` couldn't find the orphan to tear it down.

## Test plan

- [x] New tests cover the nested-discovery and same-basename cases
- [x] Existing worktree tests still pass (no behavior change for bare repos)
- [x] `node --run verify` passes locally
- [x] Manually verified against a real `owner/repo` setup — `crew cleanup` now removes the orphan correctly
