### PR TITLE
docs: normalize core skill references

### DIFF
--- a/plugins/core/skills/commit-push-pr/SKILL.md
+++ b/plugins/core/skills/commit-push-pr/SKILL.md
@@ -14,9 +14,9 @@ description: Commit, push, and open a PR. Use when the user wants to ship change
 
 ## Your task
 
-If `Commits ahead of default branch` is `(unknown)`, `origin/HEAD` couldn't be resolved — stop and tell the user to run `git remote set-head origin -a` (or otherwise set the default branch) before retrying, since the simplify step also depends on it. Otherwise, if `Git status`, `Commits ahead of default branch`, and `Existing PR` are all empty/none, stop and reply `nothing to ship.`. Otherwise:
+If `Commits ahead of default branch` is `(unknown)`, `origin/HEAD` couldn't be resolved — stop and tell the user to run `git remote set-head origin -a` (or otherwise set the default branch) before retrying, since the `core:simplify` step also depends on it. Otherwise, if `Git status`, `Commits ahead of default branch`, and `Existing PR` are all empty/none, stop and reply `nothing to ship.`. Otherwise:
 
-Before doing any step, output the full 7-step checklist below in your first response so it stays in recent context across sub-skill calls. Do not skip this — it's what keeps you from stopping after `simplify`.
+Before doing any step, output the full 7-step checklist below in your first response so it stays in recent context across sub-skill calls. Do not skip this — it's what keeps you from stopping after `core:simplify`.
 
 Use this PR body shape when creating or refreshing descriptions:
 
@@ -40,7 +40,7 @@ Optional: ticket links, rollout plan, residual risk, or areas for reviewers to f
 Script paths in this procedure are written as `scripts/...`, relative to this SKILL.md. When executing a bundled script, run it from this skill directory or resolve it to this skill's installed directory; do not look for it at the repository root.
 
 1. Create a new branch if on main (e.g., `feat/add-user-validation`, `fix/null-check-in-parser`).
-2. Run the `simplify` skill on the full PR diff — `git diff $(git merge-base HEAD origin/HEAD)..HEAD` plus any uncommitted changes. When it returns, your very next action is to restate the remaining steps (3–7) and continue with step 3 in the same turn. Do not stop, do not end the turn with a simplify summary.
+2. Run the `core:simplify` skill on the full PR diff — `git diff $(git merge-base HEAD origin/HEAD)..HEAD` plus any uncommitted changes. When it returns, your very next action is to restate the remaining steps (3–7) and continue with step 3 in the same turn. Do not stop, do not end the turn with a `core:simplify` summary.
 3. If `git status --short` shows changes, create a single conventional commit with `git commit --no-gpg-sign`.
 4. Push the branch to origin.
 5. Look up the current agent session ID by running this skill's bundled script: `bash scripts/find-session-id.sh '<phrase>'`. Pass a distinctive verbatim chunk (≥10 words) from the most recent user message; see the script header for quoting constraints. If the script prints `codex <id>`, use ``Agent session: `codex resume <id>` ``. If it prints `claude-code <id>`, use ``Agent session: `claude --resume <id>` ``. Keep the resume command in backticks so it renders as code in the PR description. If empty, there is no session footer line.

--- a/plugins/core/skills/create-groundcrew-ticket/SKILL.md
+++ b/plugins/core/skills/create-groundcrew-ticket/SKILL.md
@@ -52,7 +52,7 @@ Use a direct implementation-shaped ticket. Keep the repository line near the top
 ## Groundcrew
 
 Repository: <repo>
-Implementation workflow: use the `core:go`/`go` skill when available. If that skill is unavailable, follow this repo's AGENTS.md/CLAUDE.md implementation workflow and run the documented verification.
+Implementation workflow: use the `core:go` skill when available. If the current host exposes the same skill without plugin namespaces, use that equivalent. If that skill is unavailable, follow this repo's AGENTS.md/CLAUDE.md implementation workflow and run the documented verification.
 
 ## Task
 

