### PR TITLE
feat(ACT-4873): add require-zod-import-in-contracts ESLint rule

### DIFF
--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -161,6 +161,12 @@ module.exports = {
               "@clipboard-health/require-http-module-factory": "error",
             },
           },
+          {
+            files: ["**/*.contract.ts"],
+            rules: {
+              "@clipboard-health/require-zod-import-in-contracts": "error",
+            },
+          },
         ]
       : []),
   ],

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,9 +1,11 @@
 import enforceTsRestInControllers from "./lib/rules/enforce-ts-rest-in-controllers";
 import requireHttpModuleFactory from "./lib/rules/require-http-module-factory";
 import requireRunValidatorsWithUpsert from "./lib/rules/require-run-validators-with-upsert";
+import requireZodImportInContracts from "./lib/rules/require-zod-import-in-contracts";
 
 export const rules = {
   "enforce-ts-rest-in-controllers": enforceTsRestInControllers,
   "require-http-module-factory": requireHttpModuleFactory,
   "require-run-validators-with-upsert": requireRunValidatorsWithUpsert,
+  "require-zod-import-in-contracts": requireZodImportInContracts,
 };

--- a/packages/eslint-plugin/src/lib/rules/require-zod-import-in-contracts/README.md
+++ b/packages/eslint-plugin/src/lib/rules/require-zod-import-in-contracts/README.md
@@ -1,0 +1,135 @@
+# require-zod-import-in-contracts
+
+ESLint rule that requires every `*.contract.ts` file to reference `"zod"` in its own module scope — either via an `import` (named, default, namespace, or side-effect) or via a re-export (`export { z } from "zod"`, `export * from "zod"`).
+
+## Motivation
+
+This rule prevents a silent type-safety regression caused by a TypeScript declaration-emit pitfall.
+
+### The bug
+
+When TypeScript emits a `.d.ts` for a contract file, it has to write the inferred type of every exported value into the declaration. For a contract like `initContract().router({ list: { responses: { 200: someZodSchema } } })`, that inferred type embeds the underlying zod types (`ZodObject<...>`, `ZodString`, etc.) — even when `z` is never referenced in the source file directly.
+
+To express those zod types in the emitted `.d.ts`, TypeScript needs a **module specifier** for `"zod"`. It picks one by walking a priority list:
+
+1. **Reuse a source-level reference** to `"zod"` in the file being emitted. Any top-level `import` or re-export with `"zod"` as the source counts — even a side-effect `import "zod"` with no local binding. TypeScript reuses that clean specifier in every inline `import("zod").ZodXxx<...>` it writes, and downstream consumers resolve them correctly.
+2. **Synthesize a specifier from the resolved file path.** This is the fallback path. With `module: "nodenext"` and zod 3.25's dual-package layout, the resolved file is `node_modules/zod/index.cjs` — and TypeScript emits the malformed inline import `import("node_modules/zod/index.cjs").ZodObject<...>`. That specifier resolves for no consumer, so every type that references it silently collapses to `any`.
+
+TypeScript specifier synthesis is strictly per-file. The fact that a sibling file (e.g. one this contract imports schemas from) has `import { z } from "zod"` is invisible to the contract file's emit. Each contract file must reference zod in its own scope.
+
+This regression is silent — `tsc` does not error, downstream consumers don't get a compile failure, they just get `any` everywhere they expected typed responses. It was first observed when `@clipboard-health/contract-backend-main`'s `shiftV3.contract.ts` shipped a `.d.ts` with 441 leaked `import("node_modules/zod/index.cjs")` paths, breaking `shiftClient.list()`'s response type for `worker-app-bff`. See ACT-4870.
+
+## Rule Details
+
+The rule fires on any `*.contract.ts` file whose module body contains no `import` or re-export with a source value of `"zod"`. It does not require `z` to be _used_ at source level — only that the `"zod"` specifier appears somewhere in the file's top-level imports or re-exports.
+
+### Examples
+
+#### ❌ Incorrect
+
+```typescript
+// my.contract.ts
+import { initContract } from "@ts-rest/core";
+
+import { createDto, createResponse } from "./create.contract";
+import { listQuery, listResponse } from "./list.contract";
+
+export const myContract = initContract().router({
+  create: {
+    method: "POST",
+    path: "/x",
+    body: createDto,
+    responses: { 201: createResponse },
+  },
+  list: {
+    method: "GET",
+    path: "/x",
+    query: listQuery,
+    responses: { 200: listResponse },
+  },
+});
+```
+
+The schemas come from sibling files that import zod, but this file's own emit will still leak the `node_modules/zod/...` path.
+
+#### ✅ Correct (zod used at source level)
+
+```typescript
+import { initContract } from "@ts-rest/core";
+import { z } from "zod";
+
+export const fooSchema = z.object({ id: z.string() });
+
+export const fooContract = initContract().router({
+  get: { method: "GET", path: "/foo", responses: { 200: fooSchema } },
+});
+```
+
+#### ✅ Correct (side-effect import when zod isn't used at source level)
+
+```typescript
+import { initContract } from "@ts-rest/core";
+import "zod";
+
+import { createDto, createResponse } from "./create.contract";
+import { listQuery, listResponse } from "./list.contract";
+
+export const myContract = initContract().router({
+  create: {
+    method: "POST",
+    path: "/x",
+    body: createDto,
+    responses: { 201: createResponse },
+  },
+  list: {
+    method: "GET",
+    path: "/x",
+    query: listQuery,
+    responses: { 200: listResponse },
+  },
+});
+```
+
+The side-effect `import "zod"` form introduces no local binding, so neither `noUnusedLocals` (TypeScript compiler) nor `@typescript-eslint/no-unused-vars` (ESLint) flags it. It also doesn't expand the package's public export surface. **Prefer this form when zod isn't referenced at source level.**
+
+#### ✅ Also correct (re-export form)
+
+```typescript
+import { initContract } from "@ts-rest/core";
+
+import { createDto, createResponse } from "./create.contract";
+
+export { z } from "zod";
+
+export const myContract = initContract().router({
+  create: {
+    method: "POST",
+    path: "/x",
+    body: createDto,
+    responses: { 201: createResponse },
+  },
+});
+```
+
+The re-export form is functionally equivalent for declaration emit but adds `z` to whatever the package's barrel re-exports. Prefer the side-effect form above unless you explicitly want to re-export `z`.
+
+### Why a bare `import { z } from "zod"` doesn't work
+
+A bare `import { z } from "zod"` with `z` unused at source level fails the build with `error TS6133: 'z' is declared but its value is never read.` That's `noUnusedLocals` at the TypeScript compiler level, which `// eslint-disable-next-line` cannot suppress. You'd have to stack `// @ts-expect-error TS6133` on top of the eslint-disable — strictly worse than either of the correct forms above.
+
+## Configuration
+
+This rule is automatically applied to all `*.contract.ts` files when using `@clipboard-health/eslint-config`.
+
+## When to Disable
+
+This rule should generally not be disabled. The cost of the missing import is silent `any` collapse in downstream consumers, which is hard to detect because it does not produce a compile error. If you have a genuinely unusual case where the file is a `.contract.ts` but contains no inferred types that reference zod, you can disable with:
+
+```typescript
+/* eslint-disable @clipboard-health/require-zod-import-in-contracts */
+```
+
+## Related
+
+- ACT-4870 (root cause investigation and per-file workaround)
+- [`shiftV3.contract.ts` fix in `clipboard-health#25570`](https://github.com/ClipboardHealth/clipboard-health/pull/25570)

--- a/packages/eslint-plugin/src/lib/rules/require-zod-import-in-contracts/index.test.ts
+++ b/packages/eslint-plugin/src/lib/rules/require-zod-import-in-contracts/index.test.ts
@@ -1,0 +1,108 @@
+import { TSESLint } from "@typescript-eslint/utils";
+
+import rule from "./index";
+
+// eslint-disable-next-line n/no-unpublished-require
+const parser = require.resolve("@typescript-eslint/parser");
+
+const ruleTester = new TSESLint.RuleTester({
+  parser,
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: "module",
+  },
+});
+
+ruleTester.run("require-zod-import-in-contracts", rule, {
+  valid: [
+    {
+      name: "named zod import used at source level",
+      code: `
+        import { z } from "zod";
+
+        export const fooSchema = z.object({ id: z.string() });
+      `,
+    },
+    {
+      name: "default zod import",
+      code: `
+        import z from "zod";
+
+        export const fooSchema = z.object({ id: z.string() });
+      `,
+    },
+    {
+      name: "namespace zod import",
+      code: `
+        import * as zod from "zod";
+
+        export const fooSchema = zod.object({ id: zod.string() });
+      `,
+    },
+    {
+      name: "re-export from zod (load-bearing for declaration emit)",
+      code: `
+        import { initContract } from "@ts-rest/core";
+
+        import { fooSchema } from "./foo.contract";
+        import { barSchema } from "./bar.contract";
+
+        export { z } from "zod";
+
+        export const myContract = initContract().router({
+          foo: { method: "GET", path: "/foo", responses: { 200: fooSchema } },
+          bar: { method: "POST", path: "/bar", body: barSchema, responses: { 201: fooSchema } },
+        });
+      `,
+    },
+    {
+      name: "export-all from zod",
+      code: `
+        export * from "zod";
+      `,
+    },
+    {
+      name: "side-effect import of zod still satisfies the rule",
+      code: `
+        import "zod";
+
+        export const value = 1;
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: "no zod reference — composes schemas from sibling files only (the shiftV3 case)",
+      code: `
+        import { initContract } from "@ts-rest/core";
+
+        import { createDto, createResponse } from "./create.contract";
+        import { listQuery, listResponse } from "./list.contract";
+
+        export const myContract = initContract().router({
+          create: { method: "POST", path: "/x", body: createDto, responses: { 201: createResponse } },
+          list: { method: "GET", path: "/x", query: listQuery, responses: { 200: listResponse } },
+        });
+      `,
+      errors: [{ messageId: "missingZodReference" }],
+    },
+    {
+      name: "imports from unrelated packages but never zod",
+      code: `
+        import { initContract } from "@ts-rest/core";
+
+        export const empty = initContract().router({});
+      `,
+      errors: [{ messageId: "missingZodReference" }],
+    },
+    {
+      name: "imports from a similarly-named package, not zod",
+      code: `
+        import { something } from "zod-extras";
+
+        export const value = something;
+      `,
+      errors: [{ messageId: "missingZodReference" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/lib/rules/require-zod-import-in-contracts/index.ts
+++ b/packages/eslint-plugin/src/lib/rules/require-zod-import-in-contracts/index.ts
@@ -1,0 +1,59 @@
+/**
+ * @fileoverview Require *.contract.ts files to reference "zod" in their own module scope
+ * to prevent a TypeScript declaration-emit bug that silently collapses inferred zod types
+ * to `any` in downstream consumers.
+ */
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+
+import { createRule } from "../../createRule";
+
+const ZOD_MODULE = "zod";
+
+function referencesZod(node: TSESTree.ProgramStatement): boolean {
+  if (
+    node.type === AST_NODE_TYPES.ImportDeclaration ||
+    node.type === AST_NODE_TYPES.ExportAllDeclaration
+  ) {
+    return node.source.value === ZOD_MODULE;
+  }
+
+  if (node.type === AST_NODE_TYPES.ExportNamedDeclaration) {
+    return node.source?.value === ZOD_MODULE;
+  }
+
+  return false;
+}
+
+const rule = createRule({
+  name: "require-zod-import-in-contracts",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require *.contract.ts files to reference 'zod' in their own module scope so TypeScript emits clean declaration types for downstream consumers",
+    },
+    schema: [],
+    messages: {
+      missingZodReference:
+        'Contract files must reference \'zod\' in their own module scope. Without a top-level zod import, TypeScript\'s declaration emit can leak `import("node_modules/zod/...")` paths into the published .d.ts, silently collapsing inferred response types to `any` for downstream consumers. Add `import { z } from "zod"` if you use `z` directly, or `export { z } from "zod"` if you only compose schemas from sibling files (this satisfies both `noUnusedLocals` and the declaration emitter).',
+    },
+  },
+
+  create(context) {
+    return {
+      Program(node) {
+        if (node.body.some(referencesZod)) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: "missingZodReference",
+        });
+      },
+    };
+  },
+});
+
+export default rule;


### PR DESCRIPTION
## Summary

New ESLint rule `@clipboard-health/require-zod-import-in-contracts` that requires every `*.contract.ts` file to reference `"zod"` in its own module scope — either via an `import` (named, default, namespace, or side-effect) or via a re-export (`export { z } from "zod"`, `export * from "zod"`).

Auto-applies to all `*.contract.ts` files via `@clipboard-health/eslint-config`, mirroring how `require-http-module-factory` is applied to `*.module.ts`.

## Why

Prevents the silent type-safety regression documented in [ACT-4870](https://linear.app/clipboardhealth/issue/ACT-4870) ([clipboard-health#25570](https://github.com/ClipboardHealth/clipboard-health/pull/25570)).

When a contract file infers zod-typed schemas from sibling files but doesn't reference zod in its own scope, TypeScript's declaration emit can't reuse a clean `"zod"` specifier and falls back to synthesizing inline imports as `import("node_modules/zod/index.cjs").ZodObject<...>`. That malformed module specifier fails to resolve for downstream consumers, so every type that references it silently collapses to `any` — and `tsc` does not error.

It happened once already (`@clipboard-health/contract-backend-main`'s `shiftV3.contract.ts` shipped 441 leaked paths in v60.15.6, silently breaking `shiftClient.list()`'s response type for `worker-app-bff`). This rule prevents the next occurrence.

## What's in the PR

- `packages/eslint-plugin/src/lib/rules/require-zod-import-in-contracts/index.ts` — rule implementation. Visits `Program` once, checks for any `ImportDeclaration` / `ExportAllDeclaration` / `ExportNamedDeclaration` with `source.value === "zod"`. Reports on the Program node if none found.
- `packages/eslint-plugin/src/lib/rules/require-zod-import-in-contracts/index.test.ts` — vitest tests covering 6 valid forms (named import, default import, namespace import, `export { z } from "zod"`, `export * from "zod"`, side-effect import) and 3 invalid forms (the shiftV3 case, no zod at all, similarly-named-but-not-zod package).
- `packages/eslint-plugin/src/lib/rules/require-zod-import-in-contracts/README.md` — explains the underlying TypeScript declaration-emit pitfall, why the rule exists, and shows both the regular import form and the `export { z } from "zod"` workaround for files that compose schemas from sibling files only.
- `packages/eslint-plugin/src/index.ts` — registers the rule alongside existing rules.
- `packages/eslint-config/src/index.js` — auto-applies the rule to `**/*.contract.ts`.

## Verification

- `nx test eslint-plugin`: all 42 tests pass (33 existing + 9 new).
- `nx lint eslint-plugin`: clean.
- End-to-end against the live motivating file: ran the rule against the actual `shiftV3.contract.ts` source from `clipboard-health` checked out at `../clipboard-health`. With the current `export { z } from "zod"` line present → no error. With that line stripped (the pre-fix state that shipped v60.15.6) → fires `missingZodReference`. (Temporary verification test was deleted before commit.)

## Test plan

- [ ] CI green
- [ ] After this lands and `@clipboard-health/eslint-plugin` + `@clipboard-health/eslint-config` are republished, follow up by bumping both in `clipboard-health` (and any other consumer) and verifying the rule is active. The rule should produce no errors against current `*.contract.ts` files in `clipboard-health/packages/contract-backend-main/` since they all already have a zod import — `shiftV3.contract.ts` is the only file that previously didn't, and ACT-4870 fixed it.

Linear: [ACT-4873](https://linear.app/clipboardhealth/issue/ACT-4873)

_Posted by Claude Code_