### PR TITLE
feat: add no swallowed invariant guard rule (STAFF-1188)

### DIFF
--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -167,6 +167,10 @@ module.exports = {
   parser: "@typescript-eslint/parser",
   plugins,
   rules: {
+    ...(isOutsideCoreUtilsMonorepo
+      ? { "@clipboard-health/no-swallowed-invariant-guard": "warn" }
+      : {}),
+
     // Start: Deprecated rules removed in v8
     "@typescript-eslint/ban-types": "off",
     "@typescript-eslint/lines-between-class-members": "off",

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -34,6 +34,23 @@ module.exports = {
 };
 ```
 
+## Rules
+
+### `@clipboard-health/no-swallowed-invariant-guard`
+
+Flags a `catch` clause that swallows a failed invariant guard and continues. Guard calls are
+identified by function names beginning with `ensure`, `assert`, `throwIf`, `validate`, or `verify`.
+
+The rule allows catches that rethrow, return an error-like value, or explicitly record the violation
+with a helper whose name starts with `record` or `report` and includes `Violation`, such as
+`recordInvariantViolation`.
+
+Use a standard disable comment for intentional exceptions:
+
+```ts
+// eslint-disable-next-line @clipboard-health/no-swallowed-invariant-guard -- reason
+```
+
 ## Local development commands
 
 See [`package.json`](./package.json) `scripts` for a list of commands.

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,9 +1,11 @@
 import enforceTsRestInControllers from "./lib/rules/enforce-ts-rest-in-controllers";
+import noSwallowedInvariantGuard from "./lib/rules/no-swallowed-invariant-guard";
 import requireHttpModuleFactory from "./lib/rules/require-http-module-factory";
 import requireRunValidatorsWithUpsert from "./lib/rules/require-run-validators-with-upsert";
 
 export const rules = {
   "enforce-ts-rest-in-controllers": enforceTsRestInControllers,
+  "no-swallowed-invariant-guard": noSwallowedInvariantGuard,
   "require-http-module-factory": requireHttpModuleFactory,
   "require-run-validators-with-upsert": requireRunValidatorsWithUpsert,
 };

--- a/packages/eslint-plugin/src/lib/rules/no-swallowed-invariant-guard/index.test.ts
+++ b/packages/eslint-plugin/src/lib/rules/no-swallowed-invariant-guard/index.test.ts
@@ -1,0 +1,239 @@
+import { TSESLint } from "@typescript-eslint/utils";
+
+import rule from "./index";
+
+// eslint-disable-next-line n/no-unpublished-require
+const parser = require.resolve("@typescript-eslint/parser");
+
+const ruleTester = new TSESLint.RuleTester({
+  parser,
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: "module",
+  },
+});
+
+ruleTester.run("no-swallowed-invariant-guard", rule, {
+  valid: [
+    {
+      name: "rethrows guard failure",
+      code: `
+        async function updateUser() {
+          try {
+            await ensureNoConflictingCognitoUser(user);
+          } catch (error) {
+            throw error;
+          }
+        }
+      `,
+    },
+    {
+      name: "returns caught error",
+      code: `
+        function updateUser() {
+          try {
+            assertValidUser(user);
+          } catch (error) {
+            return error;
+          }
+        }
+      `,
+    },
+    {
+      name: "returns explicit failure value",
+      code: `
+        function updateUser() {
+          try {
+            verifyUserCanUpdate(user);
+          } catch (error) {
+            return failure(error);
+          }
+        }
+      `,
+    },
+    {
+      name: "returns error factory value",
+      code: `
+        function updateUser() {
+          try {
+            verifyUserCanUpdate(user);
+          } catch (error) {
+            return ServiceError.from(error);
+          }
+        }
+      `,
+    },
+    {
+      name: "records invariant violation explicitly",
+      code: `
+        async function updateUser() {
+          try {
+            await throwIfIdentifierCollision(user);
+          } catch (error) {
+            await recordInvariantViolation(error);
+            logger.warn("identifier collision", error);
+            return { ok: true };
+          }
+        }
+      `,
+    },
+    {
+      name: "ignores swallowed catch without guard call",
+      code: `
+        function updateUser() {
+          try {
+            maybeUpdateUser(user);
+          } catch (error) {
+            logger.warn("optional update failed", error);
+          }
+        }
+      `,
+    },
+    {
+      name: "ignores guard call inside nested function definition",
+      code: `
+        function updateUser() {
+          try {
+            const checkUser = () => ensureNoConflictingCognitoUser(user);
+            registerCallback(checkUser);
+          } catch (error) {
+            logger.warn("callback registration failed", error);
+          }
+        }
+      `,
+    },
+    {
+      name: "requires both conditional branches to rethrow",
+      code: `
+        function updateUser() {
+          try {
+            validateUser(user);
+          } catch (error) {
+            if (isServiceError(error)) {
+              throw error;
+            } else {
+              throw new Error("Unexpected guard failure");
+            }
+          }
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: "inc-406 shape logs and returns success",
+      code: `
+        async function updateCognitoUserAttributes() {
+          try {
+            await ensureNoConflictingCognitoUser(user);
+          } catch (error) {
+            logger.warn("Cognito conflict check failed during attribute update, skipping update", error);
+            return { ok: true };
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: "swallowedGuard",
+          data: { functionName: "ensureNoConflictingCognitoUser" },
+        },
+      ],
+    },
+    {
+      name: "logs and continues after assert guard failure",
+      code: `
+        function updateUser() {
+          try {
+            assertUserCanUpdate(user);
+          } catch (error) {
+            logger.warn("user update pre-check failed", error);
+          }
+
+          updateUserRecord(user);
+        }
+      `,
+      errors: [
+        {
+          messageId: "swallowedGuard",
+          data: { functionName: "assertUserCanUpdate" },
+        },
+      ],
+    },
+    {
+      name: "returns undefined after member validate guard failure",
+      code: `
+        function updateUser() {
+          try {
+            validator.validateUser(user);
+          } catch (error) {
+            return undefined;
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: "swallowedGuard",
+          data: { functionName: "validateUser" },
+        },
+      ],
+    },
+    {
+      name: "conditionally rethrows with fallthrough",
+      code: `
+        function updateUser() {
+          try {
+            throwIfIdentifierCollision(user);
+          } catch (error) {
+            if (shouldRethrow(error)) {
+              throw error;
+            }
+
+            logger.warn("collision check failed", error);
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: "swallowedGuard",
+          data: { functionName: "throwIfIdentifierCollision" },
+        },
+      ],
+    },
+    {
+      name: "verify guard returns non-error value",
+      code: `
+        function updateUser() {
+          try {
+            verifyUserCanUpdate(user);
+          } catch (error) {
+            return { status: "updated" };
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: "swallowedGuard",
+          data: { functionName: "verifyUserCanUpdate" },
+        },
+      ],
+    },
+    {
+      name: "returning logger error call still swallows",
+      code: `
+        function updateUser() {
+          try {
+            verifyUserCanUpdate(user);
+          } catch (error) {
+            return logger.error("guard failed", error);
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: "swallowedGuard",
+          data: { functionName: "verifyUserCanUpdate" },
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/lib/rules/no-swallowed-invariant-guard/index.ts
+++ b/packages/eslint-plugin/src/lib/rules/no-swallowed-invariant-guard/index.ts
@@ -1,0 +1,353 @@
+/**
+ * @fileoverview Rule to forbid catches that silently swallow invariant guard failures
+ */
+import { AST_NODE_TYPES, type TSESLint, type TSESTree } from "@typescript-eslint/utils";
+
+import { createRule } from "../../createRule";
+
+const GUARD_NAME_PREFIXES = ["ensure", "assert", "throwIf", "validate", "verify"] as const;
+
+const EXPLICIT_VIOLATION_HELPER_PREFIXES = ["record", "report"] as const;
+
+const NESTED_EXECUTABLE_BOUNDARY_NODE_TYPES = new Set<AST_NODE_TYPES>([
+  AST_NODE_TYPES.ArrowFunctionExpression,
+  AST_NODE_TYPES.ClassDeclaration,
+  AST_NODE_TYPES.ClassExpression,
+  AST_NODE_TYPES.FunctionDeclaration,
+  AST_NODE_TYPES.FunctionExpression,
+  AST_NODE_TYPES.TSDeclareFunction,
+  AST_NODE_TYPES.TSEmptyBodyFunctionExpression,
+]);
+
+type VisitorKeys = TSESLint.SourceCode["visitorKeys"];
+
+const rule = createRule({
+  name: "no-swallowed-invariant-guard",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Forbid catches that silently swallow invariant guard failures",
+    },
+    schema: [],
+    messages: {
+      swallowedGuard:
+        "This `catch` swallows a failed invariant guard (`{{functionName}}`) and continues. Rethrow, or record the violation explicitly — do not log-and-continue (cf. inc-406).",
+    },
+  },
+
+  create(context) {
+    return {
+      TryStatement(node) {
+        if (!node.handler) {
+          return;
+        }
+
+        const guardFunctionName = findGuardFunctionName(node.block, context.sourceCode.visitorKeys);
+        if (!guardFunctionName) {
+          return;
+        }
+
+        if (catchHandlesGuardFailure(node.handler, context.sourceCode.visitorKeys)) {
+          return;
+        }
+
+        context.report({
+          node: node.handler,
+          messageId: "swallowedGuard",
+          data: { functionName: guardFunctionName },
+        });
+      },
+    };
+  },
+});
+
+export default rule;
+
+function findGuardFunctionName(
+  block: TSESTree.BlockStatement,
+  visitorKeys: VisitorKeys,
+): string | undefined {
+  let guardFunctionName: string | undefined;
+
+  findDescendant(block, visitorKeys, (node) => {
+    if (node.type !== AST_NODE_TYPES.CallExpression) {
+      return false;
+    }
+
+    const functionName = getCallTargetName(node);
+    if (!functionName || !isGuardFunctionName(functionName)) {
+      return false;
+    }
+
+    guardFunctionName = functionName;
+    return true;
+  });
+
+  return guardFunctionName;
+}
+
+function catchHandlesGuardFailure(
+  catchClause: TSESTree.CatchClause,
+  visitorKeys: VisitorKeys,
+): boolean {
+  return (
+    containsExplicitViolationHelperCall(catchClause.body, visitorKeys) ||
+    blockGuaranteesErrorExit(catchClause.body)
+  );
+}
+
+function containsExplicitViolationHelperCall(
+  block: TSESTree.BlockStatement,
+  visitorKeys: VisitorKeys,
+): boolean {
+  return Boolean(
+    findDescendant(block, visitorKeys, (node) => {
+      if (node.type !== AST_NODE_TYPES.CallExpression) {
+        return false;
+      }
+
+      const functionName = getCallTargetName(node);
+      return Boolean(functionName && isExplicitViolationHelperName(functionName));
+    }),
+  );
+}
+
+function blockGuaranteesErrorExit(block: TSESTree.BlockStatement): boolean {
+  return block.body.some((statement) => statementGuaranteesErrorExit(statement));
+}
+
+function statementGuaranteesErrorExit(statement: TSESTree.Statement): boolean {
+  if (statement.type === AST_NODE_TYPES.ThrowStatement) {
+    return true;
+  }
+
+  if (statement.type === AST_NODE_TYPES.ReturnStatement) {
+    return Boolean(statement.argument && isErrorLikeExpression(statement.argument));
+  }
+
+  if (statement.type === AST_NODE_TYPES.BlockStatement) {
+    return blockGuaranteesErrorExit(statement);
+  }
+
+  if (statement.type === AST_NODE_TYPES.IfStatement) {
+    return Boolean(
+      statement.alternate &&
+      statementGuaranteesErrorExit(statement.consequent) &&
+      statementGuaranteesErrorExit(statement.alternate),
+    );
+  }
+
+  return false;
+}
+
+function isErrorLikeExpression(expression: TSESTree.Expression): boolean {
+  if (expression.type === AST_NODE_TYPES.Identifier) {
+    return isErrorLikeName(expression.name);
+  }
+
+  if (expression.type === AST_NODE_TYPES.CallExpression) {
+    return isErrorLikeCallExpression(expression);
+  }
+
+  if (expression.type === AST_NODE_TYPES.NewExpression) {
+    const constructedName = getConstructedName(expression);
+    return Boolean(constructedName && isErrorLikeName(constructedName));
+  }
+
+  if (expression.type === AST_NODE_TYPES.ObjectExpression) {
+    return expression.properties.some((property) => {
+      if (property.type !== AST_NODE_TYPES.Property) {
+        return false;
+      }
+
+      const propertyName = getPropertyName(property);
+      return Boolean(propertyName && isErrorLikeName(propertyName));
+    });
+  }
+
+  if (expression.type === AST_NODE_TYPES.AwaitExpression) {
+    return isErrorLikeExpression(expression.argument);
+  }
+
+  if (expression.type === AST_NODE_TYPES.ChainExpression) {
+    return isErrorLikeExpression(expression.expression);
+  }
+
+  if (
+    expression.type === AST_NODE_TYPES.TSAsExpression ||
+    expression.type === AST_NODE_TYPES.TSNonNullExpression ||
+    expression.type === AST_NODE_TYPES.TSSatisfiesExpression ||
+    expression.type === AST_NODE_TYPES.TSTypeAssertion
+  ) {
+    return isErrorLikeExpression(expression.expression);
+  }
+
+  return false;
+}
+
+function isErrorLikeCallExpression(expression: TSESTree.CallExpression): boolean {
+  if (expression.callee.type === AST_NODE_TYPES.Identifier) {
+    return isErrorLikeName(expression.callee.name);
+  }
+
+  if (isPromiseRejectCall(expression)) {
+    return true;
+  }
+
+  return (
+    expression.callee.type === AST_NODE_TYPES.MemberExpression &&
+    expression.callee.object.type === AST_NODE_TYPES.Identifier &&
+    isErrorLikeName(expression.callee.object.name)
+  );
+}
+
+function isPromiseRejectCall(expression: TSESTree.CallExpression): boolean {
+  return (
+    expression.callee.type === AST_NODE_TYPES.MemberExpression &&
+    expression.callee.object.type === AST_NODE_TYPES.Identifier &&
+    expression.callee.object.name === "Promise" &&
+    getPropertyName(expression.callee) === "reject"
+  );
+}
+
+function findDescendant(
+  root: TSESTree.Node,
+  visitorKeys: VisitorKeys,
+  predicate: (node: TSESTree.Node) => boolean,
+): TSESTree.Node | undefined {
+  const stack = [root];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) {
+      continue;
+    }
+
+    if (predicate(current)) {
+      return current;
+    }
+
+    if (current !== root && isNestedExecutableBoundary(current)) {
+      continue;
+    }
+
+    const childNodes = getChildNodes(current, visitorKeys);
+    for (let index = childNodes.length - 1; index >= 0; index -= 1) {
+      const childNode = childNodes[index];
+      if (childNode) {
+        stack.push(childNode);
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function getChildNodes(node: TSESTree.Node, visitorKeys: VisitorKeys): TSESTree.Node[] {
+  const keys = visitorKeys[node.type] ?? [];
+  const nodeFields = node as unknown as Record<string, unknown>;
+  const childNodes: TSESTree.Node[] = [];
+
+  for (const key of keys) {
+    const value = nodeFields[key];
+    if (isNode(value)) {
+      childNodes.push(value);
+      continue;
+    }
+
+    if (!Array.isArray(value)) {
+      continue;
+    }
+
+    for (const item of value) {
+      if (isNode(item)) {
+        childNodes.push(item);
+      }
+    }
+  }
+
+  return childNodes;
+}
+
+function isNode(value: unknown): value is TSESTree.Node {
+  return (
+    typeof value === "object" && value !== null && "type" in value && typeof value.type === "string"
+  );
+}
+
+function isNestedExecutableBoundary(node: TSESTree.Node): boolean {
+  return NESTED_EXECUTABLE_BOUNDARY_NODE_TYPES.has(node.type);
+}
+
+function getCallTargetName(callExpression: TSESTree.CallExpression): string | undefined {
+  return getExpressionName(callExpression.callee);
+}
+
+function getConstructedName(newExpression: TSESTree.NewExpression): string | undefined {
+  return getExpressionName(newExpression.callee);
+}
+
+function getExpressionName(node: TSESTree.Node): string | undefined {
+  if (node.type === AST_NODE_TYPES.Identifier) {
+    return node.name;
+  }
+
+  if (node.type === AST_NODE_TYPES.MemberExpression) {
+    return getPropertyName(node);
+  }
+
+  if (node.type === AST_NODE_TYPES.ChainExpression) {
+    return getExpressionName(node.expression);
+  }
+
+  if (
+    node.type === AST_NODE_TYPES.TSAsExpression ||
+    node.type === AST_NODE_TYPES.TSNonNullExpression ||
+    node.type === AST_NODE_TYPES.TSSatisfiesExpression ||
+    node.type === AST_NODE_TYPES.TSTypeAssertion
+  ) {
+    return getExpressionName(node.expression);
+  }
+
+  return undefined;
+}
+
+function getPropertyName(node: TSESTree.MemberExpression | TSESTree.Property): string | undefined {
+  const property = node.type === AST_NODE_TYPES.MemberExpression ? node.property : node.key;
+
+  if (property.type === AST_NODE_TYPES.Identifier) {
+    return property.name;
+  }
+
+  if (property.type === AST_NODE_TYPES.Literal && typeof property.value === "string") {
+    return property.value;
+  }
+
+  return undefined;
+}
+
+function isGuardFunctionName(functionName: string): boolean {
+  return GUARD_NAME_PREFIXES.some((prefix) => functionName.startsWith(prefix));
+}
+
+function isExplicitViolationHelperName(functionName: string): boolean {
+  const lowerCaseFunctionName = functionName.toLowerCase();
+
+  return (
+    lowerCaseFunctionName.includes("violation") &&
+    EXPLICIT_VIOLATION_HELPER_PREFIXES.some((prefix) => lowerCaseFunctionName.startsWith(prefix))
+  );
+}
+
+function isErrorLikeName(name: string): boolean {
+  const lowerCaseName = name.toLowerCase();
+
+  return (
+    lowerCaseName.includes("error") ||
+    lowerCaseName === "err" ||
+    lowerCaseName.endsWith("err") ||
+    lowerCaseName.includes("failure") ||
+    lowerCaseName.includes("violation")
+  );
+}


### PR DESCRIPTION
## Summary

Adds `@clipboard-health/no-swallowed-invariant-guard`, a custom ESLint rule that flags `catch` clauses which swallow failed invariant guard calls and continue. Guard calls use the proposed prefix predicate: `ensure`, `assert`, `throwIf`, `validate`, and `verify`.

The rule is exported from `@clipboard-health/eslint-plugin`, enabled as `warn` in `@clipboard-health/eslint-config` when the plugin is loaded, and documented in the plugin README with the standard disable-comment escape hatch. Explicit handling is allowed when the catch rethrows, returns an error-like value, or records a violation through a `record*Violation` / `report*Violation` helper.

## Validation

- `NX_WORKSPACE_DATA_DIRECTORY=/Users/rocky/dev/c/core-utils-staff-1188/.nx/workspace-data NX_CACHE_DIRECTORY=/Users/rocky/dev/c/core-utils-staff-1188/.nx/cache npm exec nx -- run eslint-plugin:test`
- `NX_WORKSPACE_DATA_DIRECTORY=/Users/rocky/dev/c/core-utils-staff-1188/.nx/workspace-data NX_CACHE_DIRECTORY=/Users/rocky/dev/c/core-utils-staff-1188/.nx/cache npm exec nx -- run eslint-plugin:lint`
- `NX_WORKSPACE_DATA_DIRECTORY=/Users/rocky/dev/c/core-utils-staff-1188/.nx/workspace-data NX_CACHE_DIRECTORY=/Users/rocky/dev/c/core-utils-staff-1188/.nx/cache npm exec nx -- run eslint-plugin:build --skipSync`
- `NX_WORKSPACE_DATA_DIRECTORY=/Users/rocky/dev/c/core-utils-staff-1188/.nx/workspace-data NX_CACHE_DIRECTORY=/Users/rocky/dev/c/core-utils-staff-1188/.nx/cache npm exec nx -- run eslint-config:lint`
- `NX_WORKSPACE_DATA_DIRECTORY=/Users/rocky/dev/c/core-utils-staff-1188/.nx/workspace-data NX_CACHE_DIRECTORY=/Users/rocky/dev/c/core-utils-staff-1188/.nx/cache npm exec nx -- run eslint-config:build --skipSync`
- `NX_WORKSPACE_DATA_DIRECTORY=/Users/rocky/dev/c/core-utils-staff-1188/.nx/workspace-data NX_CACHE_DIRECTORY=/Users/rocky/dev/c/core-utils-staff-1188/.nx/cache node --run verify`
- Pre-push hook reran `node --run verify` and passed.
- Monorepo advisory scan with only `@clipboard-health/no-swallowed-invariant-guard` enabled over `packages/`, `scripts/`, and root TS/JS sources: `hit_count=0`.

## Notes

Closes staff-1188

Kept the initial severity at `warn` and the proposed guard prefix set. Build targets required `--skipSync` because Nx reported pre-existing TypeScript project-reference sync drift before compiling; the compile steps themselves passed.

Agent session: `codex resume 019e8616-50d3-7071-a514-9c09ad2cc0ac`

<sub>🤖 <code>commit-push-pr:created v1 core@3.6.0</code></sub>
