### PR TITLE
fix(ai-rules): clarify comment in toErrorMessage

### DIFF
--- a/packages/ai-rules/scripts/toErrorMessage.ts
+++ b/packages/ai-rules/scripts/toErrorMessage.ts
@@ -1,4 +1,4 @@
-// Prefer stack over message for Error instances to keep debugging context.
+// Prefer stack over message for Error instances to preserve debugging context.
 export function toErrorMessage(error: unknown): string {
   return error instanceof Error ? (error.stack ?? error.message) : String(error);
 }


### PR DESCRIPTION
## Summary

Tweak a comment word in `toErrorMessage.ts` to trigger a patch release of the `ai-rules` package.

## Validation

- `Not run: comment-only change; pre-push hooks (architecture:check, cpd, embed:check, format:check, knip, lint, markdown:lint, spell:check, syncpack:lint) all passed.`

Agent session: claude --resume 8fe7ada9-0416-4f1c-88ff-62292239de6d
<!-- commit-push-pr:created v1 core@3.4.1 -->