### PR TITLE
fix(core/commit-push-pr): backtick session footer, drop repo-root tool grant

### DIFF
--- a/.agents/skills/commit-push-pr/SKILL.md
+++ b/.agents/skills/commit-push-pr/SKILL.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr view:*), Bash(gh pr create:*), Bash(gh pr edit:*), Bash(git diff:*), Bash(git merge-base:*), Bash(bash scripts/find-session-id.sh:*)
+allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr view:*), Bash(gh pr create:*), Bash(gh pr edit:*), Bash(git diff:*), Bash(git merge-base:*)
 description: Commit, push, and open a PR. Use when the user wants to ship changes, create a pull request, or says things like 'commit and push', 'open a PR', 'ship it', 'send it', 'create a PR for this', or 'push this up'.
 ---
 
@@ -43,7 +43,7 @@ Script paths in this procedure are written as `scripts/...`, relative to this SK
 2. Run the `simplify` skill on the full PR diff — `git diff $(git merge-base HEAD origin/HEAD)..HEAD` plus any uncommitted changes. When it returns, your very next action is to restate the remaining steps (3–7) and continue with step 3 in the same turn. Do not stop, do not end the turn with a simplify summary.
 3. If `git status --short` shows changes, create a single conventional commit with `git commit --no-gpg-sign`.
 4. Push the branch to origin.
-5. Look up the current agent session ID by running this skill's bundled script: `bash scripts/find-session-id.sh '<phrase>'`. Pass a distinctive verbatim chunk (≥10 words) from the most recent user message; see the script header for quoting constraints. If the script prints `codex <id>`, use `Agent session: codex resume <id>`. If it prints `claude-code <id>`, use `Agent session: claude --resume <id>`. If empty, there is no session footer line.
+5. Look up the current agent session ID by running this skill's bundled script: `bash scripts/find-session-id.sh '<phrase>'`. Pass a distinctive verbatim chunk (≥10 words) from the most recent user message; see the script header for quoting constraints. If the script prints `codex <id>`, use ``Agent session: `codex resume <id>` ``. If it prints `claude-code <id>`, use ``Agent session: `claude --resume <id>` ``. Keep the resume command in backticks so it renders as code in the PR description. If empty, there is no session footer line.
 6. Check for an existing PR with `gh pr view`.
    - No PR: create with `gh pr create`. Title = commit subject. Description = the PR body shape above, followed by the session footer line if known and the agent footer `<sub>🤖 <code>commit-push-pr:created v1 core@3.4.1</code></sub>` on its own line.
    - PR exists: refresh the body via `gh pr edit --body` so (a) the new commit's changes are reflected in the prose while existing `## Summary`, `## Validation`, and `## Notes` sections are preserved unless clearly stale, (b) any known session footer line is appended if missing, never removing or rewriting existing `Agent session: ...` or `Agent session ID: ...` lines, and (c) any existing footer carrying the substring `commit-push-pr:created v1` is preserved verbatim, appending `<sub>🤖 <code>commit-push-pr:created v1 core@3.4.1</code></sub>` only if absent. Then report the URL.

--- a/plugins/core/skills/commit-push-pr/SKILL.md
+++ b/plugins/core/skills/commit-push-pr/SKILL.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr view:*), Bash(gh pr create:*), Bash(gh pr edit:*), Bash(git diff:*), Bash(git merge-base:*), Bash(bash scripts/find-session-id.sh:*)
+allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr view:*), Bash(gh pr create:*), Bash(gh pr edit:*), Bash(git diff:*), Bash(git merge-base:*)
 description: Commit, push, and open a PR. Use when the user wants to ship changes, create a pull request, or says things like 'commit and push', 'open a PR', 'ship it', 'send it', 'create a PR for this', or 'push this up'.
 ---
 
@@ -43,7 +43,7 @@ Script paths in this procedure are written as `scripts/...`, relative to this SK
 2. Run the `simplify` skill on the full PR diff — `git diff $(git merge-base HEAD origin/HEAD)..HEAD` plus any uncommitted changes. When it returns, your very next action is to restate the remaining steps (3–7) and continue with step 3 in the same turn. Do not stop, do not end the turn with a simplify summary.
 3. If `git status --short` shows changes, create a single conventional commit with `git commit --no-gpg-sign`.
 4. Push the branch to origin.
-5. Look up the current agent session ID by running this skill's bundled script: `bash scripts/find-session-id.sh '<phrase>'`. Pass a distinctive verbatim chunk (≥10 words) from the most recent user message; see the script header for quoting constraints. If the script prints `codex <id>`, use `Agent session: codex resume <id>`. If it prints `claude-code <id>`, use `Agent session: claude --resume <id>`. If empty, there is no session footer line.
+5. Look up the current agent session ID by running this skill's bundled script: `bash scripts/find-session-id.sh '<phrase>'`. Pass a distinctive verbatim chunk (≥10 words) from the most recent user message; see the script header for quoting constraints. If the script prints `codex <id>`, use ``Agent session: `codex resume <id>` ``. If it prints `claude-code <id>`, use ``Agent session: `claude --resume <id>` ``. Keep the resume command in backticks so it renders as code in the PR description. If empty, there is no session footer line.
 6. Check for an existing PR with `gh pr view`.
    - No PR: create with `gh pr create`. Title = commit subject. Description = the PR body shape above, followed by the session footer line if known and the agent footer `<sub>🤖 <code>commit-push-pr:created v1 core@3.4.1</code></sub>` on its own line.
    - PR exists: refresh the body via `gh pr edit --body` so (a) the new commit's changes are reflected in the prose while existing `## Summary`, `## Validation`, and `## Notes` sections are preserved unless clearly stale, (b) any known session footer line is appended if missing, never removing or rewriting existing `Agent session: ...` or `Agent session ID: ...` lines, and (c) any existing footer carrying the substring `commit-push-pr:created v1` is preserved verbatim, appending `<sub>🤖 <code>commit-push-pr:created v1 core@3.4.1</code></sub>` only if absent. Then report the URL.


### PR DESCRIPTION
## Summary

Agents kept getting confused when adding the agent session ID to PR descriptions in the `commit-push-pr` skill. Two fixes:

- The session footer now wraps the resume command in backticks (`` `claude --resume <id>` ``) so it renders as code in the PR description instead of plain text.
- Dropped `Bash(bash scripts/find-session-id.sh:*)` from `allowed-tools`. That grant reinforced the wrong assumption that the script lives at the repo root, contradicting the skill body which resolves bundled scripts relative to SKILL.md.

Applied to the `plugins/core` source and the generated `.agents/skills` copy via `node --run sync-ai-rules`.

## Validation

- `node --run verify` — passed (lint, format:check, knip, markdown:lint, syncpack:lint, example sync all green; 0 errors).
- `simplify` review surfaced no findings.
Agent session: `claude --resume bc413700-aacc-4fe3-a274-d52542b793a1`

<!-- commit-push-pr:created v1 core@3.4.1 -->