--- a/plugins/core/skills/flaky-test-bulk-debugger/SKILL.md
+++ b/plugins/core/skills/flaky-test-bulk-debugger/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: flaky-test-bulk-debugger
-description: Bulk-triage flaky test investigation tickets by clustering sightings, sharing artifacts, and delegating per-cluster diagnosis to flaky-test-debugger. Use when investigating many flaky test tickets, Linear issues tagged flaky-investigation, CI flake bursts, or repeated failures that may share a root cause.
+description: Bulk-triage flaky test investigation tickets by clustering sightings, sharing artifacts, and delegating per-cluster diagnosis to core:flaky-test-debugger. Use when investigating many flaky test tickets, Linear issues tagged flaky-investigation, CI flake bursts, or repeated failures that may share a root cause.
 ---
 
 # Flaky Test Bulk Debugger
 
-Use this skill to investigate a queue of flaky test sightings efficiently. Its purpose is orchestration: collect tickets, build a compact manifest, cluster related failures, fetch shared artifacts once, then run `flaky-test-debugger` per cluster.
+Use this skill to investigate a queue of flaky test sightings efficiently. Its purpose is orchestration: collect tickets, build a compact manifest, cluster related failures, fetch shared artifacts once, then run `core:flaky-test-debugger` per cluster.
 
-Do not duplicate the detailed diagnosis workflow from `flaky-test-debugger`. When a cluster is ready for root-cause analysis, use `flaky-test-debugger` in plan mode unless the user explicitly asks to implement fixes.
+Do not duplicate the detailed diagnosis workflow from `core:flaky-test-debugger`. When a cluster is ready for root-cause analysis, use `core:flaky-test-debugger` in plan mode unless the user explicitly asks to implement fixes.
 
 ## Rules
 
@@ -35,7 +35,7 @@ Normalize errors before grouping:
 Cluster by strongest shared evidence first:
 
 1. Same CI run, commit, timestamp window, and setup/helper stack.
-2. Same failure surface from `flaky-test-debugger`: CI/job setup, test setup/auth/data, app bootstrap/navigation, user action, backend request, post-success render, assertion/locator.
+2. Same failure surface from `core:flaky-test-debugger`: CI/job setup, test setup/auth/data, app bootstrap/navigation, user action, backend request, post-success render, assertion/locator.
 3. Same first project stack frame or setup helper.
 4. Same endpoint/static asset/status-code pattern.
 5. Same test file or prior related tickets.
@@ -54,12 +54,12 @@ Record artifact paths in the manifest. Workers should receive paths and the rele
 
 ## Phase 4: Diagnose Clusters
 
-For each cluster, run `flaky-test-debugger` in plan mode. If the agent supports skills, explicitly load or invoke `flaky-test-debugger`; otherwise follow its workflow manually.
+For each cluster, run `core:flaky-test-debugger` in plan mode. If the agent supports skills, explicitly load or invoke `core:flaky-test-debugger`; otherwise follow its workflow manually.
 
 Use this worker prompt shape:
 
 ```text
-Use flaky-test-debugger in plan mode.
+Use core:flaky-test-debugger in plan mode.
 Investigate this cluster as one possible shared root cause, not as isolated tickets.
 
 Inputs: cluster summary, manifest rows, artifact/report paths, prior related tickets, and source ticket close-out instructions.

--- a/plugins/core/skills/flaky-test-debugger/references/fix.md
+++ b/plugins/core/skills/flaky-test-debugger/references/fix.md
@@ -1,6 +1,6 @@
 # Apply a Flaky Test Fix
 
-Apply phase of the flaky-test-debugger skill. Takes a plan produced by [`plan.md`](./plan.md) and applies it.
+Apply phase of the `core:flaky-test-debugger` skill. Takes a plan produced by [`plan.md`](./plan.md) and applies it.
 
 ## Preflight
 

--- a/plugins/core/skills/flaky-test-debugger/references/plan.md
+++ b/plugins/core/skills/flaky-test-debugger/references/plan.md
@@ -1,6 +1,6 @@
 # Plan a Flaky Test Fix
 
-Diagnosis and planning phase of the flaky-test-debugger skill. Produces a structured plan that the user reviews. In fix mode, the plan is consumed by [`fix.md`](./fix.md).
+Diagnosis and planning phase of the `core:flaky-test-debugger` skill. Produces a structured plan that the user reviews. In fix mode, the plan is consumed by [`fix.md`](./fix.md).
 
 Route by the test type identified in Phase 1 of SKILL.md:
 

--- a/plugins/core/skills/go/SKILL.md
+++ b/plugins/core/skills/go/SKILL.md
@@ -1,10 +1,10 @@
 ---
-description: Implement a plan file or direct request end-to-end, then hand off to commit-push-pr to ship it. Use when the user says 'go', 'execute the plan', 'implement the plan', or gives an implementation request.
+description: Implement a plan file or direct request end-to-end, then hand off to core:commit-push-pr to ship it. Use when the user says 'go', 'execute the plan', 'implement the plan', or gives an implementation request.
 ---
 
 # Go: Execute Work and Ship It
 
-Given a plan file or direct implementation request, implement the requested work, then invoke the `commit-push-pr` skill to create a PR.
+Given a plan file or direct implementation request, implement the requested work, then invoke the `core:commit-push-pr` skill to create a PR.
 
 This skill is the bridge between intent and shipping. It does not re-plan or re-design unless the user asked for that. If the request is wrong or cannot be implemented safely, surface that; do not silently improvise.
 
@@ -30,16 +30,16 @@ The plan or request is the source of truth for scope:
 ## Phase 3: Validate
 
 - Read `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, or equivalent contributor instructions for the mandated pre-PR command (e.g. `node --run verify`). That wins over everything.
