### PR TITLE
fix(clearance): terminate allowlist error message with a period

### DIFF
--- a/packages/clearance/src/allowlist.ts
+++ b/packages/clearance/src/allowlist.ts
@@ -22,7 +22,7 @@ export function resolveAllowlist(input: ResolveAllowlistInput): readonly string[
 
   if (normalized.length === 0) {
     throw new Error(
-      "Set CLEARANCE_ALLOW_HOSTS or CLEARANCE_ALLOW_HOSTS_FILES, e.g. CLEARANCE_ALLOW_HOSTS=api.example.com",
+      "Set CLEARANCE_ALLOW_HOSTS or CLEARANCE_ALLOW_HOSTS_FILES, e.g. CLEARANCE_ALLOW_HOSTS=api.example.com.",
     );
   }
 


### PR DESCRIPTION
## Summary
- Adds a trailing period to the `resolveAllowlist` "Set CLEARANCE_ALLOW_HOSTS..." error so the user-visible message reads as a complete sentence.

## Test plan
- [x] `nx test clearance`