### PR TITLE
feat(util-ts): add isNonEmptyString type guard

### DIFF
--- a/packages/util-ts/src/lib/strings/index.ts
+++ b/packages/util-ts/src/lib/strings/index.ts
@@ -1,4 +1,5 @@
 export * from "./createDeterministicHash";
 export * from "./isEmpty";
+export * from "./isNonEmptyString";
 export * from "./isString";
 export * from "./stringify";

--- a/packages/util-ts/src/lib/strings/isNonEmptyString.test.ts
+++ b/packages/util-ts/src/lib/strings/isNonEmptyString.test.ts
@@ -1,0 +1,23 @@
+import { isNonEmptyString } from "./isNonEmptyString";
+
+describe(isNonEmptyString, () => {
+  it.each([
+    { input: "hello", expected: true },
+    { input: "   ", expected: true },
+    { input: `template`, expected: true },
+    { input: "🚀\n\t", expected: true },
+    { input: "", expected: false },
+    // eslint-disable-next-line no-new-wrappers, unicorn/new-for-builtins
+    { input: new String("hello"), expected: false },
+    { input: 123, expected: false },
+    { input: true, expected: false },
+    { input: {}, expected: false },
+    { input: [], expected: false },
+    { input: null, expected: false },
+    { input: undefined, expected: false },
+  ])("returns $expected for $input", ({ input, expected }) => {
+    const actual = isNonEmptyString(input);
+
+    expect(actual).toBe(expected);
+  });
+});

--- a/packages/util-ts/src/lib/strings/isNonEmptyString.ts
+++ b/packages/util-ts/src/lib/strings/isNonEmptyString.ts
@@ -1,0 +1,9 @@
+/**
+ * Type guard that checks if a value is a string with at least one character.
+ *
+ * @param value - The value to check
+ * @returns `true` if the value is a non-empty string primitive, `false` otherwise
+ */
+export function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}


### PR DESCRIPTION
## Summary

Adds `isNonEmptyString` to `@clipboard-health/util-ts` — a type guard that narrows `unknown` to a `string` with at least one character. Replaces the common `isDefined(x) && x.length > 0` pattern with a single predicate.

## Design notes

- **Scope mirrors `isString`**: accepts `unknown`, narrows to `string` (composes both the type check and the length check).
- **Length-only, no trimming**: consistent with the sibling `isEmpty`, which treats `"   "` as non-empty. If a "no whitespace" semantic is wanted later, that belongs in a separate `isNonBlankString` util — keeping these orthogonal lets callers compose them.
- Only `typeof === "string"` primitives match (not boxed `new String("…")`), matching the current `isString` behavior.