### PR TITLE
feat: add frontend UI verification skill evals (DEVOP-5525)

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,25 @@
+# Evals
+
+`node --run eval` runs the default rules eval suite.
+
+Skill evals use one runner so new skills do not add new package scripts:
+
+```bash
+node --run eval:skill -- frontend-ui-verification --smoke
+```
+
+The smoke mode is deterministic and non-LLM. It uses a local fake provider to verify that Promptfoo loads the config, executes every scenario, passes `metadata.skillCalls` into `skill-used`, and runs the JavaScript workflow assertions.
+
+```bash
+node --run eval:skill -- frontend-ui-verification
+```
+
+The default skill run is manual and LLM-backed. For frontend UI verification it runs Claude and Codex by default. Narrow the provider set while debugging:
+
+```bash
+FRONTEND_UI_VERIFICATION_EVAL_PROVIDERS=codex node --run eval:skill -- frontend-ui-verification -- --filter-first-n 1
+```
+
+Claude runs require `ANTHROPIC_API_KEY`. Codex runs require the local Codex auth path used by Promptfoo's Codex adapter.
+
+When adding another skill eval, add the Promptfoo config and one entry in `scripts/runSkillEval.mts`; do not add another package script.

--- a/evals/README.md
+++ b/evals/README.md
@@ -20,6 +20,9 @@ The default skill run is manual and LLM-backed. For frontend UI verification it 
 FRONTEND_UI_VERIFICATION_EVAL_PROVIDERS=codex node --run eval:skill -- frontend-ui-verification -- --filter-first-n 1
 ```
 
-Claude runs require `ANTHROPIC_API_KEY`. Codex runs require the local Codex auth path used by Promptfoo's Codex adapter.
+Claude runs require `ANTHROPIC_API_KEY`.
+
+Codex runs use Promptfoo's `openai:codex-sdk` adapter. Set `OPENAI_API_KEY` or `CODEX_API_KEY` for explicit API-key auth, or run from a machine where the Codex SDK can read the normal local Codex login state.
+Set `CODEX_HOME=/path/to/.codex` when that state is not in the default Codex home.
 
 When adding another skill eval, add the Promptfoo config and one entry in `scripts/runSkillEval.mts`; do not add another package script.

--- a/evals/assertions/frontendUiVerificationWorkflow.ts
+++ b/evals/assertions/frontendUiVerificationWorkflow.ts
@@ -1,0 +1,209 @@
+// cspell:ignore viewmode
+
+interface GradingResult {
+  pass: boolean;
+  score: number;
+  reason: string;
+}
+
+interface PromptfooContext {
+  vars?: {
+    scenario?: string;
+    surface?: string;
+  };
+}
+
+function normalize(output: string): string {
+  return output.toLowerCase();
+}
+
+function hasAny(text: string, patterns: RegExp[]): boolean {
+  return patterns.some((pattern) => pattern.test(text));
+}
+
+function checkRequired(text: string, issues: string[], label: string, patterns: RegExp[]): void {
+  if (!hasAny(text, patterns)) {
+    issues.push(label);
+  }
+}
+
+function checkCoreWorkflow(text: string, issues: string[]): void {
+  checkRequired(text, issues, "Missing Storybook as the primary visual surface", [/\bstorybook\b/]);
+  checkRequired(text, issues, "Missing deterministic helper-script discovery", [
+    /inspect-ui-verification-surface\.sh/,
+    /\bstorybook-command\b/,
+  ]);
+  checkRequired(text, issues, "Missing Storybook canvas or iframe URL", [
+    /iframe\.html\?viewmode=story/,
+    /\bcanvas url\b/,
+    /\bstorybook iframe\b/,
+  ]);
+  checkRequired(text, issues, "Missing browser screenshot or visual evidence capture", [
+    /\bscreenshot\b/,
+    /\bvisual evidence\b/,
+    /\bcapture evidence\b/,
+  ]);
+  checkRequired(text, issues, "Missing viewport coverage", [
+    /\bviewport\b/,
+    /\b375x812\b/,
+    /\b390x844\b/,
+    /\b1440x900\b/,
+    /\biphone\b/,
+  ]);
+  checkRequired(text, issues, "Missing inspected UI states", [
+    /\bloading\b/,
+    /\bempty\b/,
+    /\berror\b/,
+    /\bdisabled\b/,
+    /\blong[- ]text\b/,
+    /\bdense[- ]data\b/,
+  ]);
+  checkRequired(text, issues, "Missing console classification", [
+    /\bconsole\b.*\b(?:story-introduced|global|pre-existing|provider|decorator)/s,
+    /\b(?:story-introduced|global|pre-existing|provider|decorator)\b.*\bconsole\b/s,
+  ]);
+  checkRequired(text, issues, "Missing component or story search before new UI", [
+    /\bexisting components?\b/,
+    /\bsearch\b.*\b(?:stories|components|patterns)\b/s,
+    /\breuse\b.*\b(?:components|patterns|tokens)\b/s,
+  ]);
+}
+
+function checkSourceScenario(text: string, scenario: string | undefined, issues: string[]): void {
+  if (scenario === "figma") {
+    checkRequired(text, issues, "Missing Figma MCP/design-context extraction", [
+      /get_design_context/,
+      /design context/,
+      /figma mcp/,
+    ]);
+    checkRequired(text, issues, "Missing Figma screenshot extraction", [
+      /get_screenshot/,
+      /figma screenshot/,
+    ]);
+    checkRequired(text, issues, "Missing Figma metadata or variables", [
+      /get_metadata/,
+      /metadata/,
+      /get_variable_defs/,
+      /\bvariables?\b/,
+    ]);
+    return;
+  }
+
+  if (scenario === "screenshot") {
+    checkRequired(text, issues, "Missing screenshot-as-reference handling", [
+      /screenshot.*reference/s,
+      /static.*reference/s,
+      /visual reference/,
+    ]);
+    checkRequired(text, issues, "Missing callout for states or viewport gaps", [
+      /missing.*states/s,
+      /missing.*viewport/s,
+      /not visible/,
+      /call out.*(?:states|viewport|interaction)/s,
+    ]);
+    return;
+  }
+
+  if (scenario === "idea") {
+    checkRequired(text, issues, "Missing written-idea fallback", [
+      /written idea/,
+      /description only/,
+      /product intent/,
+      /free-form/,
+    ]);
+    checkRequired(text, issues, "Missing human confirmation for subjective interpretation", [
+      /human confirmation/,
+      /ask.*confirm/s,
+      /confirmation.*subjective/s,
+      /storybook checkpoint.*confirm/s,
+    ]);
+  }
+}
+
+function checkSurface(text: string, surface: string | undefined, issues: string[]): void {
+  if (surface === "admin") {
+    checkRequired(text, issues, "Missing admin Berlin/redesign component mapping", [
+      /\bberlin\b/,
+      /src\/app[v]2\/redesign/,
+      /redesign\/components/,
+    ]);
+    return;
+  }
+
+  if (surface === "mobile") {
+    checkRequired(text, issues, "Missing mobile Storybook/decorator details", [
+      /theme.*decorator/s,
+      /storybook.*decorator/s,
+      /mobile.*decorator/s,
+    ]);
+    checkRequired(text, issues, "Missing mobile viewport presets", [
+      /iphone12/,
+      /390x844/,
+      /iphone\s*se/,
+      /375x667/,
+      /ipad\s*mini/,
+      /768x1024/,
+    ]);
+  }
+}
+
+function checkMotionScenario(text: string, scenario: string | undefined, issues: string[]): void {
+  if (scenario !== "motion") {
+    return;
+  }
+
+  checkRequired(text, issues, "Missing deterministic motion replay/in-flight states", [
+    /\breplay\b/,
+    /\bin-flight\b/,
+    /\bsettled\b/,
+    /animation.*starts.*settles/s,
+  ]);
+  checkRequired(text, issues, "Missing reduced-motion handling", [
+    /prefers-reduced-motion/,
+    /reduced motion/,
+  ]);
+  checkRequired(text, issues, "Missing transition discipline", [
+    /transition: all/,
+    /transform.*opacity/s,
+    /explicit transition/,
+  ]);
+}
+
+function checkForbiddenPrimaryAppServer(text: string, issues: string[]): void {
+  const appServerPrimarySentence = text.split(/[.;\n]/).some((sentence) => {
+    const mentionsPrimaryAppServer =
+      /\bapp server\b/.test(sentence) && /\bprimary\b/.test(sentence);
+    const isWarningAgainstPrimaryAppServer = /\b(?:do not|don't|avoid|never|not|instead of)\b/.test(
+      sentence,
+    );
+
+    return mentionsPrimaryAppServer && !isWarningAgainstPrimaryAppServer;
+  });
+
+  if (appServerPrimarySentence) {
+    issues.push("Uses app server as the primary visual verification surface");
+  }
+}
+
+// oxlint-disable import/no-anonymous-default-export
+export default function (output: string, context?: PromptfooContext): GradingResult {
+  const text = normalize(output);
+  const issues: string[] = [];
+  const scenario = context?.vars?.scenario;
+  const surface = context?.vars?.surface;
+
+  checkCoreWorkflow(text, issues);
+  checkSourceScenario(text, scenario, issues);
+  checkSurface(text, surface, issues);
+  checkMotionScenario(text, scenario, issues);
+  checkForbiddenPrimaryAppServer(text, issues);
+
+  const pass = issues.length === 0;
+  return {
+    pass,
+    score: pass ? 1 : 0,
+    reason: pass
+      ? "Frontend UI verification workflow preserved"
+      : `Frontend UI verification gaps: ${issues.join("; ")}`,
+  };
+}

--- a/evals/assertions/frontendUiVerificationWorkflow.ts
+++ b/evals/assertions/frontendUiVerificationWorkflow.ts
@@ -17,40 +17,51 @@ function normalize(output: string): string {
   return output.toLowerCase();
 }
 
-function hasAny(text: string, patterns: RegExp[]): boolean {
+function hasAnyPattern(text: string, patterns: RegExp[]): boolean {
   return patterns.some((pattern) => pattern.test(text));
 }
 
-function checkRequired(text: string, issues: string[], label: string, patterns: RegExp[]): void {
-  if (!hasAny(text, patterns)) {
+function hasAllPatterns(text: string, patterns: RegExp[]): boolean {
+  return patterns.every((pattern) => pattern.test(text));
+}
+
+function checkAnyRequired(text: string, issues: string[], label: string, patterns: RegExp[]): void {
+  if (!hasAnyPattern(text, patterns)) {
+    issues.push(label);
+  }
+}
+
+function checkAllRequired(text: string, issues: string[], label: string, patterns: RegExp[]): void {
+  if (!hasAllPatterns(text, patterns)) {
     issues.push(label);
   }
 }
 
 function checkCoreWorkflow(text: string, issues: string[]): void {
-  checkRequired(text, issues, "Missing Storybook as the primary visual surface", [/\bstorybook\b/]);
-  checkRequired(text, issues, "Missing deterministic helper-script discovery", [
+  checkAnyRequired(text, issues, "Missing Storybook as the primary visual surface", [
+    /\bstorybook\b/,
+  ]);
+  checkAllRequired(text, issues, "Missing deterministic helper-script discovery", [
     /inspect-ui-verification-surface\.sh/,
     /\bstorybook-command\b/,
   ]);
-  checkRequired(text, issues, "Missing Storybook canvas or iframe URL", [
+  checkAnyRequired(text, issues, "Missing Storybook canvas or iframe URL", [
     /iframe\.html\?viewmode=story/,
     /\bcanvas url\b/,
     /\bstorybook iframe\b/,
   ]);
-  checkRequired(text, issues, "Missing browser screenshot or visual evidence capture", [
+  checkAnyRequired(text, issues, "Missing browser screenshot or visual evidence capture", [
     /\bscreenshot\b/,
     /\bvisual evidence\b/,
     /\bcapture evidence\b/,
   ]);
-  checkRequired(text, issues, "Missing viewport coverage", [
-    /\bviewport\b/,
+  checkAllRequired(text, issues, "Missing viewport coverage", [/\bviewport\b/, /\b1440x900\b/]);
+  checkAnyRequired(text, issues, "Missing mobile viewport coverage", [
     /\b375x812\b/,
     /\b390x844\b/,
-    /\b1440x900\b/,
     /\biphone\b/,
   ]);
-  checkRequired(text, issues, "Missing inspected UI states", [
+  checkAllRequired(text, issues, "Missing inspected UI states", [
     /\bloading\b/,
     /\bempty\b/,
     /\berror\b/,
@@ -58,11 +69,11 @@ function checkCoreWorkflow(text: string, issues: string[]): void {
     /\blong[- ]text\b/,
     /\bdense[- ]data\b/,
   ]);
-  checkRequired(text, issues, "Missing console classification", [
+  checkAnyRequired(text, issues, "Missing console classification", [
     /\bconsole\b.*\b(?:story-introduced|global|pre-existing|provider|decorator)/s,
     /\b(?:story-introduced|global|pre-existing|provider|decorator)\b.*\bconsole\b/s,
   ]);
-  checkRequired(text, issues, "Missing component or story search before new UI", [
+  checkAnyRequired(text, issues, "Missing component or story search before new UI", [
     /\bexisting components?\b/,
     /\bsearch\b.*\b(?:stories|components|patterns)\b/s,
     /\breuse\b.*\b(?:components|patterns|tokens)\b/s,
@@ -71,16 +82,16 @@ function checkCoreWorkflow(text: string, issues: string[]): void {
 
 function checkSourceScenario(text: string, scenario: string | undefined, issues: string[]): void {
   if (scenario === "figma") {
-    checkRequired(text, issues, "Missing Figma MCP/design-context extraction", [
+    checkAnyRequired(text, issues, "Missing Figma MCP/design-context extraction", [
       /get_design_context/,
       /design context/,
       /figma mcp/,
     ]);
-    checkRequired(text, issues, "Missing Figma screenshot extraction", [
+    checkAnyRequired(text, issues, "Missing Figma screenshot extraction", [
       /get_screenshot/,
       /figma screenshot/,
     ]);
-    checkRequired(text, issues, "Missing Figma metadata or variables", [
+    checkAnyRequired(text, issues, "Missing Figma metadata or variables", [
       /get_metadata/,
       /metadata/,
       /get_variable_defs/,
@@ -90,12 +101,12 @@ function checkSourceScenario(text: string, scenario: string | undefined, issues:
   }
 
   if (scenario === "screenshot") {
-    checkRequired(text, issues, "Missing screenshot-as-reference handling", [
+    checkAnyRequired(text, issues, "Missing screenshot-as-reference handling", [
       /screenshot.*reference/s,
       /static.*reference/s,
       /visual reference/,
     ]);
-    checkRequired(text, issues, "Missing callout for states or viewport gaps", [
+    checkAnyRequired(text, issues, "Missing callout for states or viewport gaps", [
       /missing.*states/s,
       /missing.*viewport/s,
       /not visible/,
@@ -105,13 +116,13 @@ function checkSourceScenario(text: string, scenario: string | undefined, issues:
   }
 
   if (scenario === "idea") {
-    checkRequired(text, issues, "Missing written-idea fallback", [
+    checkAnyRequired(text, issues, "Missing written-idea fallback", [
       /written idea/,
       /description only/,
       /product intent/,
       /free-form/,
     ]);
-    checkRequired(text, issues, "Missing human confirmation for subjective interpretation", [
+    checkAnyRequired(text, issues, "Missing human confirmation for subjective interpretation", [
       /human confirmation/,
       /ask.*confirm/s,
       /confirmation.*subjective/s,
@@ -122,7 +133,7 @@ function checkSourceScenario(text: string, scenario: string | undefined, issues:
 
 function checkSurface(text: string, surface: string | undefined, issues: string[]): void {
   if (surface === "admin") {
-    checkRequired(text, issues, "Missing admin Berlin/redesign component mapping", [
+    checkAnyRequired(text, issues, "Missing admin Berlin/redesign component mapping", [
       /\bberlin\b/,
       /src\/app[v]2\/redesign/,
       /redesign\/components/,
@@ -131,12 +142,12 @@ function checkSurface(text: string, surface: string | undefined, issues: string[
   }
 
   if (surface === "mobile") {
-    checkRequired(text, issues, "Missing mobile Storybook/decorator details", [
+    checkAnyRequired(text, issues, "Missing mobile Storybook/decorator details", [
       /theme.*decorator/s,
       /storybook.*decorator/s,
       /mobile.*decorator/s,
     ]);
-    checkRequired(text, issues, "Missing mobile viewport presets", [
+    checkAnyRequired(text, issues, "Missing mobile viewport presets", [
       /iphone12/,
       /390x844/,
       /iphone\s*se/,
@@ -152,32 +163,43 @@ function checkMotionScenario(text: string, scenario: string | undefined, issues:
     return;
   }
 
-  checkRequired(text, issues, "Missing deterministic motion replay/in-flight states", [
+  checkAnyRequired(text, issues, "Missing deterministic motion replay/in-flight states", [
     /\breplay\b/,
     /\bin-flight\b/,
     /\bsettled\b/,
     /animation.*starts.*settles/s,
   ]);
-  checkRequired(text, issues, "Missing reduced-motion handling", [
+  checkAnyRequired(text, issues, "Missing reduced-motion handling", [
     /prefers-reduced-motion/,
     /reduced motion/,
   ]);
-  checkRequired(text, issues, "Missing transition discipline", [
-    /transition: all/,
+  checkAllRequired(text, issues, "Missing transition discipline", [
     /transform.*opacity/s,
     /explicit transition/,
   ]);
+  checkForbiddenTransitionAll(text, issues);
+}
+
+function isExplicitWarningSentence(sentence: string): boolean {
+  return /\b(?:do not|don't|avoid|never|instead of)\b/.test(sentence);
+}
+
+function checkForbiddenTransitionAll(text: string, issues: string[]): void {
+  const usesTransitionAll = text
+    .split(/[.;\n]/)
+    .some((sentence) => /transition:\s*all/.test(sentence) && !isExplicitWarningSentence(sentence));
+
+  if (usesTransitionAll) {
+    issues.push("Allows transition: all instead of explicit motion properties");
+  }
 }
 
 function checkForbiddenPrimaryAppServer(text: string, issues: string[]): void {
   const appServerPrimarySentence = text.split(/[.;\n]/).some((sentence) => {
     const mentionsPrimaryAppServer =
       /\bapp server\b/.test(sentence) && /\bprimary\b/.test(sentence);
-    const isWarningAgainstPrimaryAppServer = /\b(?:do not|don't|avoid|never|not|instead of)\b/.test(
-      sentence,
-    );
 
-    return mentionsPrimaryAppServer && !isWarningAgainstPrimaryAppServer;
+    return mentionsPrimaryAppServer && !isExplicitWarningSentence(sentence);
   });
 
   if (appServerPrimarySentence) {

--- a/evals/promptfooconfig.frontend-ui-verification.ts
+++ b/evals/promptfooconfig.frontend-ui-verification.ts
@@ -62,7 +62,9 @@ function parseProviderNames(): ProviderName[] {
       throw new Error(`Unsupported frontend UI verification eval provider: ${providerName}`);
     }
 
-    providerNames.push(providerName);
+    if (!providerNames.includes(providerName)) {
+      providerNames.push(providerName);
+    }
   }
 
   if (providerNames.length === 0) {

--- a/evals/promptfooconfig.frontend-ui-verification.ts
+++ b/evals/promptfooconfig.frontend-ui-verification.ts
@@ -1,0 +1,164 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const repoRoot = path.join(import.meta.dirname, "..");
+const agentsMd = readFileSync(path.join(repoRoot, "AGENTS.md"), "utf8");
+
+type ProviderName = "claude" | "codex";
+
+interface PromptfooProvider {
+  id: string;
+  label: string;
+  config: Record<string, unknown>;
+}
+
+const providerMap: Record<ProviderName, PromptfooProvider> = {
+  claude: {
+    // Promptfoo provider ID for the Claude agent adapter.
+    id: "anthropic:claude-agent-sdk",
+    label: "claude-agent",
+    config: {
+      working_dir: repoRoot,
+      setting_sources: ["project"],
+      tools: { type: "preset", preset: "claude_code" },
+      permission_mode: "default",
+      append_system_prompt: agentsMd,
+      model: "opus",
+      max_turns: 6,
+    },
+  },
+  codex: {
+    // Promptfoo provider ID for the Codex agent adapter.
+    id: "openai:codex-sdk",
+    label: "codex-agent",
+    config: {
+      working_dir: repoRoot,
+      sandbox_mode: "read-only",
+      approval_policy: "never",
+      model_reasoning_effort: "medium",
+      collaboration_mode: "coding",
+      model: "gpt-5-codex",
+    },
+  },
+};
+
+function isProviderName(providerName: string): providerName is ProviderName {
+  return providerName === "claude" || providerName === "codex";
+}
+
+function parseProviderNames(): ProviderName[] {
+  // oxlint-disable-next-line node/no-process-env -- Manual evals choose Claude, Codex, or both without duplicating configs.
+  const rawProviderNames = process.env.FRONTEND_UI_VERIFICATION_EVAL_PROVIDERS ?? "claude,codex";
+
+  const providerNames: ProviderName[] = [];
+
+  for (const rawProviderName of rawProviderNames.split(",")) {
+    const providerName = rawProviderName.trim();
+    if (!providerName) {
+      continue;
+    }
+
+    if (!isProviderName(providerName)) {
+      throw new Error(`Unsupported frontend UI verification eval provider: ${providerName}`);
+    }
+
+    providerNames.push(providerName);
+  }
+
+  if (providerNames.length === 0) {
+    throw new Error("FRONTEND_UI_VERIFICATION_EVAL_PROVIDERS did not include any providers");
+  }
+
+  return providerNames;
+}
+
+const providers = parseProviderNames().map((providerName) => providerMap[providerName]);
+
+const sharedAssertions = [
+  {
+    type: "skill-used",
+    value: "frontend-ui-verification",
+  },
+  {
+    type: "javascript",
+    value: "file://assertions/frontendUiVerificationWorkflow.ts",
+  },
+] as const;
+
+// oxlint-disable import/no-anonymous-default-export
+export default {
+  description: "Frontend UI verification skill regression evals",
+
+  providers,
+
+  prompts: ["file://prompts/frontendUiVerification.txt"],
+
+  tests: [
+    {
+      vars: {
+        scenario: "figma",
+        surface: "admin",
+        task: [
+          "In cbh-admin-frontend, implement a Figma-driven redesign of an admin approval tray.",
+          "The Figma URL is https://www.figma.com/design/abc123/Admin-Approval?node-id=10-20.",
+          "The UI includes dense rows, a primary approve action, a secondary defer action, and an info banner.",
+        ].join(" "),
+      },
+      assert: sharedAssertions,
+    },
+    {
+      vars: {
+        scenario: "figma",
+        surface: "mobile",
+        task: [
+          "In cbh-mobile-app, recreate a Figma design for a worker saved-shift bottom sheet.",
+          "The Figma URL is https://www.figma.com/design/def456/Mobile-Saved-Shift?node-id=31-42.",
+          "The sheet includes shift details, a saved status pill, long workplace names, and primary/secondary actions.",
+        ].join(" "),
+      },
+      assert: sharedAssertions,
+    },
+    {
+      vars: {
+        scenario: "screenshot",
+        surface: "admin",
+        task: [
+          "In cbh-admin-frontend, build a compact admin review panel from a static screenshot reference.",
+          "The screenshot shows three stacked cards, a warning banner, an approve button, and a disabled secondary action.",
+          "No Figma URL is available.",
+        ].join(" "),
+      },
+      assert: sharedAssertions,
+    },
+    {
+      vars: {
+        scenario: "idea",
+        surface: "mobile",
+        task: [
+          "In cbh-mobile-app, add a new visual idea: before workers browse open shifts, show a small preference nudge",
+          "letting them tune distance, shift time, and pay preferences.",
+          "There is no Figma URL and no screenshot.",
+        ].join(" "),
+      },
+      assert: sharedAssertions,
+    },
+    {
+      vars: {
+        scenario: "motion",
+        surface: "admin",
+        task: [
+          "In cbh-admin-frontend, refine stacked admin bottom-sheet motion for a nested approval drawer.",
+          "The parent sheet should remain visually stable while the child sheet opens, settles, dismisses, and rapidly reopens.",
+          "This is a polish task with animation behavior as the main risk.",
+        ].join(" "),
+      },
+      assert: [
+        ...sharedAssertions,
+        {
+          type: "skill-used",
+          value: "clipboard-design-engineering",
+        },
+      ],
+    },
+  ],
+};

--- a/evals/prompts/frontendUiVerification.txt
+++ b/evals/prompts/frontendUiVerification.txt
@@ -1,0 +1,11 @@
+You are handling a Clipboard frontend UI verification planning pass for this task.
+
+Task:
+{{task}}
+
+Constraints:
+- Before answering, run a read-only repository inspection to identify and read any matching `.agents/skills/**/SKILL.md` instructions. Do not skip this if the task matches a skill.
+- Do not edit files or run servers in this eval.
+- Answer with the exact workflow you would execute before product integration.
+- Include the design/reference source you would use, repo-specific Storybook surface, helper command, story/canvas URL shape, browser verification path, viewports, states, console classification, evidence to capture, and when human confirmation is required.
+- Keep the response concise but concrete enough that another agent could execute it.

--- a/evals/providers/frontendUiVerificationSmokeProvider.ts
+++ b/evals/providers/frontendUiVerificationSmokeProvider.ts
@@ -1,0 +1,54 @@
+interface ProviderOptions {
+  label?: string;
+}
+
+interface SkillCall {
+  name: string;
+  source: string;
+}
+
+interface ProviderResponse {
+  output: string;
+  metadata: {
+    skillCalls: SkillCall[];
+  };
+}
+
+const WORKFLOW_OUTPUT_LINES = [
+  "Use Storybook as the primary visual surface before product integration; do not make the app server the primary verification surface.",
+  "First search existing components, stories, patterns, and tokens in Berlin, src/appV2/redesign, redesign/components, and mobile Storybook decorators before adding new UI.",
+  "Run scripts/inspect-ui-verification-surface.sh and use its storybook-command output instead of guessing commands.",
+  "Open the Storybook iframe.html?viewMode=story canvas URL directly and capture browser screenshot visual evidence.",
+  "Check viewport sizes 375x812, 390x844, 1440x900, iPhone12, iPhone SE, and iPad Mini.",
+  "Inspect loading, empty, error, disabled, long-text, and dense-data states.",
+  "Classify console issues as story-introduced, global, pre-existing, provider, or decorator before claiming completion.",
+  "For Figma, use Figma MCP get_design_context, get_screenshot, get_metadata, and get_variable_defs to read design context, screenshot, metadata, and variables.",
+  "For screenshot references, treat the screenshot as a static visual reference and call out missing states, missing viewport coverage, and interactions that are not visible.",
+  "For written idea or free-form product intent, compose from existing Clipboard components and ask for human confirmation when subjective interpretation affects product/design direction.",
+  "For mobile, use the Storybook decorator details including mobile decorator wrappers.",
+  "For motion, replay animation starts, in-flight, and settled states, verify prefers-reduced-motion, and use explicit transition with transform and opacity instead of transition: all.",
+];
+
+export default class FrontendUiVerificationSmokeProvider {
+  public readonly label: string;
+
+  public constructor(options: ProviderOptions = {}) {
+    this.label = options.label ?? "frontend-ui-verification-smoke";
+  }
+
+  public id(): string {
+    return "smoke:frontend-ui-verification";
+  }
+
+  public async callApi(): Promise<ProviderResponse> {
+    return {
+      output: WORKFLOW_OUTPUT_LINES.join("\n"),
+      metadata: {
+        skillCalls: [
+          { name: "frontend-ui-verification", source: "smoke" },
+          { name: "clipboard-design-engineering", source: "smoke" },
+        ],
+      },
+    };
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "embed": "tsx packages/embedex/src/bin/cli.ts --sourcesGlob 'packages/*/examples/**/*.{md,ts}'",
     "embed:check": "node --run embed -- --check",
     "eval": "promptfoo eval --config evals/promptfooconfig.ts",
+    "eval:skill": "tsx scripts/runSkillEval.mts",
     "eval:view": "promptfoo view --yes",
     "format": "oxfmt",
     "format:check": "oxfmt --check",

--- a/scripts/runSkillEval.mts
+++ b/scripts/runSkillEval.mts
@@ -1,0 +1,99 @@
+import { spawnSync } from "node:child_process";
+
+type SkillEvalName = "frontend-ui-verification";
+
+interface SkillEvalConfig {
+  configPath: string;
+  smokeProviderPath: string;
+}
+
+const SKILL_EVAL_CONFIGS: Record<SkillEvalName, SkillEvalConfig> = {
+  "frontend-ui-verification": {
+    configPath: "evals/promptfooconfig.frontend-ui-verification.ts",
+    smokeProviderPath: "file://providers/frontendUiVerificationSmokeProvider.ts",
+  },
+};
+
+interface ParsedArgs {
+  skillName: SkillEvalName;
+  smoke: boolean;
+  promptfooArgs: string[];
+}
+
+function isSkillEvalName(value: string): value is SkillEvalName {
+  return value === "frontend-ui-verification";
+}
+
+function usage(): string {
+  return [
+    "Usage: node --run eval:skill -- <skill-name> [--smoke] [promptfoo args...]",
+    "",
+    "Examples:",
+    "  node --run eval:skill -- frontend-ui-verification --smoke",
+    "  node --run eval:skill -- frontend-ui-verification",
+    "  FRONTEND_UI_VERIFICATION_EVAL_PROVIDERS=codex node --run eval:skill -- frontend-ui-verification -- --filter-first-n 1",
+    "",
+    `Available skill evals: ${Object.keys(SKILL_EVAL_CONFIGS).join(", ")}`,
+  ].join("\n");
+}
+
+function parseArgs(args: string[]): ParsedArgs {
+  const [skillName, ...restArgs] = args;
+
+  if (!skillName) {
+    throw new Error(usage());
+  }
+
+  if (!isSkillEvalName(skillName)) {
+    throw new Error(`Unsupported skill eval: ${skillName}\n\n${usage()}`);
+  }
+
+  return {
+    skillName,
+    smoke: restArgs.includes("--smoke"),
+    promptfooArgs: restArgs.filter((arg) => arg !== "--smoke" && arg !== "--"),
+  };
+}
+
+function runPromptfoo(parsedArgs: ParsedArgs): number {
+  const config = SKILL_EVAL_CONFIGS[parsedArgs.skillName];
+  const commandArgs = ["eval", "--config", config.configPath];
+
+  if (parsedArgs.smoke) {
+    commandArgs.push(
+      "--providers",
+      config.smokeProviderPath,
+      "--no-cache",
+      "--no-write",
+      "--no-table",
+      "--max-concurrency",
+      "1",
+    );
+  }
+
+  commandArgs.push(...parsedArgs.promptfooArgs);
+
+  const result = spawnSync("promptfoo", commandArgs, { stdio: "inherit" });
+  if (result.error) {
+    throw result.error;
+  }
+
+  return result.status ?? 1;
+}
+
+function main(args: string[]): number {
+  if (args[0] === "--help" || args[0] === "-h") {
+    process.stdout.write(`${usage()}\n`);
+    return 0;
+  }
+
+  return runPromptfoo(parseArgs(args));
+}
+
+try {
+  process.exitCode = main(process.argv.slice(2));
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary

Adds a scalable skill-eval runner so new skill evals use one package script instead of adding a command per skill. This PR adds the first skill eval for frontend UI verification with Promptfoo scenarios for Figma, screenshot, written-idea, and motion workflows across admin and mobile surfaces.

The deterministic verifier checks the behavior we want to preserve: relevant skill activation, Storybook as the cheap visual layer, helper-script command discovery, iframe/canvas URL use, browser screenshot evidence, viewport and state coverage, console classification, Figma/screenshot/idea fallbacks, existing component search, and motion/reduced-motion handling. Review feedback tightened the grader so conjunctive requirements cannot pass from one partial match and poor motion guidance such as unqualified `transition: all` is rejected.

## Validation

- `node --run eval:skill -- frontend-ui-verification --smoke` - passed, 5/5 scenarios.
- Targeted grader probe with `node --import tsx` - passed; rejects primary app-server verification, rejects unqualified `transition: all`, allows explicitly negated `transition: all` guidance.
- `FRONTEND_UI_VERIFICATION_EVAL_PROVIDERS=codex,codex promptfoo validate config --config evals/promptfooconfig.frontend-ui-verification.ts` - passed; duplicate provider input validates after dedupe.
- `FRONTEND_UI_VERIFICATION_EVAL_PROVIDERS=codex node --run eval:skill -- frontend-ui-verification -- --filter-first-n 1 --no-cache --no-write --no-table --max-concurrency 1 --output /tmp/frontend-ui-codex-eval.1780998705.json` - passed, 1/1 scenario; Promptfoo observed `frontend-ui-verification` via `.agents/skills/frontend-ui-verification/SKILL.md`.
- `FRONTEND_UI_VERIFICATION_EVAL_PROVIDERS=claude node --run eval:skill -- frontend-ui-verification -- --filter-first-n 1 ...` - blocked locally because `ANTHROPIC_API_KEY` is not set; documented in `evals/README.md`.
- `FRONTEND_UI_VERIFICATION_EVAL_PROVIDERS=claude,codex promptfoo validate config --config evals/promptfooconfig.frontend-ui-verification.ts` - passed.
- `node --run verify` - passed locally, in the commit hook, and in the pre-push hook.

## Notes

Linear project: https://linear.app/clipboardhealth/team/ALCH/projects/view/stack-rank-11981b32c6ab
Related tickets: DEVOP-5525, DEVOP-5097

The full Claude+Codex eval is intentionally manual because it requires agent credentials and spends model tokens. The smoke run is the deterministic non-LLM guard for config/assertion changes.

Agent session: `codex resume 019ea606-e334-73c1-89eb-e8ae5e109d2a`

<sub>🤖 <code>commit-push-pr:created v1 core@3.7.1</code></sub>
