### PR TITLE
fix(oxlint-config): remove require-unicode-regexp from shared base

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -20,6 +20,7 @@
     // in ./packages/oxlint-config/src/base.json
     // See https://github.com/oxc-project/oxc/issues/21284
     "no-shadow": "off",
+    "require-unicode-regexp": "off",
     "typescript/no-deprecated": "off",
     "typescript/no-non-null-assertion": "off",
     "typescript/no-unsafe-assignment": "off",

--- a/packages/oxlint-config/src/base.json
+++ b/packages/oxlint-config/src/base.json
@@ -73,7 +73,6 @@
     "promise/prefer-await-to-callbacks": "off",
     "promise/prefer-await-to-then": "off",
     "require-await": "off",
-    "require-unicode-regexp": "off",
     "return-await": "off",
     "sort-imports": "off",
     "sort-keys": "off",


### PR DESCRIPTION
## Summary

- `require-unicode-regexp` does not exist in older oxlint versions (e.g. 1.62), so listing it in the shared `base.json` — even as `\"off\"` — makes oxlint refuse to parse any consuming project's config (`Rule 'require-unicode-regexp' not found in plugin 'eslint'`).
- Repro: ClipboardHealth/template-action-typescript#31 CI went red after the 1.7.3 → 1.9.4 Renovate bump.
- Drop the entry from `packages/oxlint-config/src/base.json` so the shared preset stays parseable on older oxlint.
- Move the suppression to this repo's own `.oxlintrc.json`, where it still applies (core-utils runs oxlint 1.65, which does implement the rule and would otherwise flag 74 existing call sites).

Other consumers that want the same suppression and run an oxlint version that knows the rule can opt in the same way.