### PR TITLE
feat: support clearance env overrides

### DIFF
--- a/packages/clearance/src/launcher.test.ts
+++ b/packages/clearance/src/launcher.test.ts
@@ -156,6 +156,36 @@ describe(ensureClearance, () => {
     expect(spawnInput.env["CLEARANCE_ALLOW_HOSTS_FILES"]).toBe(hostsFile);
   });
 
+  it("applies env overrides on top of clearance's default forwarded env", async () => {
+    cacheDir = createTempCacheDir();
+    const hostsFile = path.join(cacheDir, "team");
+    writeFileSync(hostsFile, "team.example.com\n");
+    const isListeningMock = createListenerMock([false, true]);
+    const spawnMock = vi.fn<ClearanceSpawner>().mockReturnValue(67_891);
+    vi.stubEnv("CLEARANCE_ALLOW_HOSTS", "api.example.com");
+    vi.stubEnv("CLEARANCE_ALLOW_HOSTS_FILES", "stale-hosts-file");
+    vi.stubEnv("CLEARANCE_ALLOW_PORTS", "443,8443");
+    vi.stubEnv("NOT_FORWARDED", "secret");
+
+    try {
+      await ensureClearance({
+        cacheDir,
+        envOverrides: { CLEARANCE_ALLOW_HOSTS_FILES: hostsFile },
+        isListening: isListeningMock,
+        sleep: noopAsync,
+        spawnDetached: spawnMock,
+      });
+
+      const spawnInput = onlySpawnInput(spawnMock);
+      expect(spawnInput.env["CLEARANCE_ALLOW_HOSTS"]).toBe("api.example.com");
+      expect(spawnInput.env["CLEARANCE_ALLOW_HOSTS_FILES"]).toBe(hostsFile);
+      expect(spawnInput.env["CLEARANCE_ALLOW_PORTS"]).toBe("443,8443");
+      expect(spawnInput.env["NOT_FORWARDED"]).toBeUndefined();
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
   it("uses XDG cache home for the default cache dir", async () => {
     const xdgCacheHome = createTempCacheDir();
     cacheDir = xdgCacheHome;

--- a/packages/clearance/src/launcher.ts
+++ b/packages/clearance/src/launcher.ts
@@ -43,6 +43,7 @@ export type ClearanceSpawner = (input: SpawnClearanceInput) => number;
 export interface EnsureClearanceInput {
   cacheDir?: string;
   env?: NodeJS.ProcessEnv;
+  envOverrides?: NodeJS.ProcessEnv;
   isListening?: ClearanceListenerCheck;
   logger?: (message: string) => void;
   pollIntervalMs?: number;
@@ -106,7 +107,7 @@ export function spawnClearance(input: SpawnClearanceInput): number {
 export async function ensureClearance(
   input: EnsureClearanceInput = {},
 ): Promise<EnsureClearanceResult> {
-  const env = input.env ?? defaultProxyEnv();
+  const env = proxyEnv(input);
   /* v8 ignore next @preserve -- default listener is covered directly by isClearanceListening tests */
   const isListening = input.isListening ?? isClearanceListening;
   const logger = input.logger ?? noop;
@@ -179,6 +180,18 @@ function childEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
     ...env,
     CLEARANCE_LISTEN_HOST: CLEARANCE_HOST,
     CLEARANCE_PORT: String(CLEARANCE_PORT),
+  };
+}
+
+function proxyEnv(input: Pick<EnsureClearanceInput, "env" | "envOverrides">): NodeJS.ProcessEnv {
+  const env = input.env ?? defaultProxyEnv();
+  if (input.envOverrides === undefined) {
+    return env;
+  }
+
+  return {
+    ...env,
+    ...input.envOverrides,
   };
 }
 


### PR DESCRIPTION
## Summary

Adds an `envOverrides` option to `ensureClearance` so consumers can set individual clearance env vars, like `CLEARANCE_ALLOW_HOSTS_FILES`, without replacing or mirroring clearance's default forwarded env allowlist. This lets groundcrew hand clearance its checked-in allow-host file while clearance remains owner of the env forwarding list.

## Validation

- `npm exec nx test clearance`
- `npm exec nx lint clearance`
- `npm exec nx build clearance`
- `node --run verify`

Agent session: `codex resume 019eb26d-2d27-7883-b0c5-2b9ab2a2c033`

<sub>🤖 <code>commit-push-pr:created v1 core@3.7.1</code></sub>