-- If the repo relies on pre-commit/pre-push hooks and mandates no manual command, don't invent one — let the hooks run during the `commit-push-pr` handoff.
+- If the repo relies on pre-commit/pre-push hooks and mandates no manual command, don't invent one — let the hooks run during the `core:commit-push-pr` handoff.
 - If the plan names specific checks, run them when practical. Ask before running anything that's clearly a slow CI-only suite.
 
 Fix any failures before handing off. Do not hand off with known failing checks unless the user explicitly accepts a pre-existing or unrelated failure.
 
 ## Phase 4: Hand Off
 
-Invoke the `commit-push-pr` skill. Do not commit, push, or open the PR yourself.
+Invoke the `core:commit-push-pr` skill. Do not commit, push, or open the PR yourself.
 
-If `commit-push-pr` reports `nothing to ship.`, surface that.
+If `core:commit-push-pr` reports `nothing to ship.`, surface that.
 
 ## Phase 5: Final Output
 

--- a/plugins/core/skills/interview-feature/SKILL.md
+++ b/plugins/core/skills/interview-feature/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: interview-feature
-description: Use when clarifying requirements for a feature ticket. Iteratively researches and interviews the user until the problem is well-understood, then produces a structured problem brief. Dispatched by write-feature-ticket when context is insufficient.
+description: Use when clarifying requirements for a feature ticket. Iteratively researches and interviews the user until the problem is well-understood, then produces a structured problem brief. Dispatched by core:write-feature-ticket when context is insufficient.
 ---
 
 # Interview Feature
@@ -9,7 +9,7 @@ You are an opinionated product thinker. Your job is to achieve problem clarity b
 
 ## Behavioral Rules
 
-1. **Research first, ask second.** Before asking the user any question, check if you can answer it yourself. Dispatch the `investigate-ticket` skill for codebase, Datadog, and Snowflake research. The user is the last resort for information, not the first. When researching solution-shaped input, look for evidence of the _problem the solution implies_ — not confirmation that the solution is a good idea. The goal is to surface the pain point, not validate the implementation.
+1. **Research first, ask second.** Before asking the user any question, check if you can answer it yourself. Dispatch the `core:investigate-ticket` skill for codebase, Datadog, and Snowflake research. The user is the last resort for information, not the first. When researching solution-shaped input, look for evidence of the _problem the solution implies_ — not confirmation that the solution is a good idea. The goal is to surface the pain point, not validate the implementation.
 2. **Refuse solution-shaped input.** A request is **solution-shaped** if it names a technology, architectural mechanism, or implementation detail without stating the user-facing problem it addresses. If the request describes _how_ to build something ("add a Redis cache", "create an endpoint for X"), reframe to the underlying problem. If the user insists on a solution without articulating a problem after pushback, refuse to produce a problem brief and explain: "I can't write a good feature ticket without understanding the problem it solves. If you want to write a solution-shaped ticket, you'll need to do that manually." End the interview — do not produce a problem brief with a solution disguised as a problem.
 3. **Separate problem from solution when bundled.** If the user provides a problem AND a solution together ("bookings are slow, add Redis"), accept the problem as your starting point, explicitly acknowledge it, and tell the user you're setting the solution aside. Continue interviewing from the problem. This is NOT a refusal — a real problem was stated. Only refuse when the user provides a solution with NO problem.
 4. **Never invent answers.** If you don't know and can't find it, ask. If nobody knows, document it as an explicit unknown — never silently fill a gap with a plausible guess.
