### PR TITLE
feat(tribunal): render HTML report with collapsible perspectives and auto-open

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .nx/workspace-data
 .sbx/
 .tmp-plugin-sync-*/
+.tribunal/
 .vscode/*
 coverage/
 dist/

--- a/packages/tribunal/README.md
+++ b/packages/tribunal/README.md
@@ -18,6 +18,13 @@ starts, finishes, or fails, so completed perspective outputs are preserved even
 when a later model call fails. Use `--save-intermediates <path>` to choose a
 specific file, or `--no-save-intermediates` to disable snapshots.
 
+After a successful run, an HTML report is written to
+`.tribunal/reports/<timestamp>.html` and opened in your default browser. The
+report shows the deliberator's verdict, recommendation, and confidence at the
+top, with each perspective (advocate, skeptic, analyst) as a collapsible
+accordion below. Override the path with `--html <path>`, skip opening with
+`--no-open`, or disable the report entirely with `--no-html`.
+
 Override model reasoning or thinking levels per role:
 
 ```bash

--- a/packages/tribunal/src/html.test.ts
+++ b/packages/tribunal/src/html.test.ts
@@ -1,0 +1,140 @@
+import { renderHtmlReport } from "./html.ts";
+import type { TribunalResponse } from "./tribunal.ts";
+
+const generatedAt = new Date("2026-05-20T12:34:56.000Z");
+
+const response: TribunalResponse = {
+  metadata: {
+    estimatedCostUsd: null,
+    latencyMs: 4321,
+    models: {
+      advocate: { modelId: "claude-opus-4-7", provider: "anthropic" },
+      analyst: { modelId: "gemini-3.1-pro-preview", provider: "google" },
+      deliberator: { modelId: "gpt-5.4", provider: "openai" },
+      skeptic: { modelId: "gpt-5.4", provider: "openai" },
+    },
+    totalUsage: { inputTokens: 1234, outputTokens: 567, totalTokens: 1801 },
+    warnings: ["Cost estimate unavailable."],
+  },
+  perspectives: [
+    {
+      metadata: {
+        latencyMs: 200,
+        model: { modelId: "claude-opus-4-7", provider: "anthropic" },
+        usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+      },
+      result: {
+        claims: [
+          {
+            assumptions: ["Team can ship."],
+            claim: "Demand is high.",
+            confidence: 0.82,
+            reasoning: "Users have explicitly asked for it.",
+          },
+        ],
+        openQuestions: ["Who owns rollout?"],
+        role: "advocate",
+        summary: "Launch has clear upside.",
+      },
+      role: "advocate",
+    },
+    {
+      metadata: {
+        latencyMs: 150,
+        model: { modelId: "gpt-5.4", provider: "openai" },
+      },
+      result: {
+        claims: [
+          {
+            assumptions: [],
+            claim: "Support load may spike.",
+            confidence: 0.6,
+            reasoning: "Historical analogues show 3x volume.",
+          },
+        ],
+        openQuestions: [],
+        role: "skeptic",
+        summary: "Risks remain non-trivial.",
+      },
+      role: "skeptic",
+    },
+    {
+      metadata: {
+        latencyMs: 180,
+        model: { modelId: "gemini-3.1-pro-preview", provider: "google" },
+      },
+      result: {
+        claims: [
+          {
+            assumptions: [],
+            claim: "Decision hinges on staffing.",
+            confidence: 0.5,
+            reasoning: "Capacity is the binding constraint.",
+          },
+        ],
+        openQuestions: ["What is the on-call capacity?"],
+        role: "analyst",
+        summary: "Tradeoffs depend on staffing.",
+      },
+      role: "analyst",
+    },
+  ],
+  result: {
+    answer: "Launch carefully in <phases>.",
+    caveats: ["Watch support volume."],
+    confidence: 0.72,
+    consensus: ["Demand exists."],
+    disagreements: ["Risk tolerance differs."],
+    keyTakeaways: ["Launch scope matters."],
+    openQuestions: ["Who owns rollout?"],
+    recommendation: "Launch in phases.",
+  },
+};
+
+describe("HTML report rendering", () => {
+  it("returns a complete HTML document", () => {
+    const html = renderHtmlReport({ generatedAt, query: "Should we launch?", response });
+
+    expect(html.startsWith("<!DOCTYPE html>")).toBe(true);
+    expect(html).toContain("<title>Tribunal — Should we launch?</title>");
+    expect(html).toContain("Launch carefully in &lt;phases&gt;.");
+    expect(html).toContain("Launch in phases.");
+    expect(html).toContain('style="--confidence:72%"');
+  });
+
+  it("renders each perspective as a <details> accordion in fixed order", () => {
+    const html = renderHtmlReport({ generatedAt, query: "Should we launch?", response });
+
+    const advocateAt = html.indexOf('data-role="advocate"');
+    const skepticAt = html.indexOf('data-role="skeptic"');
+    const analystAt = html.indexOf('data-role="analyst"');
+
+    expect(advocateAt).toBeGreaterThan(-1);
+    expect(skepticAt).toBeGreaterThan(advocateAt);
+    expect(analystAt).toBeGreaterThan(skepticAt);
+    expect(html.match(/<details class="testimony"/g)).toHaveLength(3);
+    expect(html).toContain("Demand is high.");
+    expect(html).toContain("Support load may spike.");
+    expect(html).toContain("Decision hinges on staffing.");
+  });
+
+  it("escapes user-supplied content", () => {
+    const html = renderHtmlReport({
+      context: "<script>alert('x')</script>",
+      generatedAt,
+      query: "Inject <script>?",
+      response,
+    });
+
+    expect(html).toContain("&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt;");
+    expect(html).not.toContain("<script>alert");
+  });
+
+  it("renders confidence percentages on claims", () => {
+    const html = renderHtmlReport({ generatedAt, query: "Should we launch?", response });
+
+    expect(html).toContain('style="--confidence:82%"');
+    expect(html).toContain('style="--confidence:60%"');
+    expect(html).toContain('<span class="claim__confidence">82%</span>');
+  });
+});

--- a/packages/tribunal/src/html.ts
+++ b/packages/tribunal/src/html.ts
@@ -1,0 +1,980 @@
+// cspell:words Fraunces Newsreader opsz wght onum liga lede Csvg Crect
+import { formatModelSpec, type ModelRole, type ModelSpec } from "./models.ts";
+import type { Role } from "./schemas.ts";
+import type { PerspectiveOutput, TribunalResponse } from "./tribunal.ts";
+
+export interface RenderHtmlReportInput {
+  response: TribunalResponse;
+  query: string;
+  context?: string;
+  generatedAt: Date;
+}
+
+interface RoleAccent {
+  label: string;
+  description: string;
+}
+
+const ROLE_ACCENTS: Record<Role, RoleAccent> = {
+  advocate: { label: "For", description: "Strongest reasonable case in favor." },
+  skeptic: { label: "Against", description: "Strongest reasonable case against." },
+  analyst: { label: "Neutral", description: "Decision space, tradeoffs, dependencies." },
+};
+
+const ROLE_ORDER: readonly Role[] = ["advocate", "skeptic", "analyst"];
+
+const REPORT_STYLES = `
+:root {
+  --paper: #F4EFE4;
+  --paper-dim: #EAE2D0;
+  --paper-edge: #E0D7C2;
+  --ink: #1A1614;
+  --ink-soft: #5C534B;
+  --ink-faint: #8B7F73;
+  --rule: #1A1614;
+  --accent: #7E1A2C;
+  --advocate: #3D5A3D;
+  --skeptic: #7E1A2C;
+  --analyst: #1E3A52;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background:
+    radial-gradient(ellipse 80% 60% at 50% 0%, rgba(126, 26, 44, 0.05), transparent 70%),
+    radial-gradient(ellipse 60% 40% at 50% 100%, rgba(30, 58, 82, 0.04), transparent 70%),
+    var(--paper);
+  background-attachment: fixed;
+  color: var(--ink);
+}
+
+body {
+  font-family: 'Newsreader', Georgia, serif;
+  font-size: 18px;
+  line-height: 1.55;
+  font-feature-settings: "onum" 1, "kern" 1, "liga" 1;
+  font-optical-sizing: auto;
+  -webkit-font-smoothing: antialiased;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.05 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  opacity: 0.6;
+  z-index: 0;
+  mix-blend-mode: multiply;
+}
+
+.report {
+  max-width: 940px;
+  margin: 0 auto;
+  padding: 56px 56px 96px;
+  position: relative;
+  z-index: 1;
+}
+
+/* MASTHEAD */
+.masthead {
+  border-top: 4px double var(--rule);
+  border-bottom: 4px double var(--rule);
+  padding: 18px 0 26px;
+  margin-bottom: 56px;
+  text-align: center;
+}
+
+.masthead__top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--ink-soft);
+  margin-bottom: 18px;
+}
+
+.masthead__title {
+  font-family: 'Fraunces', serif;
+  font-variation-settings: "opsz" 144, "SOFT" 60, "wght" 700;
+  font-size: clamp(86px, 14vw, 168px);
+  line-height: 0.82;
+  letter-spacing: -0.045em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.masthead__subtitle {
+  font-family: 'Newsreader', serif;
+  font-style: italic;
+  font-size: 17px;
+  margin: 18px auto 0;
+  color: var(--ink-soft);
+  max-width: 56ch;
+}
+
+/* SHARED */
+.section-label {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  color: var(--accent);
+  border-top: 2px solid var(--ink);
+  padding-top: 10px;
+  align-self: start;
+}
+
+/* QUESTION */
+.question {
+  margin: 0 0 72px;
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  gap: 36px;
+}
+
+.question__text {
+  font-family: 'Fraunces', serif;
+  font-variation-settings: "opsz" 60, "SOFT" 50, "wght" 500;
+  font-size: clamp(28px, 3.6vw, 42px);
+  line-height: 1.12;
+  margin: 0;
+  letter-spacing: -0.018em;
+}
+
+.question__context {
+  margin-top: 22px;
+  font-size: 16px;
+  color: var(--ink-soft);
+  font-style: italic;
+  border-left: 2px solid var(--rule);
+  padding-left: 16px;
+  white-space: pre-wrap;
+}
+
+/* VERDICT */
+.verdict {
+  margin: 0 0 32px;
+}
+
+.verdict__grid {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  gap: 36px;
+}
+
+.verdict__answer {
+  font-family: 'Newsreader', serif;
+  font-size: 21px;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.verdict__answer::first-letter {
+  font-family: 'Fraunces', serif;
+  font-variation-settings: "opsz" 144, "SOFT" 70, "wght" 700;
+  font-size: 84px;
+  line-height: 0.84;
+  float: left;
+  margin: 8px 14px -4px 0;
+  color: var(--accent);
+}
+
+.recommendation {
+  background: var(--paper-dim);
+  border-left: 6px solid var(--accent);
+  padding: 28px 32px;
+  margin-top: 32px;
+  position: relative;
+}
+
+.recommendation::after {
+  content: "§";
+  position: absolute;
+  right: 24px;
+  top: 22px;
+  font-family: 'Fraunces', serif;
+  font-style: italic;
+  font-size: 32px;
+  color: var(--accent);
+  opacity: 0.35;
+}
+
+.recommendation__label {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 10px;
+}
+
+.recommendation__text {
+  font-family: 'Fraunces', serif;
+  font-variation-settings: "opsz" 60, "SOFT" 30, "wght" 600;
+  font-size: clamp(20px, 2.4vw, 28px);
+  line-height: 1.25;
+  margin: 0;
+  letter-spacing: -0.012em;
+}
+
+/* CONFIDENCE */
+.confidence {
+  display: grid;
+  grid-template-columns: 160px 1fr auto;
+  gap: 36px;
+  align-items: center;
+  margin: 36px 0 0;
+  padding: 22px 0;
+  border-top: 1px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+}
+
+.confidence__bar {
+  height: 14px;
+  background: repeating-linear-gradient(90deg, var(--paper-edge) 0 2px, transparent 2px 8px);
+  position: relative;
+  border: 1px solid var(--ink);
+}
+
+.confidence__bar::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: var(--confidence, 0%);
+  background: var(--accent);
+  transition: width 700ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.confidence__value {
+  font-family: 'Fraunces', serif;
+  font-variation-settings: "opsz" 60, "wght" 700;
+  font-size: 28px;
+  color: var(--accent);
+  letter-spacing: -0.02em;
+}
+
+/* KEY TAKEAWAYS */
+.takeaways {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  gap: 36px;
+  margin: 56px 0;
+}
+
+.takeaways__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 18px;
+  counter-reset: takeaway;
+}
+
+.takeaways__list li {
+  counter-increment: takeaway;
+  position: relative;
+  padding-left: 64px;
+  font-family: 'Newsreader', serif;
+  font-size: 19px;
+  line-height: 1.5;
+  min-height: 36px;
+}
+
+.takeaways__list li::before {
+  content: counter(takeaway, decimal-leading-zero);
+  position: absolute;
+  left: 0;
+  top: -4px;
+  font-family: 'Fraunces', serif;
+  font-variation-settings: "opsz" 36, "SOFT" 50, "wght" 700;
+  font-size: 30px;
+  color: var(--accent);
+  line-height: 1;
+}
+
+/* SPLIT */
+.split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 56px;
+  margin: 48px 0;
+  border-top: 1px solid var(--ink);
+  padding-top: 28px;
+}
+
+.split__col h3 {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  margin: 0 0 18px;
+  color: var(--accent);
+}
+
+.split__col ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 14px;
+}
+
+.split__col li {
+  padding-left: 22px;
+  position: relative;
+  font-size: 17px;
+  line-height: 1.5;
+}
+
+.split__col li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 12px;
+  width: 14px;
+  height: 1px;
+  background: var(--ink);
+}
+
+.split__empty {
+  font-style: italic;
+  color: var(--ink-faint);
+  margin: 0;
+}
+
+/* TESTIMONIES */
+.testimonies {
+  margin: 88px 0 64px;
+  padding-top: 30px;
+  border-top: 4px double var(--rule);
+}
+
+.testimonies__title {
+  font-family: 'Fraunces', serif;
+  font-variation-settings: "opsz" 96, "SOFT" 60, "wght" 700;
+  font-size: clamp(48px, 7.6vw, 84px);
+  line-height: 0.9;
+  margin: 0 0 14px;
+  letter-spacing: -0.035em;
+  text-transform: uppercase;
+}
+
+.testimonies__lede {
+  font-family: 'Newsreader', serif;
+  font-style: italic;
+  font-size: 18px;
+  color: var(--ink-soft);
+  margin: 0 0 36px;
+  max-width: 56ch;
+}
+
+.testimony {
+  --role: var(--ink);
+  border-top: 1px solid var(--ink);
+}
+
+.testimony:last-of-type { border-bottom: 1px solid var(--ink); }
+
+.testimony[data-role="advocate"] { --role: var(--advocate); }
+.testimony[data-role="skeptic"] { --role: var(--skeptic); }
+.testimony[data-role="analyst"] { --role: var(--analyst); }
+
+.testimony summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 26px 0;
+  display: grid;
+  grid-template-columns: 70px 1fr auto;
+  align-items: baseline;
+  gap: 26px;
+  position: relative;
+  transition: background 240ms ease;
+}
+
+.testimony summary:hover { background: linear-gradient(90deg, transparent, var(--paper-dim) 30%, var(--paper-dim) 70%, transparent); }
+.testimony summary::-webkit-details-marker { display: none; }
+.testimony summary::marker { display: none; content: ""; }
+
+.testimony__index {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 13px;
+  letter-spacing: 0.18em;
+  color: var(--role);
+  font-weight: 700;
+  align-self: center;
+}
+
+.testimony__role {
+  font-family: 'Fraunces', serif;
+  font-variation-settings: "opsz" 72, "SOFT" 40, "wght" 600;
+  font-size: clamp(28px, 4vw, 44px);
+  text-transform: uppercase;
+  line-height: 1;
+  letter-spacing: -0.025em;
+  color: var(--role);
+  display: block;
+}
+
+.testimony__tagline {
+  display: block;
+  margin-top: 6px;
+  font-family: 'Newsreader', serif;
+  font-style: italic;
+  font-size: 15px;
+  color: var(--ink-soft);
+}
+
+.testimony__chevron {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  color: var(--ink-soft);
+  text-transform: uppercase;
+  display: inline-flex;
+  gap: 14px;
+  align-items: center;
+  align-self: center;
+}
+
+.testimony__chevron::after {
+  content: "+";
+  font-family: 'Fraunces', serif;
+  font-variation-settings: "opsz" 36, "wght" 500;
+  font-size: 28px;
+  line-height: 0;
+  width: 36px;
+  height: 36px;
+  border: 1px solid var(--role);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 280ms ease, background 280ms ease, color 280ms ease;
+  color: var(--role);
+  padding-bottom: 4px;
+}
+
+.testimony[open] .testimony__chevron span { opacity: 0.5; }
+.testimony[open] .testimony__chevron::after {
+  content: "−";
+  background: var(--role);
+  color: var(--paper);
+}
+
+.testimony__body {
+  padding: 6px 0 40px 96px;
+  display: grid;
+  gap: 30px;
+  animation: revealTestimony 420ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes revealTestimony {
+  from { opacity: 0; transform: translateY(-8px); }
+  to { opacity: 1; transform: none; }
+}
+
+.testimony__summary {
+  font-family: 'Fraunces', serif;
+  font-variation-settings: "opsz" 36, "SOFT" 30, "wght" 400;
+  font-style: italic;
+  font-size: 22px;
+  line-height: 1.4;
+  margin: 0;
+  border-left: 3px solid var(--role);
+  padding-left: 22px;
+}
+
+.testimony__heading {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  margin: 0 0 14px;
+  color: var(--role);
+}
+
+.claims {
+  display: grid;
+  gap: 18px;
+}
+
+.claim {
+  padding: 20px 24px 22px;
+  background: var(--paper-dim);
+  border-left: 3px solid var(--role);
+  display: grid;
+  gap: 10px;
+}
+
+.claim__top {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 16px;
+}
+
+.claim__text {
+  font-family: 'Newsreader', serif;
+  font-size: 19px;
+  line-height: 1.35;
+  font-weight: 600;
+  margin: 0;
+}
+
+.claim__confidence {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  color: var(--role);
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.claim__bar {
+  height: 3px;
+  background: rgba(26, 22, 20, 0.08);
+  position: relative;
+}
+
+.claim__bar::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: var(--confidence);
+  background: var(--role);
+}
+
+.claim__reasoning {
+  font-size: 16px;
+  line-height: 1.55;
+  color: var(--ink-soft);
+  margin: 0;
+}
+
+.claim__assumptions {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11.5px;
+  color: var(--ink-faint);
+  margin: 0;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.testimony__questions {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.testimony__questions li {
+  padding-left: 26px;
+  position: relative;
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.testimony__questions li::before {
+  content: "?";
+  position: absolute;
+  left: 0;
+  top: -2px;
+  font-family: 'Fraunces', serif;
+  font-style: italic;
+  font-weight: 700;
+  font-size: 22px;
+  color: var(--role);
+}
+
+.testimony__model {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+/* META */
+.meta {
+  margin-top: 72px;
+  padding-top: 26px;
+  border-top: 4px double var(--rule);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 12px;
+  color: var(--ink-soft);
+}
+
+.meta__row {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 24px;
+  padding: 8px 0;
+  border-bottom: 1px dotted rgba(26, 22, 20, 0.18);
+}
+
+.meta__row:last-child { border-bottom: 0; }
+
+.meta__label {
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--ink);
+}
+
+.meta__value { word-break: break-word; }
+
+.meta__warning {
+  color: var(--accent);
+}
+
+@media (max-width: 760px) {
+  .report { padding: 32px 24px 64px; }
+  .question,
+  .verdict__grid,
+  .takeaways,
+  .confidence { grid-template-columns: 1fr; gap: 18px; }
+  .section-label { border-top: none; padding-top: 0; border-left: 2px solid var(--ink); padding-left: 10px; }
+  .split { grid-template-columns: 1fr; gap: 32px; }
+  .testimony summary { grid-template-columns: 1fr auto; gap: 18px; }
+  .testimony__index { display: none; }
+  .testimony__body { padding-left: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .testimony__body { animation: none; }
+  .confidence__bar::after { transition: none; }
+}
+`;
+
+export function renderHtmlReport(input: RenderHtmlReportInput): string {
+  const { context, generatedAt, query, response } = input;
+  const { metadata, perspectives, result } = response;
+  const orderedPerspectives = sortPerspectives(perspectives);
+  const titleSuffix = query.length > 80 ? `${query.slice(0, 80)}…` : query;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Tribunal — ${escapeHtml(titleSuffix)}</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT@9..144,400..900,0..100&family=Newsreader:ital,opsz,wght@0,6..72,400..700;1,6..72,400..700&family=JetBrains+Mono:wght@400..700&display=swap" rel="stylesheet">
+<style>${REPORT_STYLES}</style>
+</head>
+<body>
+<main class="report">
+${renderMasthead(generatedAt)}
+${renderQuestion(query, context)}
+${renderVerdict(result)}
+${renderTakeaways(result.keyTakeaways)}
+${renderSplitSection({
+  hideWhenEmpty: false,
+  left: { heading: "Consensus", items: result.consensus, emptyLabel: "No consensus surfaced." },
+  right: {
+    heading: "Disagreements",
+    items: result.disagreements,
+    emptyLabel: "No disagreements surfaced.",
+  },
+})}
+${renderSplitSection({
+  hideWhenEmpty: true,
+  left: { heading: "Caveats", items: result.caveats, emptyLabel: "No caveats noted." },
+  right: {
+    heading: "Open Questions",
+    items: result.openQuestions,
+    emptyLabel: "No open questions remain.",
+  },
+})}
+${renderTestimonies(orderedPerspectives)}
+${renderMeta(metadata)}
+</main>
+</body>
+</html>`;
+}
+
+function sortPerspectives(perspectives: PerspectiveOutput[]): PerspectiveOutput[] {
+  return perspectives.toSorted(
+    (left, right) => ROLE_ORDER.indexOf(left.role) - ROLE_ORDER.indexOf(right.role),
+  );
+}
+
+function renderMasthead(generatedAt: Date): string {
+  const date = generatedAt.toUTCString().replace("GMT", "UTC");
+  const caseNumber = generatedAt
+    .toISOString()
+    .slice(0, 19)
+    .replaceAll("-", "")
+    .replaceAll(":", "")
+    .replace("T", "-");
+
+  return `<header class="masthead">
+  <div class="masthead__top">
+    <span>Case No. ${escapeHtml(caseNumber)}</span>
+    <span>${escapeHtml(date)}</span>
+  </div>
+  <h1 class="masthead__title">Tribunal</h1>
+  <p class="masthead__subtitle">A structured second opinion from advocate, skeptic, and analyst — synthesized by the deliberator.</p>
+</header>`;
+}
+
+function renderQuestion(query: string, context: string | undefined): string {
+  const contextBlock =
+    context === undefined || context.trim().length === 0
+      ? ""
+      : `<div class="question__context">${escapeHtml(context)}</div>`;
+
+  return `<section class="question">
+  <div class="section-label">The Question</div>
+  <div>
+    <p class="question__text">${escapeHtml(query)}</p>
+    ${contextBlock}
+  </div>
+</section>`;
+}
+
+function renderVerdict(result: TribunalResponse["result"]): string {
+  const recommendation = result.recommendation ?? "No recommendation.";
+  const confidencePercent = Math.round(result.confidence * 100);
+
+  return `<section class="verdict">
+  <div class="verdict__grid">
+    <div class="section-label">The Verdict</div>
+    <div>
+      <p class="verdict__answer">${escapeHtml(result.answer)}</p>
+      <div class="recommendation">
+        <div class="recommendation__label">Recommendation</div>
+        <p class="recommendation__text">${escapeHtml(recommendation)}</p>
+      </div>
+    </div>
+  </div>
+  <div class="confidence" style="--confidence:${confidencePercent}%">
+    <div class="section-label">Confidence</div>
+    <div class="confidence__bar" aria-hidden="true"></div>
+    <div class="confidence__value">${confidencePercent}%</div>
+  </div>
+</section>`;
+}
+
+function renderTakeaways(takeaways: string[]): string {
+  if (takeaways.length === 0) {
+    return "";
+  }
+
+  const items = takeaways.map((item) => `    <li>${escapeHtml(item)}</li>`).join("\n");
+
+  return `<section class="takeaways">
+  <div class="section-label">Key Takeaways</div>
+  <ol class="takeaways__list">
+${items}
+  </ol>
+</section>`;
+}
+
+function renderSplitSection(input: {
+  hideWhenEmpty: boolean;
+  left: { heading: string; items: string[]; emptyLabel: string };
+  right: { heading: string; items: string[]; emptyLabel: string };
+}): string {
+  const { hideWhenEmpty, left, right } = input;
+
+  if (hideWhenEmpty && left.items.length === 0 && right.items.length === 0) {
+    return "";
+  }
+
+  return `<section class="split">
+  <div class="split__col">
+    <h3>${escapeHtml(left.heading)}</h3>
+    ${renderInlineList(left.items, left.emptyLabel)}
+  </div>
+  <div class="split__col">
+    <h3>${escapeHtml(right.heading)}</h3>
+    ${renderInlineList(right.items, right.emptyLabel)}
+  </div>
+</section>`;
+}
+
+function renderInlineList(items: string[], emptyLabel: string): string {
+  if (items.length === 0) {
+    return `<p class="split__empty"><em>${escapeHtml(emptyLabel)}</em></p>`;
+  }
+
+  const lis = items.map((item) => `      <li>${escapeHtml(item)}</li>`).join("\n");
+  return `<ul>
+${lis}
+    </ul>`;
+}
+
+function renderTestimonies(perspectives: PerspectiveOutput[]): string {
+  if (perspectives.length === 0) {
+    return "";
+  }
+
+  const items = perspectives
+    .map((perspective, index) => renderTestimony(perspective, index + 1))
+    .join("\n");
+
+  return `<section class="testimonies">
+  <h2 class="testimonies__title">Testimonies</h2>
+  <p class="testimonies__lede">Each specialist argued their assigned position. The deliberator above weighed the merits, not the model names.</p>
+${items}
+</section>`;
+}
+
+function renderTestimony(perspective: PerspectiveOutput, index: number): string {
+  const accent = ROLE_ACCENTS[perspective.role];
+  const claims = perspective.result.claims.map(renderClaim).join("\n");
+  const openQuestions = renderTestimonyQuestions(perspective.result.openQuestions);
+
+  return `  <details class="testimony" data-role="${escapeHtml(perspective.role)}">
+    <summary>
+      <span class="testimony__index">${formatIndex(index)}</span>
+      <span>
+        <span class="testimony__role">${escapeHtml(capitalize(perspective.role))}</span>
+        <span class="testimony__tagline">${escapeHtml(accent.label)} · ${escapeHtml(accent.description)}</span>
+      </span>
+      <span class="testimony__chevron"><span>Open</span></span>
+    </summary>
+    <div class="testimony__body">
+      <p class="testimony__summary">${escapeHtml(perspective.result.summary)}</p>
+      <div>
+        <h4 class="testimony__heading">Claims</h4>
+        <div class="claims">
+${claims}
+        </div>
+      </div>
+${openQuestions}
+      <div class="testimony__model">${escapeHtml(formatModelSpec(perspective.metadata.model))} · ${formatLatency(perspective.metadata.latencyMs)}</div>
+    </div>
+  </details>`;
+}
+
+function renderClaim(claim: PerspectiveOutput["result"]["claims"][number]): string {
+  const percent = Math.round(claim.confidence * 100);
+  const assumptions =
+    claim.assumptions.length === 0
+      ? ""
+      : `        <p class="claim__assumptions">Assumptions: ${escapeHtml(claim.assumptions.join("; "))}</p>`;
+
+  return `        <article class="claim" style="--confidence:${percent}%">
+          <div class="claim__top">
+            <p class="claim__text">${escapeHtml(claim.claim)}</p>
+            <span class="claim__confidence">${percent}%</span>
+          </div>
+          <div class="claim__bar" aria-hidden="true"></div>
+          <p class="claim__reasoning">${escapeHtml(claim.reasoning)}</p>
+${assumptions}
+        </article>`;
+}
+
+function renderTestimonyQuestions(openQuestions: string[]): string {
+  if (openQuestions.length === 0) {
+    return "";
+  }
+
+  const items = openQuestions
+    .map((question) => `          <li>${escapeHtml(question)}</li>`)
+    .join("\n");
+
+  return `      <div>
+        <h4 class="testimony__heading">Open questions</h4>
+        <ul class="testimony__questions">
+${items}
+        </ul>
+      </div>`;
+}
+
+function renderMeta(metadata: TribunalResponse["metadata"]): string {
+  const rows = [
+    ["Models", formatModelSet(metadata.models)],
+    ["Tokens", formatTokens(metadata.totalUsage)],
+    ["Cost", formatCost(metadata.estimatedCostUsd)],
+    ["Latency", formatLatency(metadata.latencyMs)],
+    ["Warnings", formatWarnings(metadata.warnings)],
+  ];
+
+  const html = rows
+    .map(
+      ([label, value]) =>
+        `  <div class="meta__row"><span class="meta__label">${escapeHtml(label ?? "")}</span><span class="meta__value">${value ?? ""}</span></div>`,
+    )
+    .join("\n");
+
+  return `<footer class="meta">
+${html}
+</footer>`;
+}
+
+function formatModelSet(models: Record<ModelRole, ModelSpec>): string {
+  return (["advocate", "skeptic", "analyst", "deliberator"] as const)
+    .map((role) => `${role}=${escapeHtml(formatModelSpec(models[role]))}`)
+    .join(" · ");
+}
+
+function formatTokens(usage: TribunalResponse["metadata"]["totalUsage"]): string {
+  if (usage === undefined) {
+    return "unknown";
+  }
+
+  const parts: string[] = [];
+  if (usage.inputTokens !== undefined) {
+    parts.push(`in ${usage.inputTokens.toLocaleString("en-US")}`);
+  }
+  if (usage.outputTokens !== undefined) {
+    parts.push(`out ${usage.outputTokens.toLocaleString("en-US")}`);
+  }
+  if (usage.totalTokens !== undefined) {
+    parts.push(`total ${usage.totalTokens.toLocaleString("en-US")}`);
+  }
+  return parts.length === 0 ? "unknown" : parts.join(" · ");
+}
+
+function formatCost(estimatedCostUsd: number | null): string {
+  if (estimatedCostUsd === null) {
+    return "unknown";
+  }
+  return `$${estimatedCostUsd.toFixed(6)}`;
+}
+
+function formatLatency(latencyMs: number | undefined): string {
+  if (latencyMs === undefined) {
+    return "unknown";
+  }
+  if (latencyMs >= 1000) {
+    return `${(latencyMs / 1000).toFixed(1)}s`;
+  }
+  return `${latencyMs}ms`;
+}
+
+function formatWarnings(warnings: string[]): string {
+  if (warnings.length === 0) {
+    return "none";
+  }
+  return warnings
+    .map((warning) => `<span class="meta__warning">${escapeHtml(warning)}</span>`)
+    .join(" · ");
+}
+
+function formatIndex(value: number): string {
+  return value.toString().padStart(2, "0");
+}
+
+function capitalize(value: string): string {
+  return `${value.slice(0, 1).toUpperCase()}${value.slice(1)}`;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}

--- a/packages/tribunal/src/index.test.ts
+++ b/packages/tribunal/src/index.test.ts
@@ -68,6 +68,29 @@ describe("CLI argument parsing", () => {
 
     expect(actual.shouldSaveIntermediates).toBe(false);
   });
+
+  it("defaults to writing and opening the HTML report", () => {
+    const actual = parseCliArguments(["Should we launch?"]);
+
+    expect(actual.shouldWriteHtmlReport).toBe(true);
+    expect(actual.shouldOpenHtmlReport).toBe(true);
+    expect(actual.htmlReportFilePath).toBeUndefined();
+  });
+
+  it("parses --html and --no-open flags", () => {
+    const actual = parseCliArguments(["Should we launch?", "--html", "./report.html", "--no-open"]);
+
+    expect(actual.shouldWriteHtmlReport).toBe(true);
+    expect(actual.shouldOpenHtmlReport).toBe(false);
+    expect(actual.htmlReportFilePath).toBe("./report.html");
+  });
+
+  it("parses --no-html opt-out", () => {
+    const actual = parseCliArguments(["Should we launch?", "--no-html"]);
+
+    expect(actual.shouldWriteHtmlReport).toBe(false);
+    expect(actual.htmlReportFilePath).toBeUndefined();
+  });
 });
 
 describe("context loading", () => {
@@ -145,7 +168,7 @@ describe("CLI runner", () => {
       const model = { modelId: "gpt-5.4", provider: "openai" } as const;
 
       const runPromise = runCli({
-        argv: ["Should we launch?", "--verbose", "--no-save-intermediates"],
+        argv: ["Should we launch?", "--verbose", "--no-save-intermediates", "--no-html"],
         cwd: "/repo",
         environment: {},
         runTribunal: async (_request, options) => {
@@ -202,6 +225,7 @@ describe("CLI runner", () => {
         "deliberator=high",
         "--verbose",
         "--no-save-intermediates",
+        "--no-html",
       ],
       cwd: "/repo",
       environment: {},
@@ -260,7 +284,7 @@ describe("CLI runner", () => {
     const model = { modelId: "gpt-5.4", provider: "openai" } as const;
 
     const actual = await runCli({
-      argv: ["Should we launch?", "--save-intermediates", "./run.json"],
+      argv: ["Should we launch?", "--save-intermediates", "./run.json", "--no-html"],
       cwd: "/repo",
       environment: {},
       makeDirectory: async (path) => {
@@ -313,6 +337,103 @@ describe("CLI runner", () => {
     });
   });
 
+  it("writes an HTML report and invokes the opener once", async () => {
+    let stdout = "";
+    let stderr = "";
+    const htmlWrites: { filePath: string; html: string }[] = [];
+    const opens: string[] = [];
+
+    const actual = await runCli({
+      argv: ["Should we launch?", "--no-save-intermediates"],
+      cwd: "/repo",
+      environment: {},
+      now: createClock(["2026-05-20T12:34:56.000Z"]),
+      openHtmlReport: async (filePath) => {
+        opens.push(filePath);
+      },
+      runTribunal: async () => createCliResponse(),
+      stderr: {
+        write: (chunk: string) => {
+          stderr += chunk;
+        },
+      },
+      stdout: {
+        write: (chunk: string) => {
+          stdout += chunk;
+        },
+      },
+      writeHtmlReport: async (filePath, html) => {
+        htmlWrites.push({ filePath, html });
+      },
+    });
+
+    expect(actual).toBe(0);
+    expect(stdout).toContain("Launch carefully.");
+    expect(htmlWrites).toHaveLength(1);
+    const [write] = htmlWrites;
+    expect(write?.filePath).toBe("/repo/.tribunal/reports/2026-05-20T12-34-56-000Z.html");
+    expect(write?.html.startsWith("<!DOCTYPE html>")).toBe(true);
+    expect(opens).toStrictEqual(["/repo/.tribunal/reports/2026-05-20T12-34-56-000Z.html"]);
+    expect(stderr).toContain(
+      "Wrote HTML report to /repo/.tribunal/reports/2026-05-20T12-34-56-000Z.html\n",
+    );
+  });
+
+  it("honors --html path and --no-open", async () => {
+    const htmlWrites: { filePath: string; html: string }[] = [];
+    const opens: string[] = [];
+
+    const actual = await runCli({
+      argv: [
+        "Should we launch?",
+        "--no-save-intermediates",
+        "--html",
+        "./report.html",
+        "--no-open",
+      ],
+      cwd: "/repo",
+      environment: {},
+      openHtmlReport: async (filePath) => {
+        opens.push(filePath);
+      },
+      runTribunal: async () => createCliResponse(),
+      stderr: { write: noopWrite },
+      stdout: { write: noopWrite },
+      writeHtmlReport: async (filePath, html) => {
+        htmlWrites.push({ filePath, html });
+      },
+    });
+
+    expect(actual).toBe(0);
+    expect(htmlWrites).toHaveLength(1);
+    expect(htmlWrites[0]?.filePath).toBe("/repo/report.html");
+    expect(opens).toStrictEqual([]);
+  });
+
+  it("skips HTML when --no-html is set", async () => {
+    const htmlWrites: { filePath: string; html: string }[] = [];
+    const opens: string[] = [];
+
+    const actual = await runCli({
+      argv: ["Should we launch?", "--no-save-intermediates", "--no-html"],
+      cwd: "/repo",
+      environment: {},
+      openHtmlReport: async (filePath) => {
+        opens.push(filePath);
+      },
+      runTribunal: async () => createCliResponse(),
+      stderr: { write: noopWrite },
+      stdout: { write: noopWrite },
+      writeHtmlReport: async (filePath, html) => {
+        htmlWrites.push({ filePath, html });
+      },
+    });
+
+    expect(actual).toBe(0);
+    expect(htmlWrites).toHaveLength(0);
+    expect(opens).toHaveLength(0);
+  });
+
   it("preserves the original CLI error when failure snapshot persistence fails", async () => {
     let stdout = "";
     let stderr = "";
@@ -323,7 +444,7 @@ describe("CLI runner", () => {
     writeFile.mockRejectedValueOnce(new Error("disk full"));
 
     const actual = await runCli({
-      argv: ["Should we launch?", "--save-intermediates", "./run.json"],
+      argv: ["Should we launch?", "--save-intermediates", "./run.json", "--no-html"],
       cwd: "/repo",
       environment: {},
       makeDirectory: async (path) => {
@@ -353,6 +474,10 @@ describe("CLI runner", () => {
     expect(stderr).toContain("Error: provider failed\n");
   });
 });
+
+function noopWrite(_chunk: string): void {
+  // Silence stdout/stderr in tests that do not inspect them.
+}
 
 function createClock(values: string[]): () => Date {
   let index = 0;

--- a/packages/tribunal/src/index.ts
+++ b/packages/tribunal/src/index.ts
@@ -1,8 +1,14 @@
-import { readFile as readFileFromDisk } from "node:fs/promises";
-import { resolve } from "node:path";
+import { spawn } from "node:child_process";
+import {
+  mkdir,
+  readFile as readFileFromDisk,
+  writeFile as writeFileToDisk,
+} from "node:fs/promises";
+import { dirname, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { formatOutput } from "./format.ts";
+import { renderHtmlReport } from "./html.ts";
 import {
   createDefaultIntermediateOutputPath,
   createIntermediateOutputRecorder,
@@ -87,6 +93,12 @@ export {
   type TribunalResponse,
 } from "./tribunal.ts";
 
+interface HtmlFlagState {
+  htmlReportFilePath: string | undefined;
+  shouldOpenHtmlReport: boolean;
+  shouldWriteHtmlReport: boolean;
+}
+
 export interface ParsedCliArguments {
   query: string;
   context?: string;
@@ -94,9 +106,12 @@ export interface ParsedCliArguments {
   models: Partial<Record<ModelRole, ModelSpec>>;
   reasoning: ReasoningOverrides;
   intermediateOutputFilePath?: string;
+  htmlReportFilePath?: string;
   outputFormat: OutputFormat;
   showPerspectives: boolean;
   shouldSaveIntermediates: boolean;
+  shouldWriteHtmlReport: boolean;
+  shouldOpenHtmlReport: boolean;
   verbose: boolean;
   shouldShowHelp: boolean;
 }
@@ -132,6 +147,8 @@ export interface RunCliInput {
   readFile?: (path: string, encoding: BufferEncoding) => Promise<string>;
   writeFile?: CreateIntermediateOutputRecorderInput["writeFile"];
   makeDirectory?: CreateIntermediateOutputRecorderInput["makeDirectory"];
+  writeHtmlReport?: (filePath: string, html: string) => Promise<void>;
+  openHtmlReport?: (filePath: string) => Promise<void>;
   now?: () => Date;
   runTribunal?: (
     request: TribunalRequest,
@@ -158,6 +175,9 @@ Flags:
   --show-perspectives              Include specialist outputs in text/markdown
   --save-intermediates <path>      Write intermediate run snapshots; default .tribunal/runs/<timestamp>.json
   --no-save-intermediates          Disable intermediate run snapshots
+  --html <path>                    Write HTML report; default .tribunal/reports/<timestamp>.html
+  --no-html                        Disable HTML report
+  --no-open                        Write the HTML report but skip opening it
   --verbose                        Print progress, wait dots, and warnings to stderr
   -h, --help                       Show usage`;
 
@@ -166,11 +186,14 @@ export function parseCliArguments(argv: readonly string[]): ParsedCliArguments {
   const models: Partial<Record<ModelRole, ModelSpec>> = {};
   const reasoning: ReasoningOverrides = {};
   let intermediateOutputFilePath: string | undefined;
+  let htmlReportFilePath: string | undefined;
   let context: string | undefined;
   let contextFilePath: string | undefined;
   let outputFormat: OutputFormat = "text";
   let showPerspectives = false;
   let shouldSaveIntermediates = true;
+  let shouldWriteHtmlReport = true;
+  let shouldOpenHtmlReport = true;
   let verbose = false;
   let shouldShowHelp = false;
 
@@ -239,9 +262,23 @@ export function parseCliArguments(argv: readonly string[]): ParsedCliArguments {
         break;
       }
       default: {
+        const htmlState: HtmlFlagState = {
+          htmlReportFilePath,
+          shouldOpenHtmlReport,
+          shouldWriteHtmlReport,
+        };
+        const htmlAdvance = tryApplyHtmlFlag({ argv, argument, index, state: htmlState });
+
+        if (htmlAdvance >= 0) {
+          ({ htmlReportFilePath, shouldOpenHtmlReport, shouldWriteHtmlReport } = htmlState);
+          index += htmlAdvance;
+          break;
+        }
+
         if (argument.startsWith("-")) {
           throw new Error(`Unknown flag: ${argument}`);
         }
+
         positionalArguments.push(argument);
         break;
       }
@@ -259,7 +296,9 @@ export function parseCliArguments(argv: readonly string[]): ParsedCliArguments {
     models,
     outputFormat,
     reasoning,
+    shouldOpenHtmlReport,
     shouldSaveIntermediates,
+    shouldWriteHtmlReport,
     showPerspectives,
     verbose,
     shouldShowHelp,
@@ -268,6 +307,7 @@ export function parseCliArguments(argv: readonly string[]): ParsedCliArguments {
   assignParsedContext(parsedArguments, context);
   assignParsedContextFilePath(parsedArguments, contextFilePath);
   assignParsedIntermediateOutputFilePath(parsedArguments, intermediateOutputFilePath);
+  assignParsedHtmlReportFilePath(parsedArguments, htmlReportFilePath);
 
   return parsedArguments;
 }
@@ -391,6 +431,17 @@ export async function runCli(input: RunCliInput = {}): Promise<number> {
       })}\n`,
     );
 
+    await writeAndOpenHtmlReport({
+      cwd,
+      now: input.now,
+      openHtmlReport: input.openHtmlReport,
+      parsedArguments,
+      request: tribunalRequest,
+      response: responseWithContextWarnings,
+      stderr,
+      writeHtmlReport: input.writeHtmlReport,
+    });
+
     if (parsedArguments.verbose) {
       writeWarnings(stderr, responseWithContextWarnings.metadata.warnings);
     }
@@ -410,6 +461,34 @@ export async function runCli(input: RunCliInput = {}): Promise<number> {
   } finally {
     progressReporter?.stop();
   }
+}
+
+function tryApplyHtmlFlag(input: {
+  argv: readonly string[];
+  argument: string;
+  index: number;
+  state: HtmlFlagState;
+}): number {
+  const { argument, argv, index, state } = input;
+
+  if (argument === "--html") {
+    state.htmlReportFilePath = readFlagValue({ argv, flag: argument, index });
+    state.shouldWriteHtmlReport = true;
+    return 1;
+  }
+
+  if (argument === "--no-html") {
+    state.shouldWriteHtmlReport = false;
+    state.htmlReportFilePath = undefined;
+    return 0;
+  }
+
+  if (argument === "--no-open") {
+    state.shouldOpenHtmlReport = false;
+    return 0;
+  }
+
+  return -1;
 }
 
 function readFlagValue(input: { argv: readonly string[]; index: number; flag: string }): string {
@@ -467,6 +546,17 @@ function assignParsedIntermediateOutputFilePath(
   }
 
   arguments_.intermediateOutputFilePath = intermediateOutputFilePath;
+}
+
+function assignParsedHtmlReportFilePath(
+  arguments_: ParsedCliArguments,
+  htmlReportFilePath: string | undefined,
+): void {
+  if (htmlReportFilePath === undefined) {
+    return;
+  }
+
+  arguments_.htmlReportFilePath = htmlReportFilePath;
 }
 
 function createLoadContextInput(input: {
@@ -583,6 +673,94 @@ function resolveIntermediateOutputFilePath(input: {
   }
 
   return createDefaultIntermediateOutputPath({ cwd, now });
+}
+
+const HTML_REPORT_DIRECTORY = ".tribunal/reports";
+
+async function writeAndOpenHtmlReport(input: {
+  cwd: string;
+  now: (() => Date) | undefined;
+  openHtmlReport: ((filePath: string) => Promise<void>) | undefined;
+  parsedArguments: ParsedCliArguments;
+  request: TribunalRequest;
+  response: TribunalResponse;
+  stderr: TextWritable;
+  writeHtmlReport: ((filePath: string, html: string) => Promise<void>) | undefined;
+}): Promise<void> {
+  const { cwd, now, openHtmlReport, parsedArguments, request, response, stderr, writeHtmlReport } =
+    input;
+
+  if (!parsedArguments.shouldWriteHtmlReport) {
+    return;
+  }
+
+  const generatedAt = now === undefined ? new Date() : now();
+  const filePath = resolveHtmlReportFilePath({ cwd, generatedAt, parsedArguments });
+  const html = renderHtmlReport({
+    generatedAt,
+    query: request.query,
+    response,
+    ...(request.context === undefined ? {} : { context: request.context }),
+  });
+  const writer = writeHtmlReport ?? defaultWriteHtmlReport;
+
+  try {
+    await writer(filePath, html);
+    stderr.write(`Wrote HTML report to ${filePath}\n`);
+  } catch (error) {
+    stderr.write(`Warning: Failed to write HTML report: ${formatErrorMessage(error)}\n`);
+    return;
+  }
+
+  if (!parsedArguments.shouldOpenHtmlReport) {
+    return;
+  }
+
+  const opener = openHtmlReport ?? defaultOpenHtmlReport;
+
+  try {
+    await opener(filePath);
+  } catch (error) {
+    stderr.write(`Warning: Failed to open HTML report: ${formatErrorMessage(error)}\n`);
+  }
+}
+
+function resolveHtmlReportFilePath(input: {
+  cwd: string;
+  generatedAt: Date;
+  parsedArguments: ParsedCliArguments;
+}): string {
+  const { cwd, generatedAt, parsedArguments } = input;
+
+  if (parsedArguments.htmlReportFilePath !== undefined) {
+    return resolve(cwd, parsedArguments.htmlReportFilePath);
+  }
+
+  const timestamp = generatedAt.toISOString().replaceAll(":", "-").replaceAll(".", "-");
+  return resolve(cwd, HTML_REPORT_DIRECTORY, `${timestamp}.html`);
+}
+
+async function defaultWriteHtmlReport(filePath: string, html: string): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFileToDisk(filePath, html, "utf8");
+}
+
+async function defaultOpenHtmlReport(filePath: string): Promise<void> {
+  const { command, args } = getOpenCommand(filePath);
+  const child = spawn(command, args, { detached: true, stdio: "ignore" });
+  child.unref();
+}
+
+function getOpenCommand(filePath: string): { command: string; args: string[] } {
+  if (process.platform === "darwin") {
+    return { command: "open", args: [filePath] };
+  }
+
+  if (process.platform === "win32") {
+    return { command: "cmd", args: ["/c", "start", "", filePath] };
+  }
+
+  return { command: "xdg-open", args: [filePath] };
 }
 
 function createProgressHandler(input: {

--- a/packages/tribunal/src/index.ts
+++ b/packages/tribunal/src/index.ts
@@ -748,6 +748,9 @@ async function defaultWriteHtmlReport(filePath: string, html: string): Promise<v
 async function defaultOpenHtmlReport(filePath: string): Promise<void> {
   const { command, args } = getOpenCommand(filePath);
   const child = spawn(command, args, { detached: true, stdio: "ignore" });
+  child.on("error", () => {
+    // Swallow spawn errors (e.g., open/xdg-open not installed); the file was still written.
+  });
   child.unref();
 }
 


### PR DESCRIPTION
## Summary

`tribunal` now writes a self-contained HTML report after each successful run and opens it in the default browser. The report shows the deliberator's verdict, recommendation, and confidence at the top, with each perspective (advocate, skeptic, analyst) rendered as a collapsible `<details>` accordion containing summary, claims with confidence bars, and open questions. New flags: `--html <path>`, `--no-html`, `--no-open`. The opener uses `spawn` + `detached` + `unref` so the CLI exits immediately. `.tribunal/` is added to the workspace `.gitignore`.

## Validation

- `node --run verify` — all gates pass (architecture, cpd, embed, format, knip, lint, markdown, spell, syncpack).
- `nx run tribunal:test` — 55/55 tests pass, including new HTML rendering tests (4) and new CLI tests covering default write+open, `--html <path>` + `--no-open`, and `--no-html`.
- Manual visual smoke test: rendered a fixture report and opened it in the browser; masthead, verdict dropcap, confidence bar, and three role-colored accordions render as intended.

Agent session: claude --resume 5f12424a-17f0-4b85-846e-af5c0d39741b
<!-- commit-push-pr:created v1 core@3.4.1 -->