### PR TITLE
fix(groundcrew): resolve safehouse-clearance via Node module resolution

### DIFF
--- a/packages/groundcrew/src/lib/launchCommand.test.ts
+++ b/packages/groundcrew/src/lib/launchCommand.test.ts
@@ -1,5 +1,11 @@
+import { statSync } from "node:fs";
+
 import { DEFAULT_REMOTE_SETUP_COMMAND, type ModelDefinition } from "./config.ts";
-import { buildLaunchCommand, buildRemoteLaunchCommand } from "./launchCommand.ts";
+import {
+  buildLaunchCommand,
+  buildRemoteLaunchCommand,
+  resolveSafehouseClearancePath,
+} from "./launchCommand.ts";
 import { spriteRemoteRunnerProvider } from "./spriteRemoteRunnerProvider.ts";
 
 const REMOTE_SECRET_NAMES = ["NPM_TOKEN", "BUF_TOKEN"] as const;
@@ -42,6 +48,24 @@ function decodedSpriteRemoteCommand(command: string): string {
   expect(matches).toHaveLength(1);
   return Buffer.from(matches[0]?.[0] ?? "", "base64").toString("utf8");
 }
+
+describe(resolveSafehouseClearancePath, () => {
+  it("resolves through Node module resolution to the real safehouse-clearance file", () => {
+    const wrapperPath = resolveSafehouseClearancePath();
+
+    expect(wrapperPath).toMatch(/clearance\/safehouse\/safehouse-clearance$/);
+    expect(statSync(wrapperPath).isFile()).toBe(true);
+  });
+
+  it("wraps resolution failure in a guidance error naming clearance and groundcrew", () => {
+    // A non-absolute, non-file-URL baseUrl makes `createRequire` itself throw
+    // ERR_INVALID_ARG_VALUE before any node_modules walk, so this assertion is
+    // deterministic regardless of globalPaths, NODE_PATH, or $HOME/.node_modules.
+    expect(() => resolveSafehouseClearancePath("relative/path/that/createRequire/rejects")).toThrow(
+      /@clipboard-health\/clearance.*groundcrew/,
+    );
+  });
+});
 
 describe(buildLaunchCommand, () => {
   it("keeps the default remote setup command valid for shell control flow", () => {

--- a/packages/groundcrew/src/lib/launchCommand.ts
+++ b/packages/groundcrew/src/lib/launchCommand.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer";
+import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
 
 import {
@@ -13,15 +14,33 @@ import type { RemoteRunnerProvider } from "./spriteRemoteRunnerProvider.ts";
 
 export { shellSingleQuote } from "./shell.ts";
 
-// import.meta.dirname is `<groundcrew>/{src,dist}/lib`; the shipped Safehouse
-// proxy wrapper lives in the sibling clearance package.
-const PACKAGES_ROOT = resolve(import.meta.dirname, "..", "..", "..");
-const SAFEHOUSE_CLEARANCE_WRAPPER_PATH = resolve(
-  PACKAGES_ROOT,
-  "clearance",
-  "safehouse",
-  "safehouse-clearance",
-);
+/**
+ * Resolve the shipped Safehouse proxy wrapper inside `@clipboard-health/clearance`
+ * via Node's module-resolution algorithm so the path works whether npm hoists
+ * clearance as a sibling of groundcrew or nests it under
+ * `groundcrew/node_modules/@clipboard-health/clearance`.
+ *
+ * @param baseUrl - **Test-only seam.** Production callers must omit this so the
+ *   helper resolves from this module's URL. Tests pass an invalid value to
+ *   exercise the catch branch.
+ */
+export function resolveSafehouseClearancePath(baseUrl: string = import.meta.url): string {
+  let clearancePackageJson: string;
+  try {
+    clearancePackageJson = createRequire(baseUrl).resolve(
+      "@clipboard-health/clearance/package.json",
+    );
+  } catch (error) {
+    throw new Error(
+      "@clipboard-health/clearance is required by @clipboard-health/groundcrew but could not be resolved. " +
+        "Install it alongside groundcrew (for example: `npm install -g @clipboard-health/clearance`).",
+      { cause: error },
+    );
+  }
+  return resolve(dirname(clearancePackageJson), "safehouse", "safehouse-clearance");
+}
+
+const SAFEHOUSE_CLEARANCE_WRAPPER_PATH = resolveSafehouseClearancePath();
 
 function renderAgentCommand(arguments_: { agentCmd: string; worktreeDir: string }): string {
   return arguments_.agentCmd


### PR DESCRIPTION
## Summary

First-time installs of `@clipboard-health/groundcrew` were failing at the first `crew run` because the Safehouse wrapper path was computed by walking `..` from `import.meta.dirname` — implicitly assuming `@clipboard-health/clearance` is installed as a *sibling* of groundcrew under the same `node_modules` parent. When npm nests clearance under `groundcrew/node_modules/@clipboard-health/clearance/...` instead of hoisting it (which it does for a fresh global install in many environments), the sibling-walk lands on a non-existent path and the tmux pane dies with `no such file or directory: …/clearance/safehouse/safehouse-clearance` before the user can see it.

Switch to `createRequire(import.meta.url).resolve("@clipboard-health/clearance/package.json")` so the path is derived from Node's module-resolution algorithm — works under both hoisted and nested layouts. Wrap the resolver call so a missing `clearance` surfaces a friendly error naming both packages and the install command, rather than the default `ERR_MODULE_NOT_FOUND` stack.

## Validation

- `node --run verify` — passes (all 9 checks).
- `npx nx test groundcrew --coverage` — 100% stmts/branches/funcs/lines; new tests cover both the happy path (resolution lands on a real file) and the catch branch (friendly error rethrown).
- `npx nx build groundcrew` — passes.
- Manual probe of `createRequire("relative/path").resolve(...)` confirmed it throws `ERR_INVALID_ARG_VALUE` synchronously, regardless of `globalPaths` / `NODE_PATH` — making the negative test deterministic across machines.

## Notes

- Source: item #1 in the install-walkthrough follow-up plan (linked symptom is the first-run `crew run` failure inside the tmux pane).
- Out of scope (per the plan): adding `peerDependencies: { "@clipboard-health/clearance": "..." }` on groundcrew so npm warns instead of silently nesting. Worth a separate small PR.
- The helper exports a `baseUrl` parameter that's intentionally test-only (annotated `@internal` in the JSDoc). Production callers must omit it.

Agent session: claude --resume 177de1a7-00d1-467a-83ec-65a1a7c52f23
<!-- commit-push-pr:created v1 core@3.4.0 -->