### PR TITLE
feat: add clearance-ensure stop/restart/status subcommands

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -137,6 +137,7 @@
     "permalinks",
     "PGID",
     "pgid",
+    "pidfile",
     "pipefail",
     "pmem",
     "prereq",

--- a/packages/clearance/README.md
+++ b/packages/clearance/README.md
@@ -95,10 +95,28 @@ pid at `…/clearance.pid`.
 CLEARANCE_ALLOW_HOSTS_FILES="$REPO/clearance-allow-hosts" clearance-ensure
 ```
 
-To stop or restart the managed proxy after editing your allow-host files:
+### Lifecycle subcommands
+
+`clearance-ensure` accepts an optional subcommand. With none, it defaults to
+`start` (the idempotent launch above). All subcommands discover the running
+proxy through the pidfile.
+
+<!-- markdownlint-disable MD060 -->
+
+| Command                    | Behavior                                                                                             |
+| -------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `clearance-ensure`         | Default `start`: launch the proxy if nothing is already listening.                                   |
+| `clearance-ensure start`   | Same as the bare invocation.                                                                         |
+| `clearance-ensure stop`    | Signal the pidfile process to terminate, wait for the port to close, and remove the pidfile.         |
+| `clearance-ensure restart` | `stop` the existing proxy (if any), then `start` a fresh one. Use this to pick up edited host files. |
+| `clearance-ensure status`  | Report whether the proxy is listening and its pid. Exits non-zero when it is not running.            |
+
+<!-- markdownlint-enable MD060 -->
+
+To pick up edited allow-host files, restart in one step:
 
 ```bash
