### PR TITLE
fix: strip source export from package artifacts

### DIFF
--- a/scripts/prepareTsgoPackage.mts
+++ b/scripts/prepareTsgoPackage.mts
@@ -183,9 +183,30 @@ async function writePackageJson({
   });
 
   packageJson.types ??= packageJson.typings;
+  removeSourceExportCondition(packageJson);
 
   const packageJsonPath = joinPathFragments(workspaceRoot, outputPath, "package.json");
   writeJsonFile(packageJsonPath, packageJson);
+}
+
+function removeSourceExportCondition(packageJson: PackageJson): void {
+  stripSourceExportCondition(packageJson.exports);
+}
+
+function stripSourceExportCondition(value: unknown): void {
+  if (!isRecord(value)) {
+    return;
+  }
+
+  delete value["@clipboard-health/source"];
+
+  for (const child of Object.values(value)) {
+    stripSourceExportCondition(child);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 main().catch((error: unknown) => {


### PR DESCRIPTION
## Summary

Release artifacts generated by `prepareTsgoPackage` now strip the repo-only `@clipboard-health/source` export condition. This keeps source manifests useful inside the monorepo while preventing published/dist packages from resolving missing `.ts` source files when that condition is active.

## Validation

- `npm exec nx test clearance`
- `npm exec nx build clearance`
- `npm exec nx build groundcrew`
- `node --conditions @clipboard-health/source --input-type=module -e "const clearance = await import('@clipboard-health/clearance'); console.log(clearance.CLEARANCE_PACKAGE_NAME)"` from `dist/packages/clearance`
- `node --conditions @clipboard-health/source --input-type=module -e "const groundcrew = await import('@clipboard-health/groundcrew'); console.log(Object.keys(groundcrew).length > 0)"` from `dist/packages/groundcrew`
- `node --run verify`

## Notes

Ported and pushed the `clearance@1.0.6` tag to core-utils separately at `9647c9f257dab314b16f36761716c159193fac1a`.

<!-- commit-push-pr:created v1 core@3.4.0 -->