@@ -22,7 +22,7 @@ You are an opinionated product thinker. Your job is to achieve problem clarity b
 digraph interview_loop {
     "Assess: what do I know\nvs what's missing?" [shape=box];
     "Can I find the\nanswer myself?" [shape=diamond];
-    "Dispatch investigate-ticket" [shape=box];
+    "Dispatch core:investigate-ticket" [shape=box];
     "New questions\nfrom findings?" [shape=diamond];
     "Ask the user\n(1 question per message)" [shape=box];
     "New questions\nfrom answer?" [shape=diamond];
@@ -30,9 +30,9 @@ digraph interview_loop {
     "Produce problem brief" [shape=doublecircle];
 
     "Assess: what do I know\nvs what's missing?" -> "Can I find the\nanswer myself?";
-    "Can I find the\nanswer myself?" -> "Dispatch investigate-ticket" [label="yes"];
+    "Can I find the\nanswer myself?" -> "Dispatch core:investigate-ticket" [label="yes"];
     "Can I find the\nanswer myself?" -> "Ask the user\n(1 question per message)" [label="no"];
-    "Dispatch investigate-ticket" -> "New questions\nfrom findings?";
+    "Dispatch core:investigate-ticket" -> "New questions\nfrom findings?";
     "New questions\nfrom findings?" -> "Assess: what do I know\nvs what's missing?" [label="yes"];
     "New questions\nfrom findings?" -> "Clarity gate\npassed?" [label="no"];
     "Ask the user\n(1 question per message)" -> "New questions\nfrom answer?";
@@ -57,7 +57,7 @@ ALL must be satisfied (or explicitly marked unknown with justification):
 
 When you hit a gap you can't fill:
 
-1. Try to find the answer yourself (dispatch `investigate-ticket`)
+1. Try to find the answer yourself (dispatch `core:investigate-ticket`)
 2. Ask the user targeted questions (one per message)
 3. Suggest external research the user could do (stakeholders, support tickets, analytics)
 4. Document remaining unknowns explicitly and proceed
@@ -66,6 +66,6 @@ When you hit a gap you can't fill:
 
 ## Output
 
-When the clarity gate passes, produce a **problem brief** in the format defined in [problem-brief.md](problem-brief.md). Present it to the user for confirmation before handing back to `write-feature-ticket`.
+When the clarity gate passes, produce a **problem brief** in the format defined in [problem-brief.md](problem-brief.md). Present it to the user for confirmation before handing back to `core:write-feature-ticket`.
 
 **For interview examples** showing good pushback and common anti-patterns, see [examples.md](examples.md).

--- a/plugins/core/skills/interview-feature/examples.md
+++ b/plugins/core/skills/interview-feature/examples.md
@@ -6,7 +6,7 @@
 >
 > **Agent:** Before I can write a ticket, I need to understand the problem Redis would solve. What's happening today that's painful? Are bookings slow? Are users seeing errors? Let me check Datadog for booking service performance first.
 >
-> _(Agent dispatches investigate-ticket, finds p99 latency at 4.2s)_
+> _(Agent dispatches `core:investigate-ticket`, finds p99 latency at 4.2s)_
 >
 > **Agent:** I found that booking lookups have a p99 of 4.2s — that's high. Who is this affecting most? Is it nurses searching for shifts, or facilities reviewing bookings?
 >
@@ -28,7 +28,7 @@
 >
 > **Agent:** Let me understand the current state before I ask you questions.
 >
-> _(Agent dispatches investigate-ticket — traces notification code, checks Snowflake for notification volumes, checks Datadog for delivery rates)_
+> _(Agent dispatches `core:investigate-ticket` — traces notification code, checks Snowflake for notification volumes, checks Datadog for delivery rates)_
 >
 > **Agent:** Here's what I found: there are 4 notification types sent to workplaces, none have per-workplace controls. The daily digest has the lowest engagement (12% open rate at phone-interview workplaces vs 64% at video workplaces). Is the daily digest the one causing friction, or are you thinking about all notification types?
 

--- a/plugins/core/skills/interview-feature/problem-brief.md
+++ b/plugins/core/skills/interview-feature/problem-brief.md
@@ -15,7 +15,7 @@
 [Impact, urgency, business context — why this deserves a ticket]
 
 ### What we learned from research
-[Key findings from investigate-ticket — Datadog data, codebase observations, Snowflake queries, usage stats, etc. If no research was needed, note "Context was sufficient from conversation."]
+[Key findings from `core:investigate-ticket` — Datadog data, codebase observations, Snowflake queries, usage stats, etc. If no research was needed, note "Context was sufficient from conversation."]
 
 ### Open questions / unknowns
 [Anything that couldn't be answered, with context on why and suggestions for how to resolve. If none, note "No open questions."]

--- a/plugins/core/skills/investigate-ticket/SKILL.md
+++ b/plugins/core/skills/investigate-ticket/SKILL.md
@@ -50,5 +50,5 @@ Research-only workflow — no code changes, no fixes, no PRs. Produces a structu
 
 ## Cross-Referenced Skills
 
-- `write-bug-ticket`, `write-tech-debt-ticket`, `write-feature-ticket` — for creating tickets from findings
-- `datadog-investigate` — API reference for Datadog queries when no Datadog MCP is available
+- `core:write-bug-ticket`, `core:write-tech-debt-ticket`, `core:write-feature-ticket` — for creating tickets from findings
+- `core:datadog-investigate` — API reference for Datadog queries when no Datadog MCP is available

--- a/plugins/core/skills/investigate-ticket/reference.md
+++ b/plugins/core/skills/investigate-ticket/reference.md
@@ -2,7 +2,7 @@
 
 ## Tool Availability
 
-This skill uses MCP tools when available: Datadog MCP for logs/traces/metrics, Snowflake MCP for data queries, LaunchDarkly MCP for flag state. If the Datadog MCP is not configured, use the `datadog-investigate` skill as an API reference — it provides curl commands and `dog` CLI patterns for querying logs, traces, metrics, and monitors directly.
+This skill uses MCP tools when available: Datadog MCP for logs/traces/metrics, Snowflake MCP for data queries, LaunchDarkly MCP for flag state. If the Datadog MCP is not configured, use the `core:datadog-investigate` skill as an API reference — it provides curl commands and `dog` CLI patterns for querying logs, traces, metrics, and monitors directly.
 
 ## Datadog Search Strategy
 

--- a/plugins/core/skills/write-bug-ticket/SKILL.md
+++ b/plugins/core/skills/write-bug-ticket/SKILL.md
@@ -5,9 +5,9 @@ description: Use when creating a Linear bug report ticket from conversation cont
 
 # Write Bug Ticket
 
-Structure and write Linear bug reports from evidence that already exists in the conversation. Never diagnose root cause or propose fixes. Never investigate — that's `investigate-ticket`'s job.
+Structure and write Linear bug reports from evidence that already exists in the conversation. Never diagnose root cause or propose fixes. Never investigate — that's `core:investigate-ticket`'s job.
 
-> **No evidence yet?** If the conversation lacks Datadog links, error details, or clear symptom descriptions, STOP and redirect to `investigate-ticket` first. It will hand off back here with structured findings.
+> **No evidence yet?** If the conversation lacks Datadog links, error details, or clear symptom descriptions, STOP and redirect to `core:investigate-ticket` first. It will hand off back here with structured findings.
 >
 > **Already investigated?** If the conversation contains investigation findings (Datadog links, code paths, Snowflake queries, flag state), use them directly — don't re-investigate.
 
@@ -23,11 +23,11 @@ Structure and write Linear bug reports from evidence that already exists in the 
 ## Hard Rules
 
 - **Symptom-first, diagnosis-never.** NEVER propose a fix, root cause, or investigation steps. Technical context is fine — speculation is not.
-- **Evidence belongs in the ticket, but gathering it does not.** Include Datadog links, Snowflake findings, and flag state from the conversation. If none exist, redirect to `investigate-ticket` — don't search yourself.
+- **Evidence belongs in the ticket, but gathering it does not.** Include Datadog links, Snowflake findings, and flag state from the conversation. If none exist, redirect to `core:investigate-ticket` — don't search yourself.
 - **STR preferred, not required.** If not reproduced: "Not yet reproduced manually. Observed via monitoring." NEVER invent STR.
 - **Clean titles.** No bracket prefixes. Describe the symptom. Under 70 characters.
 - **Always document the repository.** Flag multi-repo bugs to the user for splitting.
-- **Redirect non-bugs.** Features → `write-feature-ticket`, tech debt → `write-tech-debt-ticket`.
+- **Redirect non-bugs.** Features → `core:write-feature-ticket`, tech debt → `core:write-tech-debt-ticket`.
 
 ## Ticket Format
 
@@ -45,18 +45,18 @@ See reference.md for full examples.
 
 ## Red Flags — Self-Review Before Presenting
 
-| Anti-Pattern                   | Fix                                                                     |
-| ------------------------------ | ----------------------------------------------------------------------- |
-| Root cause diagnosis           | Remove — describe symptom and evidence only                             |
-| Proposed fix                   | Remove entirely                                                         |
-| Investigation runbook          | Remove — this is a bug report, not an investigation plan                |
-| Vague actual behavior          | Be specific: "Returns 500 error when..."                                |
-| Missing expected behavior      | Add what should happen                                                  |
-| Raw logs pasted inline         | Replace with Datadog log query link                                     |
-| No evidence in conversation    | STOP drafting — redirect to `investigate-ticket` to gather evidence     |
-| Searching Datadog yourself     | This skill writes, not investigates — use existing evidence or redirect |
-| Diagnosis disguised as context | Rewrite as observable: "Cache misses increased 3x after deploy"         |
-| STR invented from assumptions  | "Not yet reproduced. Observed via monitoring."                          |
-| Guessed team assignment        | Ask the user — never guess                                              |
-| Bracket title prefixes         | Describe the symptom without brackets                                   |
-| Missing repository             | Include repo name in ticket body — derive from git remote               |
+| Anti-Pattern                   | Fix                                                                      |
+| ------------------------------ | ------------------------------------------------------------------------ |
+| Root cause diagnosis           | Remove — describe symptom and evidence only                              |
+| Proposed fix                   | Remove entirely                                                          |
+| Investigation runbook          | Remove — this is a bug report, not an investigation plan                 |
+| Vague actual behavior          | Be specific: "Returns 500 error when..."                                 |
+| Missing expected behavior      | Add what should happen                                                   |
+| Raw logs pasted inline         | Replace with Datadog log query link                                      |
+| No evidence in conversation    | STOP drafting — redirect to `core:investigate-ticket` to gather evidence |
+| Searching Datadog yourself     | This skill writes, not investigates — use existing evidence or redirect  |
+| Diagnosis disguised as context | Rewrite as observable: "Cache misses increased 3x after deploy"          |
+| STR invented from assumptions  | "Not yet reproduced. Observed via monitoring."                           |
+| Guessed team assignment        | Ask the user — never guess                                               |
+| Bracket title prefixes         | Describe the symptom without brackets                                    |
+| Missing repository             | Include repo name in ticket body — derive from git remote                |

--- a/plugins/core/skills/write-feature-ticket/SKILL.md
+++ b/plugins/core/skills/write-feature-ticket/SKILL.md
@@ -5,7 +5,7 @@ description: Use when creating a Linear feature request ticket from conversation
 
 # Write Feature Ticket
 
-Draft Linear feature request tickets that describe what users need and why — never how to implement it. Dispatches to the `interview-feature` skill when context is insufficient to write a clear ticket.
+Draft Linear feature request tickets that describe what users need and why — never how to implement it. Dispatches to the `core:interview-feature` skill when context is insufficient to write a clear ticket.
 
 ## Process
 
@@ -13,8 +13,8 @@ Draft Linear feature request tickets that describe what users need and why — n
 2. **Clarity gate** — does the available context answer: (a) Who is affected? (b) What can't they do? (c) Why does it matter? Is the framing problem-shaped? Are there no invented details?
    - **Yes** → step 3
    - **1-2 factual gaps** (missing repo, unclear who) → ask the user directly. Don't dispatch the full interview for a single missing data point.
-   - **Structural problems** (solution-shaped framing, no problem articulated, mostly unknowns) → dispatch `interview-feature` skill. Receive a structured problem brief. Re-check gate against the brief.
-   - If `interview-feature` terminates without producing a problem brief (user refused to articulate a problem), abort the ticket process. Inform the user that the ticket cannot be created without a problem statement.
+   - **Structural problems** (solution-shaped framing, no problem articulated, mostly unknowns) → dispatch `core:interview-feature` skill. Receive a structured problem brief. Re-check gate against the brief.
+   - If `core:interview-feature` terminates without producing a problem brief (user refused to articulate a problem), abort the ticket process. Inform the user that the ticket cannot be created without a problem statement.
 3. **Final validation** — run the checklist below before drafting. This is the ticket skill's own quality check — it doesn't blindly trust upstream context.
 4. **Assess scope** — does the problem contain multiple independent user-facing outcomes? If so, decompose into parent + sub-issues, each describing one outcome. Decomposition is about what the user gets, not how the engineer builds it.
 5. **Draft** — title + description, structure scaled to complexity (see Ticket Format below)
@@ -25,7 +25,7 @@ Draft Linear feature request tickets that describe what users need and why — n
 
 ## Final Validation Checklist
 
-Before drafting, verify ALL of these. If any fail, bounce back to `interview-feature` or ask the user directly:
+Before drafting, verify ALL of these. If any fail, bounce back to `core:interview-feature` or ask the user directly:
 
 | Check                  | Fail condition                                                                                                                                     |
 | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -46,7 +46,7 @@ Before drafting, verify ALL of these. If any fail, bounce back to `interview-fea
 - **Never invent.** If a detail isn't established from the user, research, or conversation, it doesn't go in the ticket. Period.
 - **Approval required.** Always present the draft for user review first. Only create the ticket in Linear after the user explicitly approves.
 - **Always document the repository.** Every ticket must specify which repo the work belongs in. If the feature spans multiple repos, flag this — it likely needs separate tickets.
-- **Feature requests only.** Redirect bug reports to `write-bug-ticket`, tech debt to `write-tech-debt-ticket`.
+- **Feature requests only.** Redirect bug reports to `core:write-bug-ticket`, tech debt to `core:write-tech-debt-ticket`.
 
 ## Ticket Format
 

--- a/plugins/core/skills/write-tech-debt-ticket/SKILL.md
+++ b/plugins/core/skills/write-tech-debt-ticket/SKILL.md
@@ -9,7 +9,7 @@ Draft Linear tech debt tickets that justify _why_ the debt matters — cost to c
 
 **This is NOT a refactoring task.** It documents the _case_ for prioritization — cost of inaction, not a how-to guide.
 
-> Debt not well-understood yet (vague complaint, unclear cost)? Use `investigate-ticket` first. If the conversation already has investigation findings, use them — don't re-ask.
+> Debt not well-understood yet (vague complaint, unclear cost)? Use `core:investigate-ticket` first. If the conversation already has investigation findings, use them — don't re-ask.
 
 ## Process
 
@@ -38,7 +38,7 @@ Draft Linear tech debt tickets that justify _why_ the debt matters — cost to c
 - **Never invent.** Every claim must be backed by code you read, data you found, or context from the conversation. If you can't find evidence for an assertion, don't include it — even if it seems plausible.
 - **One ticket, one concern.** If the debt spans multiple independent problems (e.g., a performance issue AND a maintainability issue in the same service), split into separate tickets — each with its own classification, evidence, and impact. Related debt can reference each other.
 - **Always document the repository.** Flag multi-repo debt to the user for splitting.
-- **Redirect non-debt.** Bugs → `write-bug-ticket`, features → `write-feature-ticket`.
+- **Redirect non-debt.** Bugs → `core:write-bug-ticket`, features → `core:write-feature-ticket`.
 
 ## Ticket Format
 


### PR DESCRIPTION
## Summary

Normalize cross-skill references inside `plugins/core/skills` so handoffs consistently use the `core:` namespace. Keeps host-agnostic fallback wording where needed without mixing bare and prefixed names in the main handoff text.

## Validation

- `node --run sync-ai-rules`
- `node --run verify`
- Pre-commit hook: `lint-staged` on the 14 staged Markdown files
- Pre-push hook: `node --run verify`

Agent session: `codex resume 019e9988-91eb-7371-9d17-d9160625e265`

<sub>🤖 <code>commit-push-pr:created v1 core@3.7.1</code></sub>