### PR TITLE
feat(groundcrew): disable shipped model defaults via per-model flag

### DIFF
--- a/docs/superpowers/plans/2026-05-17-groundcrew-disable-shipped-model.md
+++ b/docs/superpowers/plans/2026-05-17-groundcrew-disable-shipped-model.md
@@ -1,0 +1,723 @@
+# Groundcrew — Disable a shipped default model — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a per-model `disabled: true` knob to `models.definitions` that removes a shipped default from the resolved config, so `crew doctor` stops probing for the disabled model's CLI.
+
+**Architecture:** Filter at the merge boundary (`mergeDefinitions` in `packages/groundcrew/src/lib/config.ts`). Disabled entries are stripped from the resolved `Record<string, ModelDefinition>`, so every downstream consumer (`doctor`, `eligibility`, `boardSource`, `setupWorkspace`, `usage`) becomes correct without any consumer-side code change. Three loud-failure validation cases: `disabled` combined with `cmd`/`color`/`usage`, `disabled` on a non-shipped key, and `models.default` pointing at a disabled model.
+
+**Tech Stack:** TypeScript, Node, Vitest, nx (workspace runner), oxlint, oxfmt.
+
+**Spec:** `docs/superpowers/specs/2026-05-17-groundcrew-disable-shipped-model-design.md`
+
+---
+
+## File Structure
+
+All production code in one file, tests in three:
+
+- **Modify:** `packages/groundcrew/src/lib/config.ts`
+  - Add `disabled?: boolean` to `UserModelDefinition` (line 77).
+  - Extend `failIfLegacyModelKeys` (line 464) with shape rule + combined-fields rule.
+  - Extend `mergeDefinitions` (line 483) with filter logic + typo guard.
+  - Extend `applyDefaults` (line 544) with the default-points-at-disabled check.
+
+- **Modify:** `packages/groundcrew/src/lib/config.test.ts` — primary test surface (Tasks 1–3).
+
+- **Modify:** `packages/groundcrew/src/commands/doctor.test.ts` — regression-guard test that disabled models aren't probed (Task 4).
+
+- **Modify:** `packages/groundcrew/src/lib/boardSource.test.ts` — regression-guard test that `agent-codex` labels fall back to `models.default` when codex is disabled (Task 4).
+
+- **Modify:** `packages/groundcrew/README.md` — add a `disabled` snippet under the existing Models guidance and update the Gotchas section (Task 5).
+
+---
+
+## Conventions used by this codebase
+
+- **Test runner.** Vitest via nx. Per-file: `node --run -- nx test groundcrew -- src/lib/config.test.ts`. By name filter: append `-t "<test name fragment>"`. (If `nx` isn't on PATH, `npx nx test groundcrew -- …` also works.)
+- **Test fixture style for `config.test.ts`.** Tests write a temp `config.ts` file via the `writeConfigFile()` + `configSource()` / hand-written-string helpers already in the file, point `GROUNDCREW_CONFIG` at it via `setEnvironmentVariable`, then call `loadFreshConfig()` → `loadConfig()`. Reuse `VALID_LINEAR`, `VALID_WORKSPACE(temporary)`.
+- **Test naming.** Existing tests use phrases like `"rejects legacy …"`, `"merges per-key overrides …"`. Match that voice.
+- **Error matching.** Existing tests use `await expect(loadConfig()).rejects.toThrow(/regex/)`. Escape regex metacharacters when matching backticks or parens.
+
+---
+
+## Task 1: Input shape validation — `disabled` field type, shape rule, combined-fields rule
+
+**Files:**
+
+- Modify: `packages/groundcrew/src/lib/config.ts:77` (the `UserModelDefinition` type)
+- Modify: `packages/groundcrew/src/lib/config.ts:464-481` (`failIfLegacyModelKeys`)
+- Modify: `packages/groundcrew/src/lib/config.test.ts` (append new `it` blocks alongside the existing legacy-rejection tests around line 423)
+
+### Step 1.1: Write the first failing test (shape rule: `disabled: false`)
+
+Append this test to `packages/groundcrew/src/lib/config.test.ts` immediately after the existing `"rejects legacy per-model sandbox config"` test (around line 459):
+
+```ts
+it("rejects `disabled: false` on a model definition", async () => {
+  const path = writeConfigFile(temporary, ["export const config = {", `  linear: ${JSON.stringify(VALID_LINEAR)},`, `  workspace: ${JSON.stringify(VALID_WORKSPACE(temporary))},`, "  models: { definitions: { codex: { disabled: false } } },", "};"].join("\n"));
+  setEnvironmentVariable("GROUNDCREW_CONFIG", path);
+
+  const { loadConfig } = await loadFreshConfig();
+
+  await expect(loadConfig()).rejects.toThrow(/models\.definitions\.codex\.disabled must be exactly `true` when set/);
+});
+```
+
+- [ ] **Step 1.2: Run the test, confirm it fails**
+
+```bash
+node --run -- nx test groundcrew -- src/lib/config.test.ts -t "rejects \`disabled: false\`"
+```
+
+Expected: FAIL. The error path doesn't yet exist; either the test config will load successfully or a different error will fire.
+
+- [ ] **Step 1.3: Extend the `UserModelDefinition` type**
+
+Change `packages/groundcrew/src/lib/config.ts:77` from:
+
+```ts
+type UserModelDefinition = Partial<ModelDefinition>;
+```
+
+to:
+
+```ts
+type UserModelDefinition = Partial<ModelDefinition> & { disabled?: boolean };
+```
+
+- [ ] **Step 1.4: Extend `failIfLegacyModelKeys` with the shape rule**
+
+Replace `packages/groundcrew/src/lib/config.ts:464-481` (the entire `failIfLegacyModelKeys` function) with:
+
+```ts
+function failIfLegacyModelKeys(name: string, override: unknown): asserts override is UserModelDefinition {
+  if (!isPlainObject(override)) {
+    fail(`models.definitions.${name} must be an object`);
+  }
+  if (Object.hasOwn(override, "isolation")) {
+    fail(`models.definitions.${name}.isolation is no longer supported: per-model isolation is no longer supported`);
+  }
+  if (Object.hasOwn(override, "sandbox")) {
+    fail(`models.definitions.${name}.sandbox is no longer supported: Docker Sandboxes are no longer supported`);
+  }
+  if (Object.hasOwn(override, "disabled")) {
+    if (override.disabled !== true) {
+      fail(`models.definitions.${name}.disabled must be exactly \`true\` when set (got ${JSON.stringify(override.disabled)})`);
+    }
+    const conflicting = (["cmd", "color", "usage"] as const).filter((key) => Object.hasOwn(override, key));
+    if (conflicting.length > 0) {
+      fail(`models.definitions.${name}: cannot combine \`disabled: true\` with other fields (${conflicting.join(", ")}). Either disable the model or override its fields, not both.`);
+    }
+  }
+}
+```
+
+- [ ] **Step 1.5: Run the failing test, confirm it now passes**
+
+```bash
+node --run -- nx test groundcrew -- src/lib/config.test.ts -t "rejects \`disabled: false\`"
+```
+
+Expected: PASS.
+
+- [ ] **Step 1.6: Add a test for non-boolean `disabled` (e.g. `"true"` string)**
+
+Append to `packages/groundcrew/src/lib/config.test.ts`:
+
+```ts
+it('rejects a non-boolean `disabled` value (e.g. the string "true")', async () => {
+  const path = writeConfigFile(temporary, ["export const config = {", `  linear: ${JSON.stringify(VALID_LINEAR)},`, `  workspace: ${JSON.stringify(VALID_WORKSPACE(temporary))},`, '  models: { definitions: { codex: { disabled: "true" } } },', "};"].join("\n"));
+  setEnvironmentVariable("GROUNDCREW_CONFIG", path);
+
+  const { loadConfig } = await loadFreshConfig();
+
+  await expect(loadConfig()).rejects.toThrow(/models\.definitions\.codex\.disabled must be exactly `true` when set/);
+});
+```
+
+- [ ] **Step 1.7: Run, confirm it passes (same code path)**
+
+```bash
+node --run -- nx test groundcrew -- src/lib/config.test.ts -t "non-boolean"
+```
+
+Expected: PASS.
+
+- [ ] **Step 1.8: Write a failing test for the combined-fields rule**
+
+Append to `packages/groundcrew/src/lib/config.test.ts`:
+
+```ts
+it("rejects `disabled: true` combined with other fields (cmd / color / usage)", async () => {
+  const path = writeConfigFile(temporary, ["export const config = {", `  linear: ${JSON.stringify(VALID_LINEAR)},`, `  workspace: ${JSON.stringify(VALID_WORKSPACE(temporary))},`, "  models: { definitions: { codex: { disabled: true, cmd: 'override' } } },", "};"].join("\n"));
+  setEnvironmentVariable("GROUNDCREW_CONFIG", path);
+
+  const { loadConfig } = await loadFreshConfig();
+
+  await expect(loadConfig()).rejects.toThrow(/models\.definitions\.codex: cannot combine `disabled: true` with other fields \(cmd\)/);
+});
+```
+
+- [ ] **Step 1.9: Run, confirm it passes (the combined-fields branch in Step 1.4 already covers this)**
+
+```bash
+node --run -- nx test groundcrew -- src/lib/config.test.ts -t "cannot combine"
+```
+
+Expected: PASS.
+
+- [ ] **Step 1.10: Run the full config.test.ts suite to confirm nothing else broke**
+
+```bash
+node --run -- nx test groundcrew -- src/lib/config.test.ts
+```
+
+Expected: PASS (all original tests + 3 new ones).
+
+- [ ] **Step 1.11: Commit**
+
+```bash
+git add packages/groundcrew/src/lib/config.ts packages/groundcrew/src/lib/config.test.ts
+git commit -m "$(cat <<'EOF'
+feat(groundcrew): add `disabled` field shape rules to model definitions
+
+Adds the `disabled?: boolean` field to UserModelDefinition and extends
+failIfLegacyModelKeys with two validation rules:
+
+  1. `disabled`, when present, must be exactly `true` (not falsy, not
+     truthy strings/numbers — strictly boolean true-or-absent).
+  2. `disabled: true` cannot be combined with cmd/color/usage; the user
+     must express one operation per entry.
+
+Part of groundcrew #4B (disable-shipped-default-model). No behavior
+change yet: the filter logic that removes disabled entries from the
+resolved config lands in the next commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Merge-time filter — drop disabled entries + typo guard
+
+**Files:**
+
+- Modify: `packages/groundcrew/src/lib/config.ts:483-525` (`mergeDefinitions`)
+- Modify: `packages/groundcrew/src/lib/config.test.ts` (append two more `it` blocks)
+
+### Step 2.1: Write the happy-path failing test (codex disabled → absent from resolved)
+
+Append to `packages/groundcrew/src/lib/config.test.ts`, near the existing `"merges per-key overrides"` test (around line 365):
+
+```ts
+it("drops a shipped default when `disabled: true` is set", async () => {
+  const path = writeConfigFile(
+    temporary,
+    configSource({
+      linear: { ...VALID_LINEAR },
+      workspace: VALID_WORKSPACE(temporary),
+      models: {
+        definitions: {
+          codex: { disabled: true },
+        },
+      },
+    }),
+  );
+  setEnvironmentVariable("GROUNDCREW_CONFIG", path);
+
+  const { loadConfig } = await loadFreshConfig();
+  const actual = await loadConfig();
+
+  expect(Object.keys(actual.models.definitions).toSorted()).toStrictEqual(["claude"]);
+  expect(actual.models.definitions["codex"]).toBeUndefined();
+  expect(actual.models.default).toBe("claude");
+});
+```
+
+- [ ] **Step 2.2: Run, confirm failure**
+
+```bash
+node --run -- nx test groundcrew -- src/lib/config.test.ts -t "drops a shipped default"
+```
+
+Expected: FAIL. Either the keys still include `codex`, or validation throws because `disabled` is now accepted by the shape rule but the merge logic still calls `requireString(cmd, …)` against the empty `merged[name]` build.
+
+- [ ] **Step 2.3: Implement the merge-time filter + typo guard**
+
+Replace the user-entries loop inside `packages/groundcrew/src/lib/config.ts` `mergeDefinitions` (currently at lines 495-523) with:
+
+```ts
+for (const [name, override] of Object.entries(user ?? {})) {
+  failIfLegacyModelKeys(name, override);
+
+  if (override.disabled === true) {
+    if (!Object.hasOwn(DEFAULT_MODEL_DEFINITIONS, name)) {
+      fail(`models.definitions.${name}: \`disabled: true\` is only valid for shipped defaults (${Object.keys(DEFAULT_MODEL_DEFINITIONS).join(", ")}). Remove the entry instead.`);
+    }
+    delete merged[name];
+    continue;
+  }
+
+  const base: Partial<ModelDefinition> = merged[name] === undefined ? {} : cloneModelDefinition(merged[name]);
+  // Per-key spread so overriding `cmd` alone preserves the default
+  // `color` / `usage`. Brand-new entries must supply both required fields.
+  const candidate: Partial<ModelDefinition> = { ...base };
+  if (override.cmd !== undefined) {
+    candidate.cmd = override.cmd;
+  }
+  if (override.color !== undefined) {
+    candidate.color = override.color;
+  }
+  if (override.usage !== undefined) {
+    candidate.usage = override.usage;
+  }
+  const { cmd, color, usage } = candidate;
+  if (typeof cmd !== "string" || cmd.length === 0) {
+    fail(`models.definitions.${name}.cmd must be a non-empty string`);
+  }
+  if (typeof color !== "string" || color.length === 0) {
+    fail(`models.definitions.${name}.color must be a non-empty string`);
+  }
+  const definition: ModelDefinition = { cmd, color };
+  if (usage !== undefined) {
+    definition.usage = usage;
+  }
+  merged[name] = definition;
+}
+```
+
+The only change vs the original is the early `if (override.disabled === true)` block before the spread. The existing per-key spread is preserved verbatim.
+
+- [ ] **Step 2.4: Run the happy-path test, confirm pass**
+
+```bash
+node --run -- nx test groundcrew -- src/lib/config.test.ts -t "drops a shipped default"
+```
+
+Expected: PASS.
+
+- [ ] **Step 2.5: Write the typo-guard failing test**
+
+Append to `packages/groundcrew/src/lib/config.test.ts`:
+
+```ts
+it("rejects `disabled: true` on a key that isn't a shipped default", async () => {
+  const path = writeConfigFile(
+    temporary,
+    configSource({
+      linear: { ...VALID_LINEAR },
+      workspace: VALID_WORKSPACE(temporary),
+      models: {
+        // Typo of "codex" — guard catches this before the user is left wondering
+        // why doctor still probes for the codex binary.
+        definitions: {
+          codexx: { disabled: true },
+        },
+      },
+    }),
+  );
+  setEnvironmentVariable("GROUNDCREW_CONFIG", path);
+
+  const { loadConfig } = await loadFreshConfig();
+
+  await expect(loadConfig()).rejects.toThrow(/models\.definitions\.codexx: `disabled: true` is only valid for shipped defaults \(claude, codex\)\. Remove the entry instead\./);
+});
+```
+
+- [ ] **Step 2.6: Run, confirm pass (the typo branch in Step 2.3 already covers this)**
+
+```bash
+node --run -- nx test groundcrew -- src/lib/config.test.ts -t "isn't a shipped default"
+```
+
+Expected: PASS.
+
+- [ ] **Step 2.7: Run the full config.test.ts suite**
+
+```bash
+node --run -- nx test groundcrew -- src/lib/config.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2.8: Commit**
+
+```bash
+git add packages/groundcrew/src/lib/config.ts packages/groundcrew/src/lib/config.test.ts
+git commit -m "$(cat <<'EOF'
+feat(groundcrew): filter disabled models from resolved config + typo guard
+
+`mergeDefinitions` now drops any entry with `disabled: true` from the
+merged map, so downstream consumers (doctor, eligibility, boardSource,
+setupWorkspace, usage) see the disabled model as if it were never
+declared. Also adds a typo guard: `disabled: true` on a key that isn't
+a shipped default (e.g. `codexx`) throws with a message listing the
+valid shipped names.
+
+Part of groundcrew #4B.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `models.default` points at a disabled model
+
+**Files:**
+
+- Modify: `packages/groundcrew/src/lib/config.ts:544-590` (`applyDefaults`)
+- Modify: `packages/groundcrew/src/lib/config.test.ts` (append one `it` block)
+
+### Step 3.1: Write the failing test
+
+Append to `packages/groundcrew/src/lib/config.test.ts`:
+
+```ts
+it("rejects disabling the model used as `models.default`", async () => {
+  const path = writeConfigFile(
+    temporary,
+    configSource({
+      linear: { ...VALID_LINEAR },
+      workspace: VALID_WORKSPACE(temporary),
+      models: {
+        default: "codex",
+        definitions: {
+          codex: { disabled: true },
+        },
+      },
+    }),
+  );
+  setEnvironmentVariable("GROUNDCREW_CONFIG", path);
+
+  const { loadConfig } = await loadFreshConfig();
+
+  // Asserts on the specific "is disabled" wording, not the generic
+  // "is not a key in models.definitions" wording — proves the
+  // disabled-specific check runs before the existing default-validity check.
+  await expect(loadConfig()).rejects.toThrow(/models\.default \("codex"\) is disabled\. Either re-enable it or set models\.default to an enabled model\./);
+});
+```
+
+- [ ] **Step 3.2: Run, confirm it fails (or fails with the WRONG message)**
+
+```bash
+node --run -- nx test groundcrew -- src/lib/config.test.ts -t "rejects disabling the model used as"
+```
+
+Expected: FAIL. The existing `validate()` throws `models.default ("codex") is not a key in models.definitions (have: claude)` — the new test's regex won't match.
+
+- [ ] **Step 3.3: Add the disabled-default check to `applyDefaults`**
+
+Inside `applyDefaults`, just before the final `return {…}` (currently line 563), insert:
+
+```ts
+const mergedDefinitions = mergeDefinitions(user.models?.definitions);
+const effectiveDefault = user.models?.default ?? "claude";
+if (Object.hasOwn(DEFAULT_MODEL_DEFINITIONS, effectiveDefault) && !Object.hasOwn(mergedDefinitions, effectiveDefault)) {
+  fail(`models.default ("${effectiveDefault}") is disabled. Either re-enable it or set models.default to an enabled model.`);
+}
+```
+
+Then change the existing `models:` block in the returned object from:
+
+```ts
+    models: {
+      default: user.models?.default ?? "claude",
+      definitions: mergeDefinitions(user.models?.definitions),
+    },
+```
+
+to use the names you just bound (so `mergeDefinitions` is invoked once, not twice):
+
+```ts
+    models: {
+      default: effectiveDefault,
+      definitions: mergedDefinitions,
+    },
+```
+
+Why "shipped-default + missing-from-merged" is sufficient: the only way a shipped default disappears from `merged` is via the `disabled: true` path in `mergeDefinitions` (Task 2). Brand-new user-defined names can't trigger this check because `Object.hasOwn(DEFAULT_MODEL_DEFINITIONS, …)` is false for them; they continue to be handled by the existing default-not-in-definitions check at `config.ts:661-664`.
+
+- [ ] **Step 3.4: Run, confirm pass**
+
+```bash
+node --run -- nx test groundcrew -- src/lib/config.test.ts -t "rejects disabling the model used as"
+```
+
+Expected: PASS.
+
+- [ ] **Step 3.5: Run the full config.test.ts suite**
+
+```bash
+node --run -- nx test groundcrew -- src/lib/config.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add packages/groundcrew/src/lib/config.ts packages/groundcrew/src/lib/config.test.ts
+git commit -m "$(cat <<'EOF'
+feat(groundcrew): reject disabling the model used as models.default
+
+Adds a disabled-specific error message when models.default points at a
+model that was disabled via `disabled: true`. The existing validation at
+config.ts:661 would otherwise fire with the misleading "is not a key in
+models.definitions" message — the user did declare the entry; they just
+disabled it.
+
+Part of groundcrew #4B.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Downstream smoke tests — doctor + boardSource
+
+**Why these tests exist:** With the filter-at-merge approach in Task 2, downstream consumers don't need code changes. These tests are regression guards that prove the claim — they pin the contract so a future refactor that re-introduces disabled entries into the resolved map will be caught.
+
+**Files:**
+
+- Modify: `packages/groundcrew/src/commands/doctor.test.ts` (append one `it` block inside the existing `describe(doctor, …)`)
+- Modify: `packages/groundcrew/src/lib/boardSource.test.ts` (append one `it` block alongside the existing `"resolves the model from an agent-* label"` test)
+
+### Step 4.1: Write the doctor regression test
+
+Append to `packages/groundcrew/src/commands/doctor.test.ts`, inside `describe(doctor, …)`, anywhere a similar `it("…")` block fits (e.g. after the existing `"skips flag values when tokenizing model commands"` test around line 254):
+
+```ts
+it("does not probe a disabled model's CLI binary", async () => {
+  // makeConfig's default fixture has only `claude` in definitions —
+  // simulating the post-filter state of a config with codex disabled.
+  loadConfigMock.mockResolvedValue(makeConfig());
+
+  await doctor();
+
+  expect(checkedCommands()).not.toContain("codex");
+  expect(checkedCommands()).toContain("claude");
+});
+```
+
+- [ ] **Step 4.2: Run, confirm pass**
+
+```bash
+node --run -- nx test groundcrew -- src/commands/doctor.test.ts -t "does not probe a disabled model"
+```
+
+Expected: PASS. This is verifying existing behavior (doctor only iterates `Object.values(definitions)`), so no implementation change is required — that's the point.
+
+- [ ] **Step 4.3: Write the boardSource regression test**
+
+Append to `packages/groundcrew/src/lib/boardSource.test.ts`, inside the same `describe` block as the existing `"resolves the model from an agent-* label"` test:
+
+```ts
+it("falls back to models.default when an agent-<model> label refers to a disabled model", async () => {
+  // Simulate the post-filter state of a config with codex disabled —
+  // codex is absent from definitions. An agent-codex label should fall
+  // back to models.default (claude), the same way unknown labels do.
+  const configWithoutCodex = makeConfig({
+    models: {
+      default: "claude",
+      definitions: {
+        claude: { cmd: "claude", color: "#fff" },
+      },
+    },
+  });
+
+  const { source } = makeBoardSource(
+    makeClient({
+      pages: [[issueNode({ labels: { nodes: [{ name: "agent-codex" }] } })]],
+    }),
+    configWithoutCodex,
+  );
+  const state = await source.fetch();
+  const [first] = state.issues;
+  expect(first?.model).toBe("claude");
+  expect(first?.runner).toBe("local");
+});
+```
+
+- [ ] **Step 4.4: Run, confirm pass**
+
+```bash
+node --run -- nx test groundcrew -- src/lib/boardSource.test.ts -t "falls back to models.default when an agent"
+```
+
+Expected: PASS (existing fallback at `boardSource.ts:411` handles unknown agent labels).
+
+- [ ] **Step 4.5: Run both touched test files**
+
+```bash
+node --run -- nx test groundcrew -- src/commands/doctor.test.ts
+node --run -- nx test groundcrew -- src/lib/boardSource.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add packages/groundcrew/src/commands/doctor.test.ts packages/groundcrew/src/lib/boardSource.test.ts
+git commit -m "$(cat <<'EOF'
+test(groundcrew): regression guards for disabled-model downstream behavior
+
+Two regression tests pinning the contract introduced in #4B:
+
+  1. doctor.test.ts — when a model is absent from the resolved
+     definitions (the post-filter state for a disabled model), its CLI
+     binary is not probed by doctor.
+  2. boardSource.test.ts — an agent-<model> label on a ticket falls
+     back to models.default when that model is absent (i.e. disabled).
+     Confirms the existing unknown-label fallback at boardSource.ts:411
+     handles the disabled case without special-casing.
+
+Part of groundcrew #4B.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: README updates
+
+**Files:**
+
+- Modify: `packages/groundcrew/README.md` (Config reference section around line 114; Gotchas section around line 164)
+
+### Step 5.1: Locate the Models guidance in `Config reference`
+
+```bash
+grep -n "^##\|definitions" packages/groundcrew/README.md | head -30
+```
+
+Find the heading that introduces `models.definitions` (or, if there is no dedicated subsection, the closest place under `## Config reference` where it makes sense to add one).
+
+- [ ] **Step 5.2: Add a "Disabling a shipped default" subsection**
+
+Under the existing models guidance in the `## Config reference` section of `packages/groundcrew/README.md`, add (adjust heading level to match the surrounding subsections):
+
+````markdown
+#### Disabling a shipped default
+
+Groundcrew ships with `claude` and `codex` as default model definitions. If you only ever route work through one of them, disable the other so `crew doctor` stops probing for the unused CLI:
+
+```ts
+// config.ts
+export const config = {
+  // …
+  models: {
+    default: "claude",
+    definitions: {
+      codex: { disabled: true },
+    },
+  },
+};
+```
+
+Rules:
+
+- `disabled: true` is only valid for shipped defaults (`claude`, `codex`).
+- It cannot be combined with `cmd`, `color`, or `usage` overrides in the same entry.
+- `models.default` must point at an enabled model.
+````
+
+- [ ] **Step 5.3: Update the Gotchas entry from PR #663**
+
+Find the existing Gotcha that discusses `crew doctor` checking both `claude` and `codex` (added in PR #663). Replace its "workaround" or "until-fixed" wording with a pointer to the new knob:
+
+> **`crew doctor` checks every model in `models.definitions`.** If you only use one shipped model, disable the other with `models.definitions.<name>: { disabled: true }` — see [Config reference → Disabling a shipped default](#disabling-a-shipped-default).
+
+If the existing Gotcha is phrased differently, edit only the parts about the workaround / future fix. Don't move the entry.
+
+- [ ] **Step 5.4: Run markdown lint**
+
+```bash
+node --run markdown:lint
+```
+
+Expected: PASS. If it complains about heading levels or list spacing, fix those inline (do not silence the rule).
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add packages/groundcrew/README.md
+git commit -m "$(cat <<'EOF'
+docs(groundcrew): document `disabled: true` for shipped model defaults
+
+Adds a Config reference subsection showing the `disabled: true` snippet
+for the common "I only use one shipped model" case, and updates the
+Gotchas entry from PR #663 to point at the new knob.
+
+Part of groundcrew #4B.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Final verification
+
+**Files:** None (verification only).
+
+- [ ] **Step 6.1: Run all groundcrew tests**
+
+```bash
+node --run -- nx test groundcrew
+```
+
+Expected: PASS (every existing test plus the 7 new ones from this plan).
+
+- [ ] **Step 6.2: Run the pre-push verify pipeline**
+
+```bash
+node --run verify
+```
+
+Expected: PASS for `architecture:check`, `cpd`, `embed:check`, `format:check`, `knip`, `lint`, `markdown:lint`, `spell:check`, `syncpack:lint`. If `cspell` flags a new word (unlikely — we only added `disabled`, which is common), fix it by either: (a) rephrasing if it was unintentional, or (b) adding the word to `cspell.json` if it's intentional and globally valid.
+
+- [ ] **Step 6.3: Hand-spot-check the resolved type narrative**
+
+```bash
+grep -n "definitions\[" packages/groundcrew/src/commands/setupWorkspace.ts packages/groundcrew/src/lib/usage.ts packages/groundcrew/src/commands/eligibility.ts
+```
+
+Confirm each access site already tolerates a missing key (e.g. uses optional chaining, defensive lookup, or `Object.hasOwn`). No code changes — this is a 30-second mental check that the spec's "filter-don't-flag means no consumer needs changes" claim holds in the current source. If any site directly indexes without an undefined-check, raise it before merging — that's a pre-existing brittleness that would have been latent without the disable feature.
+
+- [ ] **Step 6.4: Inspect the commit chain**
+
+```bash
+git log --oneline main..HEAD
+```
+
+Expected: 5 commits in this order (each one self-contained):
+
+1. `feat(groundcrew): add \`disabled\` field shape rules to model definitions`
+2. `feat(groundcrew): filter disabled models from resolved config + typo guard`
+3. `feat(groundcrew): reject disabling the model used as models.default`
+4. `test(groundcrew): regression guards for disabled-model downstream behavior`
+5. `docs(groundcrew): document \`disabled: true\` for shipped model defaults`
+
+The spec commit from the brainstorming session is upstream of these (`docs(groundcrew): spec for disabling shipped default models`).
+
+---
+
+## Self-review checklist (run before declaring this plan finished)
+
+- [ ] Spec coverage — each of the spec's three loud-failure cases is implemented (Tasks 1+2+3) and tested. The merge-time filter is implemented (Task 2) and the type extension is in place (Task 1).
+- [ ] No placeholders — every step has either a concrete command, a concrete code block, or both.
+- [ ] Type consistency — `UserModelDefinition`, `ModelDefinition`, `mergeDefinitions`, `DEFAULT_MODEL_DEFINITIONS`, `effectiveDefault`, `mergedDefinitions` are used consistently across tasks.
+- [ ] Test command consistency — all `node --run -- nx test groundcrew -- …` invocations use the same shape; filter strings (`-t "…"`) match the test names they target.
+- [ ] Implementation order respects dependencies — Task 2 depends on the type extension from Task 1 (the merge filter reads `override.disabled`); Task 3 depends on Task 2 (it asks whether a shipped default left the merged map); Task 4 depends on Tasks 1–3 having shipped (since the regression tests assume disabled-aware behavior).

--- a/docs/superpowers/plans/2026-05-17-groundcrew-disable-shipped-model.md
+++ b/docs/superpowers/plans/2026-05-17-groundcrew-disable-shipped-model.md
@@ -636,7 +636,7 @@ Rules:
 
 Find the existing Gotcha that discusses `crew doctor` checking both `claude` and `codex` (added in PR #663). Replace its "workaround" or "until-fixed" wording with a pointer to the new knob:
 
-> **`crew doctor` checks every model in `models.definitions`.** If you only use one shipped model, disable the other with `models.definitions.<name>: { disabled: true }` — see [Config reference → Disabling a shipped default](#disabling-a-shipped-default).
+> **`crew doctor` checks every model in `models.definitions`.** If you only use one shipped model, disable the other with `models.definitions.<name>: { disabled: true }` — see the "Disabling a shipped default" subsection under "Config reference" above.
 
 If the existing Gotcha is phrased differently, edit only the parts about the workaround / future fix. Don't move the entry.
 

--- a/docs/superpowers/specs/2026-05-17-groundcrew-disable-shipped-model-design.md
+++ b/docs/superpowers/specs/2026-05-17-groundcrew-disable-shipped-model-design.md
@@ -74,7 +74,7 @@ Rationale: ambiguous intent. Forces the user to express one operation per entry.
 
 ### 2. `disabled` on a key that isn't a shipped default
 
-```
+```text
 { codexx: { disabled: true } }   // typo of "codex"
 ```
 

--- a/docs/superpowers/specs/2026-05-17-groundcrew-disable-shipped-model-design.md
+++ b/docs/superpowers/specs/2026-05-17-groundcrew-disable-shipped-model-design.md
@@ -1,0 +1,223 @@
+# Groundcrew — Disable a shipped default model
+
+**Date:** 2026-05-17
+**Plan reference:** `~/plans/2026-05-17-groundcrew-followup-fixes.md` §4 — "`crew doctor` is hard to use as a CI gate when shipped defaults aren't installed"
+**Chosen option:** §4 Option B, shape 2 (`disabled: true` per-model)
+**Scope:** Single PR. Estimated ~30 lines of production code in one file plus tests.
+
+## Problem
+
+`@clipboard-health/groundcrew` ships two default model definitions in `DEFAULT_MODEL_DEFINITIONS` (`packages/groundcrew/src/lib/config.ts:220-231`): `claude` and `codex`. Both are merged into every resolved config additively, which means:
+
+- `crew doctor` always probes for both CLIs on `PATH`. A user who only routes work through `agent-claude` still fails doctor's required-check tier when `codex` is not installed, because the codex binary token is gathered from every model's `cmd` (`packages/groundcrew/src/commands/doctor.ts:103-113`).
+- This makes `crew doctor || exit 1` unusable in CI for the common single-model case.
+
+Documentation in PR #663 calls this out as a gotcha, but the exit code remains misleading.
+
+## Goal
+
+Give the user a single config-level lever to remove a shipped default from the merged result, so that doctor, dispatch, eligibility, and label resolution all behave as if the disabled model were never declared.
+
+## Non-goals
+
+- Adding a `crew doctor --models <list>` CLI flag (§4 Option A).
+- Re-tiering doctor's exit codes (§4 Option C).
+- Auto-fallback of `models.default` when the default is disabled (rejected during brainstorming as too magical).
+- Changes to label-resolution fallback in `boardSource.ts` (existing behavior is preserved by design).
+
+## User-facing shape
+
+```ts
+// config.ts
+export default {
+  // …
+  models: {
+    default: "claude",
+    definitions: {
+      codex: { disabled: true },
+    },
+  },
+};
+```
+
+That is the only valid form of a disabled entry: `disabled: true` and nothing else.
+
+## Semantics
+
+After config resolution, a disabled model is **absent** from `ResolvedConfig.models.definitions`. It is not a separate state to be checked at each consumer; it simply does not exist downstream.
+
+Specifically:
+
+| Consumer         | Path                                                       | Behavior with disabled codex                                                                                                                 |
+| ---------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `doctor`         | `gatherToolTokens()` iterates `Object.values(definitions)` | Codex binary token never gathered → no codex check → doctor passes when only claude is installed                                             |
+| `eligibility`    | `Object.keys(definitions)`                                 | Codex never appears as a dispatch candidate                                                                                                  |
+| `boardSource`    | `Object.hasOwn(definitions, "codex")`                      | Returns false; an `agent-codex` ticket falls back to `models.default` exactly as it would for any unknown agent label (`boardSource.ts:411`) |
+| `setupWorkspace` | `definitions[model]` lookup                                | Returns `undefined`; existing missing-model error path applies                                                                               |
+| `usage`          | iterates definitions for codexbar gating                   | Codex never contributes to usage state                                                                                                       |
+
+This filter-don't-flag posture means no consumer needs an `if (!definition.disabled)` guard, which in turn means no future consumer can forget one.
+
+## Validation — three loud-failure cases
+
+All errors go through the existing `fail()` helper so they carry the `groundcrew config:` prefix.
+
+### 1. `disabled` combined with other fields
+
+```ts
+{ codex: { disabled: true, cmd: "x" } }
+```
+
+→ `models.definitions.codex: cannot combine \`disabled: true\` with other fields (cmd, color, usage). Either disable the model or override its fields, not both.`
+
+Rationale: ambiguous intent. Forces the user to express one operation per entry.
+
+### 2. `disabled` on a key that isn't a shipped default
+
+```
+{ codexx: { disabled: true } }   // typo of "codex"
+```
+
+→ `models.definitions.codexx: \`disabled: true\` is only valid for shipped defaults (claude, codex). Remove the entry instead.`
+
+Rationale: catches typos at config-load time. Without this guard, the typo silently disables nothing and the user finds out only when doctor still complains about codex.
+
+The list of shipped defaults in the error message is derived from `Object.keys(DEFAULT_MODEL_DEFINITIONS)` so it stays accurate if the shipped set changes.
+
+### 3. `models.default` points at a disabled model
+
+```ts
+models: { default: "codex", definitions: { codex: { disabled: true } } }
+```
+
+→ `models.default ("codex") is disabled. Either re-enable it or set models.default to an enabled model.`
+
+Rationale: the existing validation at `config.ts:661-664` (`models.default ("codex") is not a key in models.definitions`) would technically fire, but it tells the user the wrong story — they _did_ declare codex, they just disabled it. The new check must run before the existing one so the more specific message wins.
+
+### Shape validation
+
+`disabled`, when present, must be exactly the boolean `true`. `false`, `0`, `"true"`, and other truthy/falsy values fail with a shape-style error: `models.definitions.codex.disabled must be exactly \`true\` when set`. No tri-state semantics — the flag is strictly true-or-absent.
+
+## Implementation outline
+
+All changes live in `packages/groundcrew/src/lib/config.ts`. Estimated diff: ~30 lines of production code.
+
+### 1. Type — `UserModelDefinition` (config.ts:77)
+
+```ts
+type UserModelDefinition = Partial<ModelDefinition> & { disabled?: boolean };
+```
+
+`ModelDefinition` (the resolved shape, config.ts:51-66) is **not** changed. `disabled` is purely an input-time concept.
+
+### 2. Input validation — extend the existing guard
+
+The current `failIfLegacyModelKeys()` (config.ts:464-481) is the natural place to add per-entry shape rules. It already rejects legacy `isolation` and `sandbox` keys. Add:
+
+- If `disabled` is present and not `=== true`, fail with the shape error.
+- If `disabled === true` and any of `cmd`/`color`/`usage` is also present, fail with case 1's message.
+
+(Stylistic note: the function's name skews negative. A small rename to e.g. `validateUserModelDefinition` is optional polish and not load-bearing.)
+
+### 3. Filter logic — `mergeDefinitions()` (config.ts:483-525)
+
+Inside the loop over user entries:
+
+```ts
+for (const [name, override] of Object.entries(user ?? {})) {
+  failIfLegacyModelKeys(name, override);
+
+  if (override.disabled === true) {
+    if (!Object.hasOwn(DEFAULT_MODEL_DEFINITIONS, name)) {
+      fail(`models.definitions.${name}: \`disabled: true\` is only valid for shipped defaults (${Object.keys(DEFAULT_MODEL_DEFINITIONS).join(", ")}). Remove the entry instead.`);
+    }
+    delete merged[name];
+    continue;
+  }
+
+  // …existing per-key spread for cmd/color/usage
+}
+```
+
+The `delete` is safe because `merged` was constructed fresh from `DEFAULT_MODEL_DEFINITIONS` in the lines immediately above. The function continues to return `Record<string, ModelDefinition>` with no new optional fields.
+
+### 4. Default-vs-disabled check — `validate()` (config.ts:602+)
+
+Just before the existing default-not-in-definitions check at `config.ts:661`:
+
+```ts
+const disabledNames = collectDisabledNames(userModels); // computed once in applyDefaults, passed in
+if (disabledNames.has(config.models.default)) {
+  fail(`models.default ("${config.models.default}") is disabled. Either re-enable it or set models.default to an enabled model.`);
+}
+```
+
+Two reasonable plumbings:
+
+- **(a)** Compute the disabled set in `applyDefaults` and thread it through to `validate`. Explicit, no hidden state.
+- **(b)** Re-derive at validate time by diffing the merged definitions against `DEFAULT_MODEL_DEFINITIONS`: any shipped default not present in `merged` was disabled (since the only way a shipped default leaves the merge is via the disable path). Less plumbing but reads as "magic" until you know the invariant.
+
+Recommendation: (a). The cost is one extra parameter and the relationship is self-documenting.
+
+### 5. Documentation
+
+- Add a brief subsection under the existing "Models" guidance in the groundcrew README (or wherever shipped models are documented) showing the `disabled: true` snippet and noting the CI-gating motivation.
+- Update the "Gotchas" entry in the README from PR #663 to reference the new knob.
+
+## Test plan
+
+All tests live in existing `*.test.ts` files in `packages/groundcrew/src/`.
+
+### `lib/config.test.ts` — primary test surface
+
+1. **Happy path: disabled codex**
+   - Given a config with `{ codex: { disabled: true } }` and `models.default: "claude"`,
+   - Resolved `definitions` contains only `claude`,
+   - `definitions.codex` is `undefined`.
+
+2. **Combined-fields error**
+   - `{ codex: { disabled: true, cmd: "x" } }` throws with the case-1 message.
+
+3. **Typo-guard error**
+   - `{ codexx: { disabled: true } }` throws with the case-2 message; the error includes the shipped-default list.
+
+4. **Default-points-at-disabled error**
+   - `models.default: "codex"` + `codex: { disabled: true }` throws case-3's message.
+   - Assert specifically on the "is disabled" wording, not the generic "is not a key" wording — proves the new check runs first.
+
+5. **`disabled: false` is rejected by the shape rule**
+   - `{ codex: { disabled: false } }` throws the shape error. Confirms `disabled` is strictly `true`-or-absent and not a tri-state.
+
+6. **`disabled` with non-boolean (e.g., `"true"`, `0`)**
+   - Throws with the shape error.
+
+### `commands/doctor.test.ts`
+
+1. **Disabled model is not probed**
+   - With codex disabled, `gatherToolTokens()` does not yield the codex executable token, and the doctor run does not call `which("codex")`.
+
+### `lib/boardSource.test.ts`
+
+1. **`agent-codex` label falls back to `models.default` when codex is disabled**
+   - Confirms the "behaves like not-declared" claim — the existing fallback at `boardSource.ts:411` handles it without change.
+
+### Out-of-scope but worth a smoke check
+
+- `eligibility.test.ts`: the candidate filter already excludes anything not in `Object.keys(definitions)`, so no new test is strictly required. A one-line assertion that a disabled model is not a candidate would be cheap insurance.
+- `setupWorkspace.test.ts`: same story — the existing missing-model path handles `definitions[model] === undefined`. No new test required.
+
+## Risks and rollout
+
+- **Risk: filter-at-merge means downstream consumers cannot distinguish "user disabled" from "user never declared".** This is intentional but worth noting in a code comment near the `delete` so the next reader doesn't try to "improve" it by preserving the disabled state. Effect on users: an `agent-codex` ticket falls back to `models.default` either way; the failure mode is identical and the diagnostic for unknown labels (if any) is preserved.
+- **Risk: README drift.** The "Gotchas" entry in PR #663 will become outdated when this PR ships. Update it as part of the same PR to avoid divergence.
+- **No migration needed.** Configs without `disabled` keys are unchanged.
+
+## Suggested implementation order
+
+1. Add the type extension and `failIfLegacyModelKeys` updates with their unit tests. (Red → green.)
+2. Add the merge-time filter with its happy-path test.
+3. Add the `models.default` disabled-check with its test.
+4. Add the doctor and boardSource downstream-behavior tests.
+5. Update README.
+
+Each step is independently green-able; the PR ships as a single commit or a small commit chain per the project's "small & focused" rule.

--- a/packages/groundcrew/README.md
+++ b/packages/groundcrew/README.md
@@ -146,6 +146,29 @@ Required fields are marked **required**; everything else has a default and can b
 
 The branch prefix (`<prefix>-<TICKET>`) is derived from your OS username (`os.userInfo().username`), not configured. Agent selection looks for a top-level Linear label named `agent-<model>` (e.g. `agent-claude`, `agent-codex`). Add `agent-remote` to run that ticket in the configured remote runner instead of locally; `agent-remote` is a modifier label, not a model. **`crew run` only fetches tickets with an `agent-*` label** — the GraphQL query filters them server-side, so unlabeled tickets are never returned by Linear's API and do not appear in the rendered board. Use `crew setup <TICKET>` to provision an unlabeled ticket on demand (manual setup falls back to `models.default`). The reserved label `agent-any` routes the ticket to the configured model with the most available session capacity (lowest codexbar session-used percent), skipping any model already over `sessionLimitPercentage`. With no usage data, `agent-any` resolves to `models.default`. The name `any` cannot be used in `models.definitions`. Todo tickets blocked by Linear issues that are not in `linear.statuses.terminal` are skipped until their blockers reach a terminal status.
 
+### Disabling a shipped default
+
+Groundcrew ships with `claude` and `codex` as default model definitions. If you only ever route work through one of them, disable the other so `crew doctor` stops probing for the unused CLI:
+
+```ts
+// config.ts
+export const config = {
+  // …
+  models: {
+    default: "claude",
+    definitions: {
+      codex: { disabled: true },
+    },
+  },
+};
+```
+
+Rules:
+
+- Shipped defaults (`claude`, `codex`) are the only models that accept `disabled: true`.
+- It cannot be combined with `cmd`, `color`, or `usage` overrides in the same entry.
+- `models.default` must point at an enabled model.
+
 ## Manual commands
 
 ```bash
@@ -176,7 +199,7 @@ crew cleanup <TICKET>
 - **Project must be on a single Linear team in practice.** Cross-team projects work — the orchestrator caches the in-progress state ID per team — but every team in the project must use the same status name for `linear.statuses.inProgress`.
 - **Claude launches in bypass-permissions mode by default.** Groundcrew creates isolated per-ticket worktrees and unattended remote sessions, so the shipped `claude` command is `claude --permission-mode bypassPermissions` to avoid workspace-trust and tool-permission prompts blocking automation. Override `models.definitions.claude.cmd` if you want a stricter mode.
 - **Doctor's command introspection is shallow.** Doctor reports whether the host can run local tickets with macOS plus Safehouse, then tokenizes model `cmd` and checks the first two non-flag tokens against PATH (so `safehouse claude --foo` checks both `safehouse` and `claude`). Boolean flags without values, env-var assignments (`FOO=1`), shell pipelines, and subshells are not parsed — verify those manually. In particular, `npx -y claude` and `env FOO=1 claude` only check the wrapper, not the wrapped CLI.
-- **Doctor checks every configured model, including shipped defaults you don't use.** `models.definitions` always contains `claude` and `codex` (additive merge with the shipped defaults). If you only intend to label tickets `agent-claude`, doctor will still fail on a missing `codex` binary and exit non-zero. `crew run` itself only routes to the model named in a ticket's `agent-*` label, so a doctor failure for an unused model does not block actual ticket dispatch.
+- **Doctor checks every configured model, including shipped defaults you don't use.** `models.definitions` always contains `claude` and `codex` (additive merge with the shipped defaults). If you only intend to label tickets `agent-claude`, set `models.definitions.codex: { disabled: true }` so doctor stops probing for the unused CLI — see "Disabling a shipped default" under "Config reference" above. Without that, doctor exits non-zero on a missing `codex` binary even though `crew run` would never route to it.
 - **Switch to tmux if cmux is misbehaving.** Set `workspaceKind: "tmux"` to force the tmux backend when cmux's CLI/socket bridge is flaky (symptoms: `cmux --json list-workspaces` returning `Failed to write to socket (Broken pipe)` or `Socket not found at ...cmux.sock` on every tick). tmux is more reliable — just a unix socket, no GUI app — at the cost of losing cmux's status pills, notifications, and vertical-tab sidebar.
 - **Agent CLI must accept a positional prompt.** The handoff is `<your cmd> "<prompt>"`. `claude`, `codex`, and `cursor-agent` all support this.
 

--- a/packages/groundcrew/README.md
+++ b/packages/groundcrew/README.md
@@ -166,6 +166,7 @@ export const config = {
 Rules:
 
 - Shipped defaults (`claude`, `codex`) are the only models that accept `disabled: true`.
+- `disabled` must be exactly boolean `true` (not `false` or other values).
 - It cannot be combined with `cmd`, `color`, or `usage` overrides in the same entry.
 - `models.default` must point at an enabled model.
 
@@ -199,7 +200,7 @@ crew cleanup <TICKET>
 - **Project must be on a single Linear team in practice.** Cross-team projects work — the orchestrator caches the in-progress state ID per team — but every team in the project must use the same status name for `linear.statuses.inProgress`.
 - **Claude launches in bypass-permissions mode by default.** Groundcrew creates isolated per-ticket worktrees and unattended remote sessions, so the shipped `claude` command is `claude --permission-mode bypassPermissions` to avoid workspace-trust and tool-permission prompts blocking automation. Override `models.definitions.claude.cmd` if you want a stricter mode.
 - **Doctor's command introspection is shallow.** Doctor reports whether the host can run local tickets with macOS plus Safehouse, then tokenizes model `cmd` and checks the first two non-flag tokens against PATH (so `safehouse claude --foo` checks both `safehouse` and `claude`). Boolean flags without values, env-var assignments (`FOO=1`), shell pipelines, and subshells are not parsed — verify those manually. In particular, `npx -y claude` and `env FOO=1 claude` only check the wrapper, not the wrapped CLI.
-- **Doctor checks every configured model, including shipped defaults you don't use.** `models.definitions` always contains `claude` and `codex` (additive merge with the shipped defaults). If you only intend to label tickets `agent-claude`, set `models.definitions.codex: { disabled: true }` so doctor stops probing for the unused CLI — see "Disabling a shipped default" under "Config reference" above. Without that, doctor exits non-zero on a missing `codex` binary even though `crew run` would never route to it.
+- **Doctor checks every configured model, including shipped defaults you don't use.** By default, `models.definitions` includes shipped `claude` and `codex` via additive merge. If you only intend to label tickets `agent-claude`, set `models.definitions.codex: { disabled: true }` so doctor stops probing for the unused CLI — see "Disabling a shipped default" under "Config reference" above. Without that, doctor exits non-zero on a missing `codex` binary even though `crew run` would never route to it.
 - **Switch to tmux if cmux is misbehaving.** Set `workspaceKind: "tmux"` to force the tmux backend when cmux's CLI/socket bridge is flaky (symptoms: `cmux --json list-workspaces` returning `Failed to write to socket (Broken pipe)` or `Socket not found at ...cmux.sock` on every tick). tmux is more reliable — just a unix socket, no GUI app — at the cost of losing cmux's status pills, notifications, and vertical-tab sidebar.
 - **Agent CLI must accept a positional prompt.** The handoff is `<your cmd> "<prompt>"`. `claude`, `codex`, and `cursor-agent` all support this.
 

--- a/packages/groundcrew/src/commands/doctor.test.ts
+++ b/packages/groundcrew/src/commands/doctor.test.ts
@@ -268,6 +268,17 @@ describe(doctor, () => {
     expect(checked).not.toContain("script.ts");
   });
 
+  it("does not probe a disabled model's CLI binary", async () => {
+    // makeConfig's default fixture has only `claude` in definitions —
+    // simulating the post-filter state of a config with codex disabled.
+    loadConfigMock.mockResolvedValue(makeConfig());
+
+    await doctor();
+
+    expect(checkedCommands()).not.toContain("codex");
+    expect(checkedCommands()).toContain("claude");
+  });
+
   it("reports missing Safehouse as a local runner warning", async () => {
     detectHostMock.mockResolvedValue({
       hasSafehouse: false,

--- a/packages/groundcrew/src/lib/boardSource.test.ts
+++ b/packages/groundcrew/src/lib/boardSource.test.ts
@@ -394,6 +394,31 @@ describe(createBoardSource, () => {
       expect(first?.runner).toBe("local");
     });
 
+    it("falls back to models.default when an agent-<model> label refers to a disabled model", async () => {
+      // Simulate the post-filter state of a config with codex disabled —
+      // codex is absent from definitions. An agent-codex label should fall
+      // back to models.default (claude), the same way unknown labels do.
+      const configWithoutCodex = makeConfig({
+        models: {
+          default: "claude",
+          definitions: {
+            claude: { cmd: "claude", color: "#fff" },
+          },
+        },
+      });
+
+      const { source } = makeBoardSource(
+        makeClient({
+          pages: [[issueNode({ labels: { nodes: [{ name: "agent-codex" }] } })]],
+        }),
+        configWithoutCodex,
+      );
+      const state = await source.fetch();
+      const [first] = state.issues;
+      expect(first?.model).toBe("claude");
+      expect(first?.runner).toBe("local");
+    });
+
     it("defaults the local runner for labeled tickets without agent-remote", async () => {
       const { source } = makeBoardSource(
         makeClient({

--- a/packages/groundcrew/src/lib/config.test.ts
+++ b/packages/groundcrew/src/lib/config.test.ts
@@ -520,6 +520,55 @@ describe("loadConfig", () => {
     );
   });
 
+  it("drops a shipped default when `disabled: true` is set", async () => {
+    const path = writeConfigFile(
+      temporary,
+      configSource({
+        linear: { ...VALID_LINEAR },
+        workspace: VALID_WORKSPACE(temporary),
+        models: {
+          definitions: {
+            codex: { disabled: true },
+          },
+        },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", path);
+
+    const { loadConfig } = await loadFreshConfig();
+    const actual = await loadConfig();
+
+    expect(Object.keys(actual.models.definitions).toSorted()).toStrictEqual(["claude"]);
+    expect(actual.models.definitions["codex"]).toBeUndefined();
+    expect(actual.models.default).toBe("claude");
+  });
+
+  it("rejects `disabled: true` on a key that isn't a shipped default", async () => {
+    const path = writeConfigFile(
+      temporary,
+      configSource({
+        linear: { ...VALID_LINEAR },
+        workspace: VALID_WORKSPACE(temporary),
+        models: {
+          // Typo of "codex" — guard catches this before the user is left wondering
+          // why doctor still probes for the codex binary.
+          definitions: {
+            // cspell:disable-next-line
+            codexx: { disabled: true },
+          },
+        },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", path);
+
+    const { loadConfig } = await loadFreshConfig();
+
+    await expect(loadConfig()).rejects.toThrow(
+      // cspell:disable-next-line
+      /models\.definitions\.codexx: `disabled: true` is only valid for shipped defaults \(claude, codex\)\. Remove the entry instead\./,
+    );
+  });
+
   it("defaults workspaceKind to auto when omitted", async () => {
     const path = writeConfigFile(
       temporary,

--- a/packages/groundcrew/src/lib/config.test.ts
+++ b/packages/groundcrew/src/lib/config.test.ts
@@ -460,6 +460,66 @@ describe("loadConfig", () => {
     );
   });
 
+  it("rejects `disabled: false` on a model definition", async () => {
+    const path = writeConfigFile(
+      temporary,
+      [
+        "export const config = {",
+        `  linear: ${JSON.stringify(VALID_LINEAR)},`,
+        `  workspace: ${JSON.stringify(VALID_WORKSPACE(temporary))},`,
+        "  models: { definitions: { codex: { disabled: false } } },",
+        "};",
+      ].join("\n"),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", path);
+
+    const { loadConfig } = await loadFreshConfig();
+
+    await expect(loadConfig()).rejects.toThrow(
+      /models\.definitions\.codex\.disabled must be exactly `true` when set/,
+    );
+  });
+
+  it('rejects a non-boolean `disabled` value (e.g. the string "true")', async () => {
+    const path = writeConfigFile(
+      temporary,
+      [
+        "export const config = {",
+        `  linear: ${JSON.stringify(VALID_LINEAR)},`,
+        `  workspace: ${JSON.stringify(VALID_WORKSPACE(temporary))},`,
+        '  models: { definitions: { codex: { disabled: "true" } } },',
+        "};",
+      ].join("\n"),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", path);
+
+    const { loadConfig } = await loadFreshConfig();
+
+    await expect(loadConfig()).rejects.toThrow(
+      /models\.definitions\.codex\.disabled must be exactly `true` when set/,
+    );
+  });
+
+  it("rejects `disabled: true` combined with other fields (cmd / color / usage)", async () => {
+    const path = writeConfigFile(
+      temporary,
+      [
+        "export const config = {",
+        `  linear: ${JSON.stringify(VALID_LINEAR)},`,
+        `  workspace: ${JSON.stringify(VALID_WORKSPACE(temporary))},`,
+        "  models: { definitions: { codex: { disabled: true, cmd: 'override' } } },",
+        "};",
+      ].join("\n"),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", path);
+
+    const { loadConfig } = await loadFreshConfig();
+
+    await expect(loadConfig()).rejects.toThrow(
+      /models\.definitions\.codex: cannot combine `disabled: true` with other fields \(cmd\)/,
+    );
+  });
+
   it("defaults workspaceKind to auto when omitted", async () => {
     const path = writeConfigFile(
       temporary,

--- a/packages/groundcrew/src/lib/config.test.ts
+++ b/packages/groundcrew/src/lib/config.test.ts
@@ -1133,4 +1133,30 @@ config.orchestrator = { sessionLimitPercentage: Number.NaN };\n`,
 
     await expect(loadConfig()).rejects.toThrow(/codexbar must be an object/);
   });
+
+  it("rejects disabling the model used as `models.default`", async () => {
+    const path = writeConfigFile(
+      temporary,
+      configSource({
+        linear: { ...VALID_LINEAR },
+        workspace: VALID_WORKSPACE(temporary),
+        models: {
+          default: "codex",
+          definitions: {
+            codex: { disabled: true },
+          },
+        },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", path);
+
+    const { loadConfig } = await loadFreshConfig();
+
+    // Asserts on the specific "is disabled" wording, not the generic
+    // "is not a key in models.definitions" wording — proves the
+    // disabled-specific check runs before the existing default-validity check.
+    await expect(loadConfig()).rejects.toThrow(
+      /models\.default \("codex"\) is disabled\. Either re-enable it or set models\.default to an enabled model\./,
+    );
+  });
 });

--- a/packages/groundcrew/src/lib/config.ts
+++ b/packages/groundcrew/src/lib/config.ts
@@ -74,7 +74,7 @@ export interface RemoteRunnerConfig {
   secretNames: string[];
 }
 
-type UserModelDefinition = Partial<ModelDefinition>;
+type UserModelDefinition = Partial<ModelDefinition> & { disabled?: boolean };
 
 /**
  * Setup command run inside sibling worktrees on the host. The host is
@@ -477,6 +477,21 @@ function failIfLegacyModelKeys(
     fail(
       `models.definitions.${name}.sandbox is no longer supported: Docker Sandboxes are no longer supported`,
     );
+  }
+  if (Object.hasOwn(override, "disabled")) {
+    if (override.disabled !== true) {
+      fail(
+        `models.definitions.${name}.disabled must be exactly \`true\` when set (got ${JSON.stringify(override.disabled)})`,
+      );
+    }
+    const conflicting = (["cmd", "color", "usage"] as const).filter((key) =>
+      Object.hasOwn(override, key),
+    );
+    if (conflicting.length > 0) {
+      fail(
+        `models.definitions.${name}: cannot combine \`disabled: true\` with other fields (${conflicting.join(", ")}). Either disable the model or override its fields, not both.`,
+      );
+    }
   }
 }
 

--- a/packages/groundcrew/src/lib/config.ts
+++ b/packages/groundcrew/src/lib/config.ts
@@ -479,9 +479,9 @@ function failIfLegacyModelKeys(
     );
   }
   if (Object.hasOwn(override, "disabled")) {
-    if (override.disabled !== true) {
+    if (override["disabled"] !== true) {
       fail(
-        `models.definitions.${name}.disabled must be exactly \`true\` when set (got ${JSON.stringify(override.disabled)})`,
+        `models.definitions.${name}.disabled must be exactly \`true\` when set (got ${JSON.stringify(override["disabled"])})`,
       );
     }
     const conflicting = (["cmd", "color", "usage"] as const).filter((key) =>
@@ -509,6 +509,18 @@ function mergeDefinitions(
   );
   for (const [name, override] of Object.entries(user ?? {})) {
     failIfLegacyModelKeys(name, override);
+
+    if (override.disabled === true) {
+      if (!Object.hasOwn(DEFAULT_MODEL_DEFINITIONS, name)) {
+        fail(
+          `models.definitions.${name}: \`disabled: true\` is only valid for shipped defaults (${Object.keys(DEFAULT_MODEL_DEFINITIONS).join(", ")}). Remove the entry instead.`,
+        );
+      }
+      // oxlint-disable-next-line typescript/no-dynamic-delete -- `merged` is a fresh, function-local clone of DEFAULT_MODEL_DEFINITIONS, so V8 dictionary-mode concerns don't apply.
+      delete merged[name];
+      continue;
+    }
+
     const base: Partial<ModelDefinition> =
       merged[name] === undefined ? {} : cloneModelDefinition(merged[name]);
     // Per-key spread so overriding `cmd` alone preserves the default

--- a/packages/groundcrew/src/lib/config.ts
+++ b/packages/groundcrew/src/lib/config.ts
@@ -587,6 +587,16 @@ function applyDefaults(user: Config): ResolvedConfig {
       `linear.projectSlug must end with a 12-character hex slugId (got ${JSON.stringify(user.linear.projectSlug)}). Copy the trailing segment from your Linear project URL, e.g. "ai-strategy-5152195762f3" from "https://linear.app/<workspace>/project/ai-strategy-5152195762f3".`,
     );
   }
+  const mergedDefinitions = mergeDefinitions(user.models?.definitions);
+  const effectiveDefault = user.models?.default ?? "claude";
+  if (
+    Object.hasOwn(DEFAULT_MODEL_DEFINITIONS, effectiveDefault) &&
+    !Object.hasOwn(mergedDefinitions, effectiveDefault)
+  ) {
+    fail(
+      `models.default ("${effectiveDefault}") is disabled. Either re-enable it or set models.default to an enabled model.`,
+    );
+  }
   return {
     linear: {
       projectSlug: user.linear.projectSlug,
@@ -600,8 +610,8 @@ function applyDefaults(user: Config): ResolvedConfig {
     },
     orchestrator: { ...DEFAULT_ORCHESTRATOR, ...user.orchestrator },
     models: {
-      default: user.models?.default ?? "claude",
-      definitions: mergeDefinitions(user.models?.definitions),
+      default: effectiveDefault,
+      definitions: mergedDefinitions,
     },
     prompts: {
       initial: user.prompts?.initial ?? DEFAULT_PROMPT_INITIAL,

--- a/packages/groundcrew/src/lib/config.ts
+++ b/packages/groundcrew/src/lib/config.ts
@@ -516,7 +516,14 @@ function mergeDefinitions(
           `models.definitions.${name}: \`disabled: true\` is only valid for shipped defaults (${Object.keys(DEFAULT_MODEL_DEFINITIONS).join(", ")}). Remove the entry instead.`,
         );
       }
-      // oxlint-disable-next-line typescript/no-dynamic-delete -- `merged` is a fresh, function-local clone of DEFAULT_MODEL_DEFINITIONS, so V8 dictionary-mode concerns don't apply.
+      /**
+       * Filter-don't-flag is the intended design: removing the key (rather than tagging it as
+       * disabled) means downstream consumers (doctor, eligibility, boardSource, setupWorkspace,
+       * usage) see disabled models as if they were never declared, with no special-case logic.
+       * Lint-wise, `merged` is a fresh, function-local clone of DEFAULT_MODEL_DEFINITIONS, so
+       * V8 dictionary-mode / prototype-pollution concerns don't apply here.
+       */
+      // oxlint-disable-next-line typescript/no-dynamic-delete -- see comment above
       delete merged[name];
       continue;
     }
@@ -589,6 +596,11 @@ function applyDefaults(user: Config): ResolvedConfig {
   }
   const mergedDefinitions = mergeDefinitions(user.models?.definitions);
   const effectiveDefault = user.models?.default ?? "claude";
+  // Invariant: we infer "disabled" from absence — a shipped-default name missing from
+  // `mergedDefinitions` must have been removed via the `disabled: true` path in
+  // `mergeDefinitions`, which is the only removal path today. If a future change adds
+  // another removal path (e.g., a "remove this entry" sentinel), teach this check about
+  // it or plumb an explicit `disabledNames` set through to `validate()`.
   if (
     Object.hasOwn(DEFAULT_MODEL_DEFINITIONS, effectiveDefault) &&
     !Object.hasOwn(mergedDefinitions, effectiveDefault)


### PR DESCRIPTION
## Summary

Adds a per-model `disabled: true` knob to `models.definitions` so a user who only routes work through one shipped model (typically `claude`) can suppress the other from doctor, dispatch, label resolution, and usage gating.

```ts
// config.ts
models: {
  default: "claude",
  definitions: {
    codex: { disabled: true },
  },
}
```

After this lands, `crew doctor` no longer probes for the codex binary when codex is disabled, making `crew doctor || exit 1` viable as a CI gate.

### Why

`@clipboard-health/groundcrew` ships `claude` and `codex` as shipped default model definitions, merged additively into every resolved config. `crew doctor` probes every model's `cmd` against `PATH`, so a user who never routes to codex still fails doctor's required tier when the codex CLI isn't installed.

### Alternatives considered

- **A CLI flag (`crew doctor --models <list>`)** restricting which models doctor checks. Has to be repeated in every CI script; doesn't actually remove codex from the merged config, so dispatch could still route there.
- **Exit-code tiers** (exit 1 for hard failures, exit 2 for "informational"). Requires every CI script to learn the new convention and use `[[ $? -lt 2 ]]`-style checks.
- **Per-model config knob (this PR)**. Single declaration in config; doctor, dispatch, label resolution all honor it. Single source of truth, no per-invocation flags.

### Design — filter, don't flag

Disabled entries are stripped at the merge boundary in `mergeDefinitions` (`packages/groundcrew/src/lib/config.ts`), so they're absent from `ResolvedConfig.models.definitions`. The five downstream consumers (`doctor`, `eligibility`, `boardSource`, `setupWorkspace`, `usage`) need no code changes — they already tolerate missing keys via `Object.hasOwn` / undefined-checks / `Object.values` iteration. The regression tests added to `doctor.test.ts` and `boardSource.test.ts` pin that claim.

### Validation — three loud-failure cases

| Case | Trigger | Message |
|---|---|---|
| Disabled + other fields | `{ codex: { disabled: true, cmd: "x" } }` | `models.definitions.codex: cannot combine \`disabled: true\` with other fields (cmd). Either disable the model or override its fields, not both.` |
| Disabled on non-shipped key | `{ codexx: { disabled: true } }` | `models.definitions.codexx: \`disabled: true\` is only valid for shipped defaults (claude, codex). Remove the entry instead.` |
| Default points at disabled model | `default: "codex"` + `codex: { disabled: true }` | `models.default ("codex") is disabled. Either re-enable it or set models.default to an enabled model.` |

Shape rule: `disabled`, when present, must be exactly the boolean `true` (no tri-state semantics).

### Files

- `packages/groundcrew/src/lib/config.ts` — type extension, three validation rules, merge-time filter.
- `packages/groundcrew/src/lib/config.test.ts` — 6 new tests covering the three error cases and the happy path.
- `packages/groundcrew/src/commands/doctor.test.ts` — regression test pinning that doctor doesn't probe disabled models' CLIs.
- `packages/groundcrew/src/lib/boardSource.test.ts` — regression test pinning that `agent-<name>` labels for disabled models fall back to `models.default`.
- `packages/groundcrew/README.md` — new "Disabling a shipped default" subsection under Config reference; updated the Gotcha that previously documented the missing knob.
- `docs/superpowers/specs/`, `docs/superpowers/plans/` — design doc and implementation plan committed alongside the code.

## Test plan

- [x] Full groundcrew suite: 579/579 tests pass (`npx vitest run --config packages/groundcrew/vitest.config.ts`).
- [x] `node --run verify` fully green (architecture:check, cpd, embed:check, format:check, knip, lint, markdown:lint, spell:check, syncpack:lint).
- [x] All three new error paths covered by dedicated tests asserting on the exact wording.
- [x] Happy path: `{ codex: { disabled: true } }` produces a resolved config with `definitions === { claude: { … } }` and `models.default === "claude"`.
- [x] Backwards compatibility: every existing test still passes with no behavior change for configs that don't set `disabled`.
- [x] Hand-spot-checked the three `definitions[model]` indexing sites (`setupWorkspace.ts:105`, `setupWorkspace.ts:204`, `usage.ts:178`) — all already guard for `undefined`.

## Out of scope (deferred)

- Adding a `crew doctor --models <list>` CLI flag.
- Re-tiering doctor's exit codes.
- Auto-fallback of `models.default` when the default is disabled (rejected as too magical — explicit error is clearer).
- Changes to label-resolution fallback in `boardSource.ts` (existing unknown-label fallback handles the disabled case without special-casing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)