### PR TITLE
fix: exempt test files from no-shadow (DEVOP-5096)

### DIFF
--- a/packages/oxlint-config/src/base.json
+++ b/packages/oxlint-config/src/base.json
@@ -135,6 +135,7 @@
         "**/tests/**"
       ],
       "rules": {
+        "no-shadow": "off",
         "typescript/no-non-null-assertion": "off",
         "typescript/no-unsafe-argument": "off",
         "typescript/no-unsafe-assignment": "off",


### PR DESCRIPTION
## Summary

Adds `"no-shadow": "off"` to the shared test-file override in `@clipboard-health/oxlint-config`, alongside the existing type-unsafe-family exemptions ([DEVOP-5096](https://linear.app/clipboardhealth/issue/DEVOP-5096/kill-eslint-in-favor-of-oxlint)).

Rationale: enabling `no-shadow` in clipboard-health surfaces ~170 prod hits worth fixing but ~613 test hits — overwhelmingly describe-scoped fixtures and mock-factory parameters shadowing outer test variables, which is noise, not risk. Exempting test files makes the rule cheap to enable for prod code across all backend repos (same reasoning as the `no-non-null-assertion`/`no-unsafe-*` entries already in this override).

This unblocks the `no-shadow` enablement wave in clipboard-health (follow-up to https://github.com/ClipboardHealth/clipboard-health/pull/26063).

## Validation

- `base.json` parses and loads under oxlint 1.68.0 (ran `npx oxlint -c .../base.json` against a sample file in clipboard-health).
- One-line config change; repo CI covers the rest.

Agent session: `claude --resume f5b07508-4062-4898-8dfe-91641dcc77cb`

<sub>🤖 <code>cb-ship:created v1 core@3.8.0</code></sub>
