### PR TITLE
feat(contract-core): add dollarOrMoneySchema for analyst dollar inputs

### DIFF
--- a/packages/contract-core/src/lib/schemas/money.test.ts
+++ b/packages/contract-core/src/lib/schemas/money.test.ts
@@ -1,6 +1,10 @@
+import {
+  expectToBeSafeParseError,
+  expectToBeSafeParseSuccess,
+} from "@clipboard-health/testing-core";
 import type { ZodError } from "zod";
 
-import { money } from "./money";
+import { dollarOrMoneySchema, money } from "./money";
 
 describe("money schema", () => {
   it("validates the data", () => {
@@ -30,5 +34,130 @@ describe("money schema", () => {
         received: "EUR",
       },
     ]);
+  });
+});
+
+describe(dollarOrMoneySchema, () => {
+  const schema = dollarOrMoneySchema();
+
+  describe("success cases", () => {
+    it("converts a positive dollar number to the money DTO", () => {
+      const actual = schema.safeParse(45.5);
+
+      expectToBeSafeParseSuccess(actual);
+      expect(actual.data).toStrictEqual({
+        amountInMinorUnits: 4550,
+        currencyCode: "USD",
+      });
+    });
+
+    it("passes through a valid money object", () => {
+      const input = { amountInMinorUnits: 4500, currencyCode: "USD" as const };
+
+      const actual = schema.safeParse(input);
+
+      expectToBeSafeParseSuccess(actual);
+      expect(actual.data).toStrictEqual(input);
+    });
+  });
+
+  describe("error cases", () => {
+    it.each<{ input: unknown; message: string; name: string }>([
+      {
+        name: "rejects zero",
+        input: 0,
+        message: "Amount must be a positive dollar amount",
+      },
+      {
+        name: "rejects negative amounts",
+        input: -15,
+        message: "Amount must be a positive dollar amount",
+      },
+      {
+        name: "rejects NaN",
+        input: Number.NaN,
+        message: "Amount must be a finite number",
+      },
+      {
+        name: "rejects positive infinity",
+        input: Number.POSITIVE_INFINITY,
+        message: "Amount must be a finite number",
+      },
+      {
+        name: "rejects negative infinity",
+        input: Number.NEGATIVE_INFINITY,
+        message: "Amount must be a finite number",
+      },
+    ])("$name", ({ input, message }) => {
+      const actual = schema.safeParse(input);
+
+      expectToBeSafeParseError(actual);
+      expect(actual.error.issues.map((issue) => issue.message)).toContain(message);
+      expect(actual.error.issues.map((issue) => issue.message)).not.toContain(
+        "Expected object, received number",
+      );
+    });
+
+    it.each<{ input: unknown; message: string; name: string }>([
+      {
+        name: "rejects string",
+        input: "45",
+        message: "Amount must be a positive dollar amount or money object",
+      },
+      {
+        name: "rejects array",
+        input: [45],
+        message: "Amount must be a positive dollar amount or money object",
+      },
+      {
+        name: "rejects null",
+        input: null,
+        message: "Amount must be a positive dollar amount or money object",
+      },
+      {
+        name: "rejects undefined",
+        input: undefined,
+        message: "Amount must be a positive dollar amount or money object",
+      },
+    ])("$name", ({ input, message }) => {
+      const actual = schema.safeParse(input);
+
+      expectToBeSafeParseError(actual);
+      expect(actual.error.issues.map((issue) => issue.message)).toContain(message);
+      expect(actual.error.issues.map((issue) => issue.message)).not.toContain(
+        "Expected object, received number",
+      );
+    });
+  });
+
+  describe("custom label", () => {
+    it("uses the label in validation messages", () => {
+      const labeledSchema = dollarOrMoneySchema({ label: "Hourly rate" });
+
+      const actual = labeledSchema.safeParse(0);
+
+      expectToBeSafeParseError(actual);
+      expect(actual.error.issues.map((issue) => issue.message)).toContain(
+        "Hourly rate must be a positive dollar amount",
+      );
+    });
+  });
+
+  describe("composability", () => {
+    it("composes with .optional()", () => {
+      const optionalSchema = dollarOrMoneySchema().optional();
+
+      // eslint-disable-next-line unicorn/no-useless-undefined
+      const undef = optionalSchema.safeParse(undefined);
+      expectToBeSafeParseSuccess(undef);
+      expect(undef.data).toBeUndefined();
+
+      const valid = optionalSchema.safeParse(12);
+      expectToBeSafeParseSuccess(valid);
+      expect(valid.data).toStrictEqual({
+        amountInMinorUnits: 1200,
+        currencyCode: "USD",
+      });
+    });
   });
 });

--- a/packages/contract-core/src/lib/schemas/money.test.ts
+++ b/packages/contract-core/src/lib/schemas/money.test.ts
@@ -61,6 +61,40 @@ describe(dollarOrMoneySchema, () => {
     });
   });
 