-kill "$(cat "${XDG_CACHE_HOME:-$HOME/.cache}/clearance/clearance.pid")"
+CLEARANCE_ALLOW_HOSTS_FILES="$REPO/clearance-allow-hosts" clearance-ensure restart
 ```
 
 ## Safehouse integration (macOS)

--- a/packages/clearance/src/ensureCli.ts
+++ b/packages/clearance/src/ensureCli.ts
@@ -1,12 +1,42 @@
 #!/usr/bin/env node
 
-import { ensureClearance } from "./launcher.ts";
+import {
+  ensureClearance,
+  parseClearanceCommand,
+  restartClearance,
+  statusClearance,
+  stopClearance,
+} from "./launcher.ts";
 
-ensureClearance({
-  logger: (message) => {
-    process.stderr.write(`${message}\n`);
-  },
-}).catch((error: unknown) => {
+function logToStderr(message: string): void {
+  process.stderr.write(`${message}\n`);
+}
+
+async function main(): Promise<void> {
+  const command = parseClearanceCommand(process.argv.slice(2));
+
+  if (command === "stop") {
+    await stopClearance({ logger: logToStderr });
+    return;
+  }
+
+  if (command === "restart") {
+    await restartClearance({ logger: logToStderr });
+    return;
+  }
+
+  if (command === "status") {
+    const result = await statusClearance({ logger: logToStderr });
+    if (result.status === "not-running") {
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  await ensureClearance({ logger: logToStderr });
+}
+
+main().catch((error: unknown) => {
   const message = error instanceof Error ? error.message : String(error);
   process.stderr.write(`${message}\n`);
   process.exit(2);

--- a/packages/clearance/src/index.ts
+++ b/packages/clearance/src/index.ts
@@ -11,14 +11,26 @@ import { normalizeHost, normalizeRules, parseList } from "./hostRule.ts";
 export { resolveAllowlist, type ResolveAllowlistInput } from "./allowlist.ts";
 export {
   type ClearanceCheckInput,
+  type ClearanceCommand,
   type ClearanceListenerCheck,
   type ClearanceSpawner,
   ensureClearance,
   type EnsureClearanceInput,
   type EnsureClearanceResult,
   isClearanceListening,
+  parseClearanceCommand,
+  type ProcessKiller,
+  type ProcessKillInput,
+  restartClearance,
+  type RestartClearanceInput,
   spawnClearance,
   type SpawnClearanceInput,
+  statusClearance,
+  type StatusClearanceInput,
+  type StatusClearanceResult,
+  stopClearance,
+  type StopClearanceInput,
+  type StopClearanceResult,
 } from "./launcher.ts";
 export {
   resolveSafehouseCmuxIntegration,

--- a/packages/clearance/src/launcher.test.ts
+++ b/packages/clearance/src/launcher.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import * as net from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -8,8 +8,13 @@ import {
   type ClearanceSpawner,
   ensureClearance,
   isClearanceListening,
+  parseClearanceCommand,
+  type ProcessKiller,
+  restartClearance,
   spawnClearance,
   type SpawnClearanceInput,
+  statusClearance,
+  stopClearance,
 } from "./launcher.ts";
 
 function createTempCacheDir(): string {
@@ -322,5 +327,235 @@ describe(spawnClearance, () => {
     });
 
     expect(actual).toBeGreaterThan(0);
+  });
+});
+
+function writePidFile(cacheDir: string, pid: number): string {
+  const pidPath = path.join(cacheDir, "clearance.pid");
+  writeFileSync(pidPath, `${pid}\n`);
+  return pidPath;
+}
+
+describe(stopClearance, () => {
+  let cacheDir: string | undefined;
+
+  afterEach(() => {
+    cleanupCacheDir(cacheDir);
+    cacheDir = undefined;
+  });
+
+  it("kills the pidfile process, removes the pidfile, and reports stopped", async () => {
+    cacheDir = createTempCacheDir();
+    const pidPath = writePidFile(cacheDir, 12_345);
+    const isListeningMock = createListenerMock([false]);
+    const killMock = vi.fn<ProcessKiller>();
+    const messages: string[] = [];
+
+    const actual = await stopClearance({
+      cacheDir,
+      isListening: isListeningMock,
+      kill: killMock,
+      logger: rememberMessage(messages),
+    });
+
+    expect(actual).toStrictEqual({ pid: 12_345, port: 19_999, status: "stopped" });
+    expect(killMock).toHaveBeenCalledWith({ pid: 12_345 });
+    expect(existsSync(pidPath)).toBe(false);
+    expect(messages).toContain("Stopped clearance (pid 12345)");
+  });
+
+  it("reports not-running when no pidfile exists, deriving the cache dir from env", async () => {
+    cacheDir = createTempCacheDir();
+    const isListeningMock = vi.fn<ClearanceListenerCheck>();
+    const killMock = vi.fn<ProcessKiller>();
+
+    const actual = await stopClearance({
+      env: { XDG_CACHE_HOME: cacheDir },
+      isListening: isListeningMock,
+      kill: killMock,
+    });
+
+    expect(actual.status).toBe("not-running");
+    expect(killMock).not.toHaveBeenCalled();
+  });
+
+  it("treats a garbage pidfile as not running", async () => {
+    cacheDir = createTempCacheDir();
+    writeFileSync(path.join(cacheDir, "clearance.pid"), "not-a-pid\n");
+    const isListeningMock = vi.fn<ClearanceListenerCheck>();
+    const killMock = vi.fn<ProcessKiller>();
+
+    const actual = await stopClearance({
+      cacheDir,
+      isListening: isListeningMock,
+      kill: killMock,
+    });
+
+    expect(actual.status).toBe("not-running");
+    expect(killMock).not.toHaveBeenCalled();
+  });
+
+  it("removes a stale pidfile when the process is already gone", async () => {
+    cacheDir = createTempCacheDir();
+    const pidPath = writePidFile(cacheDir, 999_999);
+    const isListeningMock = vi.fn<ClearanceListenerCheck>();
+    const killMock = vi.fn<ProcessKiller>().mockImplementation(() => {
+      const error: NodeJS.ErrnoException = new Error("no such process");
+      error.code = "ESRCH";
+      throw error;
+    });
+
+    const actual = await stopClearance({
+      cacheDir,
+      isListening: isListeningMock,
+      kill: killMock,
+      sleep: noopAsync,
+    });
+
+    expect(actual.status).toBe("not-running");
+    expect(existsSync(pidPath)).toBe(false);
+    expect(isListeningMock).not.toHaveBeenCalled();
+  });
+
+  it("rethrows kill errors that are not 'already gone'", async () => {
+    cacheDir = createTempCacheDir();
+    writePidFile(cacheDir, 12_345);
+    const isListeningMock = vi.fn<ClearanceListenerCheck>();
+    const killMock = vi.fn<ProcessKiller>().mockImplementation(() => {
+      const error: NodeJS.ErrnoException = new Error("operation not permitted");
+      error.code = "EPERM";
+      throw error;
+    });
+
+    await expect(
+      stopClearance({
+        cacheDir,
+        isListening: isListeningMock,
+        kill: killMock,
+        sleep: noopAsync,
+      }),
+    ).rejects.toThrow(/operation not permitted/);
+    expect(isListeningMock).not.toHaveBeenCalled();
+  });
+
+  it("throws when the process refuses to stop within the timeout", async () => {
+    cacheDir = createTempCacheDir();
+    writePidFile(cacheDir, 12_345);
+    const isListeningMock = vi.fn<ClearanceListenerCheck>().mockResolvedValue(true);
+    const killMock = vi.fn<ProcessKiller>();
+
+    await expect(
+      stopClearance({
+        cacheDir,
+        isListening: isListeningMock,
+        kill: killMock,
+        pollIntervalMs: 1,
+        sleep: noopAsync,
+        timeoutMs: 2,
+      }),
+    ).rejects.toThrow(/did not stop/);
+  });
+});
+
+describe(statusClearance, () => {
+  let cacheDir: string | undefined;
+
+  afterEach(() => {
+    cleanupCacheDir(cacheDir);
+    cacheDir = undefined;
+  });
+
+  it("reports a running proxy with its pid", async () => {
+    cacheDir = createTempCacheDir();
+    writePidFile(cacheDir, 54_321);
+    const isListeningMock = vi.fn<ClearanceListenerCheck>().mockResolvedValue(true);
+    const messages: string[] = [];
+
+    const actual = await statusClearance({
+      cacheDir,
+      env: { XDG_CACHE_HOME: cacheDir },
+      isListening: isListeningMock,
+      logger: rememberMessage(messages),
+    });
+
+    expect(actual).toStrictEqual({ pid: 54_321, port: 19_999, status: "running" });
+    expect(messages).toContain("Clearance is running (pid 54321) on http://127.0.0.1:19999");
+  });
+
+  it("reports a running proxy even when no pidfile is present", async () => {
+    cacheDir = createTempCacheDir();
+    const isListeningMock = vi.fn<ClearanceListenerCheck>().mockResolvedValue(true);
+    const messages: string[] = [];
+
+    const actual = await statusClearance({
+      cacheDir,
+      isListening: isListeningMock,
+      logger: rememberMessage(messages),
+    });
+
+    expect(actual).toStrictEqual({ port: 19_999, status: "running" });
+    expect(messages).toContain("Clearance is running on http://127.0.0.1:19999");
+  });
+
+  it("reports not-running when nothing is listening, deriving the cache dir from env", async () => {
+    cacheDir = createTempCacheDir();
+    const isListeningMock = vi.fn<ClearanceListenerCheck>().mockResolvedValue(false);
+
+    const actual = await statusClearance({
+      env: { XDG_CACHE_HOME: cacheDir },
+      isListening: isListeningMock,
+    });
+
+    expect(actual.status).toBe("not-running");
+    expect(actual.pid).toBeUndefined();
+  });
+});
+
+describe(restartClearance, () => {
+  let cacheDir: string | undefined;
+
+  afterEach(() => {
+    cleanupCacheDir(cacheDir);
+    cacheDir = undefined;
+  });
+
+  it("stops the existing proxy and starts a fresh one", async () => {
+    cacheDir = createTempCacheDir();
+    const pidPath = writePidFile(cacheDir, 111);
+    const isListeningMock = createListenerMock([false, false, true]);
+    const killMock = vi.fn<ProcessKiller>();
+    const spawnMock = vi.fn<ClearanceSpawner>().mockReturnValue(222);
+
+    const actual = await restartClearance({
+      cacheDir,
+      env: { CLEARANCE_ALLOW_HOSTS: "api.example.com" },
+      isListening: isListeningMock,
+      kill: killMock,
+      sleep: noopAsync,
+      spawnDetached: spawnMock,
+    });
+
+    expect(killMock).toHaveBeenCalledWith({ pid: 111 });
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(actual.status).toBe("started");
+    expect(actual.pid).toBe(222);
+    expect(readFileSync(pidPath, "utf8")).toBe("222\n");
+  });
+});
+
+describe(parseClearanceCommand, () => {
+  it("defaults to start when no command is given", () => {
+    expect(parseClearanceCommand([])).toBe("start");
+  });
+
+  it("returns the recognized command", () => {
+    expect(parseClearanceCommand(["stop"])).toBe("stop");
+    expect(parseClearanceCommand(["restart"])).toBe("restart");
+    expect(parseClearanceCommand(["status"])).toBe("status");
+    expect(parseClearanceCommand(["start"])).toBe("start");
+  });
+
+  it("throws on an unknown command", () => {
+    expect(() => parseClearanceCommand(["bogus"])).toThrow(/Unknown clearance-ensure command/);
   });
 });

--- a/packages/clearance/src/launcher.test.ts
+++ b/packages/clearance/src/launcher.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import * as net from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -436,6 +436,34 @@ describe(stopClearance, () => {
       }),
     ).rejects.toThrow(/operation not permitted/);
     expect(isListeningMock).not.toHaveBeenCalled();
+  });
+
+  it("rethrows non-ENOENT pidfile read failures", async () => {
+    cacheDir = createTempCacheDir();
+    mkdirSync(path.join(cacheDir, "clearance.pid"));
+    const isListeningMock = vi.fn<ClearanceListenerCheck>();
+    const killMock = vi.fn<ProcessKiller>();
+
+    await expect(
+      stopClearance({ cacheDir, isListening: isListeningMock, kill: killMock }),
+    ).rejects.toThrow(/EISDIR/);
+    expect(killMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-positive poll interval", async () => {
+    cacheDir = createTempCacheDir();
+    writePidFile(cacheDir, 12_345);
+    const isListeningMock = vi.fn<ClearanceListenerCheck>().mockResolvedValue(false);
+    const killMock = vi.fn<ProcessKiller>();
+
+    await expect(
+      stopClearance({
+        cacheDir,
+        isListening: isListeningMock,
+        kill: killMock,
+        pollIntervalMs: 0,
+      }),
+    ).rejects.toThrow(/pollIntervalMs must be a positive number/);
   });
 
   it("throws when the process refuses to stop within the timeout", async () => {

--- a/packages/clearance/src/launcher.test.ts
+++ b/packages/clearance/src/launcher.test.ts
@@ -395,6 +395,22 @@ describe(stopClearance, () => {
     expect(killMock).not.toHaveBeenCalled();
   });
 
+  it("treats a partially numeric pidfile as not running", async () => {
+    cacheDir = createTempCacheDir();
+    writeFileSync(path.join(cacheDir, "clearance.pid"), "123abc\n");
+    const isListeningMock = vi.fn<ClearanceListenerCheck>();
+    const killMock = vi.fn<ProcessKiller>();
+
+    const actual = await stopClearance({
+      cacheDir,
+      isListening: isListeningMock,
+      kill: killMock,
+    });
+
+    expect(actual.status).toBe("not-running");
+    expect(killMock).not.toHaveBeenCalled();
+  });
+
   it("removes a stale pidfile when the process is already gone", async () => {
     cacheDir = createTempCacheDir();
     const pidPath = writePidFile(cacheDir, 999_999);

--- a/packages/clearance/src/launcher.test.ts
+++ b/packages/clearance/src/launcher.test.ts
@@ -411,6 +411,22 @@ describe(stopClearance, () => {
     expect(killMock).not.toHaveBeenCalled();
   });
 
+  it("treats an unsafe numeric pidfile as not running", async () => {
+    cacheDir = createTempCacheDir();
+    writeFileSync(path.join(cacheDir, "clearance.pid"), `${Number.MAX_SAFE_INTEGER + 1}\n`);
+    const isListeningMock = vi.fn<ClearanceListenerCheck>();
+    const killMock = vi.fn<ProcessKiller>();
+
+    const actual = await stopClearance({
+      cacheDir,
+      isListening: isListeningMock,
+      kill: killMock,
+    });
+
+    expect(actual.status).toBe("not-running");
+    expect(killMock).not.toHaveBeenCalled();
+  });
+
   it("removes a stale pidfile when the process is already gone", async () => {
     cacheDir = createTempCacheDir();
     const pidPath = writePidFile(cacheDir, 999_999);

--- a/packages/clearance/src/launcher.ts
+++ b/packages/clearance/src/launcher.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { closeSync, mkdirSync, openSync, writeFileSync } from "node:fs";
+import { closeSync, mkdirSync, openSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import * as net from "node:net";
 import { homedir } from "node:os";
 import path from "node:path";
@@ -10,6 +10,7 @@ const CLEARANCE_HOST = "127.0.0.1";
 const CLEARANCE_PORT = 19_999;
 const CLEARANCE_START_TIMEOUT_MS = 3000;
 const CLEARANCE_POLL_INTERVAL_MS = 100;
+const CLEARANCE_COMMANDS = ["restart", "start", "status", "stop"] as const;
 
 const FORWARDED_ENV_VARS = [
   "CLEARANCE_ALLOW_HOSTS",
@@ -58,6 +59,49 @@ export interface EnsureClearanceResult {
   pidPath?: string;
   port: number;
   status: "already-running" | "started";
+}
+
+export type ClearanceCommand = (typeof CLEARANCE_COMMANDS)[number];
+
+export interface ProcessKillInput {
+  pid: number;
+  signal?: NodeJS.Signals;
+}
+
+export type ProcessKiller = (input: ProcessKillInput) => void;
+
+export interface StopClearanceInput {
+  cacheDir?: string;
+  env?: NodeJS.ProcessEnv;
+  isListening?: ClearanceListenerCheck;
+  kill?: ProcessKiller;
+  logger?: (message: string) => void;
+  pollIntervalMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+  timeoutMs?: number;
+}
+
+export interface StopClearanceResult {
+  pid?: number;
+  port: number;
+  status: "not-running" | "stopped";
+}
+
+export interface StatusClearanceInput {
+  cacheDir?: string;
+  env?: NodeJS.ProcessEnv;
+  isListening?: ClearanceListenerCheck;
+  logger?: (message: string) => void;
+}
+
+export interface StatusClearanceResult {
+  pid?: number;
+  port: number;
+  status: "not-running" | "running";
+}
+
+export interface RestartClearanceInput extends EnsureClearanceInput {
+  kill?: ProcessKiller;
 }
 
 // import.meta.dirname is `<package>/{src,dist}`; the proxy server bin lives at `<package>/bin/run.js`.
@@ -135,11 +179,9 @@ export async function ensureClearance(
   });
   writeFileSync(pidPath, `${pid}\n`);
 
-  const isReady = await waitForListening({
-    host: CLEARANCE_HOST,
-    isListening,
+  const isReady = await pollUntil({
+    check: async () => await isListening({ host: CLEARANCE_HOST, port: CLEARANCE_PORT }),
     pollIntervalMs: input.pollIntervalMs ?? CLEARANCE_POLL_INTERVAL_MS,
-    port: CLEARANCE_PORT,
     sleep: input.sleep ?? defaultSleep,
     timeoutMs: input.timeoutMs ?? CLEARANCE_START_TIMEOUT_MS,
   });
@@ -155,8 +197,153 @@ export async function ensureClearance(
   return { logPath, pid, pidPath, port: CLEARANCE_PORT, status: "started" };
 }
 
+export function parseClearanceCommand(cliArguments: readonly string[]): ClearanceCommand {
+  const [first] = cliArguments;
+  if (first === undefined) {
+    return "start";
+  }
+
+  if (isClearanceCommand(first)) {
+    return first;
+  }
+
+  throw new Error(
+    `Unknown clearance-ensure command: ${first}. Use ${CLEARANCE_COMMANDS.join(", ")}.`,
+  );
+}
+
+export async function stopClearance(input: StopClearanceInput = {}): Promise<StopClearanceResult> {
+  const { isListening, logger, pidPath } = resolveLifecycleContext(input);
+  /* v8 ignore next @preserve -- default killer signals a real process; tests inject kill instead */
+  const kill = input.kill ?? defaultKill;
+
+  const pid = readPidFile(pidPath);
+  if (pid === undefined) {
+    logger(`Clearance is not running (no pidfile at ${pidPath})`);
+    return { port: CLEARANCE_PORT, status: "not-running" };
+  }
+
+  let didSignal = false;
+  try {
+    kill({ pid });
+    didSignal = true;
+  } catch (error) {
+    if (!isAlreadyGoneError(error)) {
+      throw error;
+    }
+  }
+
+  if (didSignal) {
+    const stopped = await pollUntil({
+      check: async () => !(await isListening({ host: CLEARANCE_HOST, port: CLEARANCE_PORT })),
+      pollIntervalMs: input.pollIntervalMs ?? CLEARANCE_POLL_INTERVAL_MS,
+      sleep: input.sleep ?? defaultSleep,
+      timeoutMs: input.timeoutMs ?? CLEARANCE_START_TIMEOUT_MS,
+    });
+    if (!stopped) {
+      throw new Error(
+        `Clearance (pid ${pid}) did not stop listening on ${CLEARANCE_HOST}:${CLEARANCE_PORT}`,
+      );
+    }
+  }
+
+  rmSync(pidPath, { force: true });
+
+  if (didSignal) {
+    logger(`Stopped clearance (pid ${pid})`);
+    return { pid, port: CLEARANCE_PORT, status: "stopped" };
+  }
+
+  logger(`Clearance (pid ${pid}) was already gone; removed stale pidfile ${pidPath}`);
+  return { pid, port: CLEARANCE_PORT, status: "not-running" };
+}
+
+export async function statusClearance(
+  input: StatusClearanceInput = {},
+): Promise<StatusClearanceResult> {
+  const { isListening, logger, pidPath } = resolveLifecycleContext(input);
+
+  const pid = readPidFile(pidPath);
+  const url = `http://${CLEARANCE_HOST}:${CLEARANCE_PORT}`;
+
+  if (await isListening({ host: CLEARANCE_HOST, port: CLEARANCE_PORT })) {
+    if (pid === undefined) {
+      logger(`Clearance is running on ${url}`);
+      return { port: CLEARANCE_PORT, status: "running" };
+    }
+
+    logger(`Clearance is running (pid ${pid}) on ${url}`);
+    return { pid, port: CLEARANCE_PORT, status: "running" };
+  }
+
+  logger(`Clearance is not running on ${url}`);
+  return { port: CLEARANCE_PORT, status: "not-running" };
+}
+
+export async function restartClearance(
+  input: RestartClearanceInput = {},
+): Promise<EnsureClearanceResult> {
+  // stopClearance ignores the ensure-only fields (envOverrides, spawnDetached) and
+  // ensureClearance ignores `kill`, so the combined input is safe to forward to both.
+  await stopClearance(input);
+  return await ensureClearance(input);
+}
+
 function noop(): void {
   // No-op default for the optional logger hook.
+}
+
+/* v8 ignore start @preserve -- signaling is exercised through an injected kill in stopClearance tests */
+function defaultKill(input: ProcessKillInput): void {
+  process.kill(input.pid, input.signal);
+}
+/* v8 ignore stop */
+
+function readPidFile(pidPath: string): number | undefined {
+  let raw: string;
+  try {
+    raw = readFileSync(pidPath, "utf8");
+  } catch {
+    return undefined;
+  }
+
+  const pid = Number.parseInt(raw.trim(), 10);
+  return pid > 0 ? pid : undefined;
+}
+
+function isAlreadyGoneError(error: unknown): boolean {
+  /* v8 ignore next @preserve -- defensive: thrown kill errors are always Error instances carrying a code */
+  if (!(error instanceof Error) || !("code" in error)) {
+    return false;
+  }
+
+  return error.code === "ESRCH";
+}
+
+function isClearanceCommand(value: string): value is ClearanceCommand {
+  return (CLEARANCE_COMMANDS as readonly string[]).includes(value);
+}
+
+interface LifecycleContext {
+  isListening: ClearanceListenerCheck;
+  logger: (message: string) => void;
+  pidPath: string;
+}
+
+function resolveLifecycleContext(input: {
+  cacheDir?: string;
+  env?: NodeJS.ProcessEnv;
+  isListening?: ClearanceListenerCheck;
+  logger?: (message: string) => void;
+}): LifecycleContext {
+  const env = input.env ?? defaultProxyEnv();
+  const cacheDir = input.cacheDir ?? cacheDirFor(env);
+  return {
+    /* v8 ignore next @preserve -- default listener is covered directly by isClearanceListening tests */
+    isListening: input.isListening ?? isClearanceListening,
+    logger: input.logger ?? noop,
+    pidPath: path.join(cacheDir, "clearance.pid"),
+  };
 }
 
 function cacheDirFor(env: NodeJS.ProcessEnv): string {
@@ -204,18 +391,16 @@ function defaultProxyEnv(): NodeJS.ProcessEnv {
   );
 }
 
-async function waitForListening(input: {
-  host: string;
-  isListening: ClearanceListenerCheck;
+async function pollUntil(input: {
+  check: () => Promise<boolean>;
   pollIntervalMs: number;
-  port: number;
   sleep: (ms: number) => Promise<void>;
   timeoutMs: number;
 }): Promise<boolean> {
   const attempts = Math.max(1, Math.ceil(input.timeoutMs / input.pollIntervalMs));
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     // eslint-disable-next-line no-await-in-loop -- readiness polling is intentionally sequential
-    if (await input.isListening({ host: input.host, port: input.port })) {
+    if (await input.check()) {
       return true;
     }
     // eslint-disable-next-line no-await-in-loop -- readiness polling is intentionally sequential

--- a/packages/clearance/src/launcher.ts
+++ b/packages/clearance/src/launcher.ts
@@ -313,8 +313,13 @@ function readPidFile(pidPath: string): number | undefined {
     throw error;
   }
 
-  const pid = Number.parseInt(raw.trim(), 10);
-  return pid > 0 ? pid : undefined;
+  const trimmedPid = raw.trim();
+  if (!/^\d+$/.test(trimmedPid)) {
+    return undefined;
+  }
+
+  const pid = Number.parseInt(trimmedPid, 10);
+  return Number.isSafeInteger(pid) && pid > 0 ? pid : undefined;
 }
 
 function isAlreadyGoneError(error: unknown): boolean {

--- a/packages/clearance/src/launcher.ts
+++ b/packages/clearance/src/launcher.ts
@@ -303,8 +303,14 @@ function readPidFile(pidPath: string): number | undefined {
   let raw: string;
   try {
     raw = readFileSync(pidPath, "utf8");
-  } catch {
-    return undefined;
+  } catch (error) {
+    // A missing pidfile means "not running"; surface any other read failure
+    // (permissions, I/O) rather than masking it as a stopped proxy.
+    if (errnoCode(error) === "ENOENT") {
+      return undefined;
+    }
+
+    throw error;
   }
 
   const pid = Number.parseInt(raw.trim(), 10);
@@ -312,12 +318,16 @@ function readPidFile(pidPath: string): number | undefined {
 }
 
 function isAlreadyGoneError(error: unknown): boolean {
-  /* v8 ignore next @preserve -- defensive: thrown kill errors are always Error instances carrying a code */
-  if (!(error instanceof Error) || !("code" in error)) {
-    return false;
+  return errnoCode(error) === "ESRCH";
+}
+
+function errnoCode(error: unknown): string | undefined {
+  /* v8 ignore next @preserve -- defensive: thrown FS/signal errors are always Error instances carrying a string code */
+  if (!(error instanceof Error) || !("code" in error) || typeof error.code !== "string") {
+    return undefined;
   }
 
-  return error.code === "ESRCH";
+  return error.code;
 }
 
 function isClearanceCommand(value: string): value is ClearanceCommand {
@@ -397,6 +407,11 @@ async function pollUntil(input: {
   sleep: (ms: number) => Promise<void>;
   timeoutMs: number;
 }): Promise<boolean> {
+  // A non-positive interval makes `attempts` Infinity below, which would never terminate.
+  if (input.pollIntervalMs <= 0) {
+    throw new Error("pollIntervalMs must be a positive number");
+  }
+
   const attempts = Math.max(1, Math.ceil(input.timeoutMs / input.pollIntervalMs));
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     // eslint-disable-next-line no-await-in-loop -- readiness polling is intentionally sequential


### PR DESCRIPTION
## Summary

`clearance-ensure` only had an idempotent start, so restarting the managed proxy after editing allow-host files meant a manual `kill $(cat clearance.pid)` followed by a re-run. This adds three pidfile-driven lifecycle subcommands (the bare invocation still defaults to `start`):

- `stop` - signal the pidfile process, wait for the port to close, and remove the pidfile. A missing, garbage, or stale pidfile is treated as not-running (and a stale one is cleaned up).
- `restart` - `stop` the existing proxy (if any), then `start` a fresh one. This is the one-step way to pick up edited host files.
- `status` - report whether the proxy is listening and its pid; exits non-zero when not running.

The OS signal is injected through a `ProcessKiller` seam (mirroring the existing `isListening`/`spawnDetached` seams) so the lifecycle is unit-tested without signaling real processes. Readiness and shutdown polling share one `pollUntil` helper, and the env/cache-dir/pidfile preamble is shared via `resolveLifecycleContext`. README documents the new subcommands in place of the old manual-kill recipe.

## Validation

- `nx run-many --targets=lint,build,test --projects=clearance` - green; package coverage remains at the enforced 100%.
- `node --run verify` - exits 0 (lint, build, test, format, knip, spell, markdown, architecture, cpd, syncpack).

Agent session: `claude --resume 5c43b3f4-a897-4612-84cc-840b99593bbd`

<sub>🤖 <code>commit-push-pr:created v1 core@3.9.0</code></sub>