+  describe("invalid money object", () => {
+    it("propagates money schema errors for non-integer minor units", () => {
+      const actual = schema.safeParse({
+        amountInMinorUnits: 45.5,
+        currencyCode: "USD",
+      });
+
+      expectToBeSafeParseError(actual);
+      expect(actual.error.issues).toMatchObject([
+        {
+          path: ["amountInMinorUnits"],
+          code: "invalid_type",
+          message: "Expected integer, received float",
+        },
+      ]);
+    });
+
+    it("propagates money schema errors for unsupported currency", () => {
+      const actual = schema.safeParse({
+        amountInMinorUnits: 4500,
+        currencyCode: "EUR",
+      });
+
+      expectToBeSafeParseError(actual);
+      expect(actual.error.issues).toMatchObject([
+        {
+          path: ["currencyCode"],
+          code: "invalid_enum_value",
+          message: "Invalid enum value. Expected 'USD', received 'EUR'",
+        },
+      ]);
+    });
+  });
+
   describe("error cases", () => {
     it.each<{ input: unknown; message: string; name: string }>([
       {

--- a/packages/contract-core/src/lib/schemas/money.ts
+++ b/packages/contract-core/src/lib/schemas/money.ts
@@ -9,3 +9,82 @@ export const money = z.object({
   amountInMinorUnits: z.number().int(),
   currencyCode,
 });
+
+export type Money = z.infer<typeof money>;
+
+export interface DollarOrMoneySchemaOptions {
+  /**
+   * Human-readable field name used in validation messages,
+   * e.g. `"Hourly rate"` → `"Hourly rate must be a positive dollar amount"`.
+   */
+  label?: string;
+}
+
+function dollarsToMoneyDto(dollars: number): Money {
+  return { amountInMinorUnits: Math.round(dollars * 100), currencyCode: "USD" };
+}
+
+/**
+ * Accepts a positive USD dollar number or a canonical money object.
+ * Output is always `{ amountInMinorUnits, currencyCode }`.
+ *
+ * Composable with `.optional()`, `.nullable()`, `.nullish()`, etc. at the call site:
+ * ```ts
+ * z.object({
+ *   reportedHourlyRate: dollarOrMoneySchema({ label: "Hourly rate" }),
+ *   listedHourlyRateAtReportTime: dollarOrMoneySchema({ label: "Hourly rate" })
+ *     .nullish()
+ *     .transform((value) => value ?? undefined),
+ * });
+ * ```
+ *
+ * z.input  → number | { amountInMinorUnits: number; currencyCode: "USD" }
+ * z.output → { amountInMinorUnits: number; currencyCode: "USD" }
+ */
+export function dollarOrMoneySchema(options: DollarOrMoneySchemaOptions = {}) {
+  const label = options.label ?? "Amount";
+  const positiveMessage = `${label} must be a positive dollar amount`;
+  const finiteMessage = `${label} must be a finite number`;
+  const invalidMessage = `${label} must be a positive dollar amount or money object`;
+
+  return z
+    .unknown()
+    .superRefine((value, context) => {
+      if (typeof value === "number") {
+        if (!Number.isFinite(value)) {
+          context.addIssue({ code: z.ZodIssueCode.custom, message: finiteMessage });
+          return;
+        }
+
+        if (value <= 0) {
+          context.addIssue({ code: z.ZodIssueCode.custom, message: positiveMessage });
+        }
+
+        return;
+      }
+
+      if (
+        value === null ||
+        value === undefined ||
+        typeof value !== "object" ||
+        Array.isArray(value)
+      ) {
+        context.addIssue({ code: z.ZodIssueCode.custom, message: invalidMessage });
+        return;
+      }
+
+      const parsed = money.safeParse(value);
+      if (!parsed.success) {
+        for (const issue of parsed.error.issues) {
+          context.addIssue(issue);
+        }
+      }
+    })
+    .transform((value): Money => {
+      if (typeof value === "number") {
+        return dollarsToMoneyDto(value);
+      }
+
+      return money.parse(value);
+    });
+}


### PR DESCRIPTION
## Summary

Adds `dollarOrMoneySchema({ label })` to `@clipboard-health/contract-core` so shared contracts can accept either a positive USD dollar number or the canonical `{ amountInMinorUnits, currencyCode }` money object. Invalid values (0, negative, NaN/Infinity, strings, etc.) get field-labeled messages instead of preprocess/union leakage like "Expected object, received number". The base `money` schema is unchanged for existing consumers.

Follow-up for clipboard-health placement pay report import (TG-3559): replace local `z.preprocess(dollarsToMoneyRequestInput, money)` with this helper after release.

## Validation

- `vitest run --config packages/contract-core/vitest.config.ts` — 151 tests passed
- `oxlint packages/contract-core/src/lib/schemas/money.ts packages/contract-core/src/lib/schemas/money.test.ts` — 0 warnings/errors
- `tsx scripts/prepareTsgoPackage.mts packages/contract-core && tsgo -p packages/contract-core/tsconfig.lib.json --noEmit` — pass

## Notes

Consumer migration example:

```ts
const moneyRequestSchema = dollarOrMoneySchema({ label: "Hourly rate" });
const optionalMoneyRequestSchema = dollarOrMoneySchema({ label: "Hourly rate" })
  .nullish()
  .transform((value) => value ?? undefined);
```

<!-- commit-push-pr:created v1 core@3.4.1 -->

Made with [Cursor](https://cursor.com)