### PR TITLE
docs: simplify safehouse alias setup

### DIFF
--- a/packages/clearance/README.md
+++ b/packages/clearance/README.md
@@ -144,17 +144,15 @@ SAFEHOUSE_CLEARANCE="$(npm root -g)/@clipboard-health/clearance/safehouse/safeho
   -- codex --dangerously-bypass-approvals-and-sandbox
 ```
 
-For day-to-day agent use, set `CLEARANCE_ALLOW_HOSTS_FILES` to point at
-your team's checked-in file (and optionally a personal file), then add
-shell aliases:
+For day-to-day agent use, configure your allow-host files and add shell
+aliases:
 
 ```bash
-SAFEHOUSE_CLEARANCE="$(npm root -g)/@clipboard-health/clearance/safehouse/safehouse-clearance"
-SAFEHOUSE_CLAUDE_PROXY="$(npm root -g)/@clipboard-health/clearance/safehouse/safehouse-claude-proxy"
+SAFEHOUSE="$(npm root -g)/@clipboard-health/clearance/safehouse"
 export CLEARANCE_ALLOW_HOSTS_FILES="$HOME/code/<your-repo>/clearance-allow-hosts:$HOME/.config/clearance/personal-allow-hosts"
 
-alias codex-proxy="$SAFEHOUSE_CLEARANCE codex --dangerously-bypass-approvals-and-sandbox"
-alias claude-proxy="$SAFEHOUSE_CLAUDE_PROXY"
+alias codex-proxy="$SAFEHOUSE/safehouse-clearance codex --dangerously-bypass-approvals-and-sandbox"
+alias claude-proxy="$SAFEHOUSE/safehouse-claude-proxy"
 ```
 
 `safehouse-claude-proxy` runs Claude through Safehouse with
@@ -173,7 +171,7 @@ credentials flag through the wrapper:
 
 ```bash
 aws sso login --profile <profile>
-AWS_PROFILE=<profile> "$SAFEHOUSE_CLEARANCE" \
+AWS_PROFILE=<profile> "$SAFEHOUSE/safehouse-clearance" \
   --enable=cloud-credentials --env-pass=AWS_PROFILE,AWS_REGION,AWS_SDK_LOAD_CONFIG,AWS_CONFIG_FILE,AWS_SHARED_CREDENTIALS_FILE,AWS_CA_BUNDLE \
   -- codex --dangerously-bypass-approvals-and-sandbox
 ```


### PR DESCRIPTION
## Summary

Simplifies the Clearance Safehouse day-to-day alias setup by using one shared `SAFEHOUSE` directory variable, while keeping the required `CLEARANCE_ALLOW_HOSTS_FILES` configuration visible. Also updates the AWS SSO example to use the same wrapper path so the README no longer depends on a variable that the shorter alias snippet does not define.

## Validation

- `git diff --check`
- `node --run verify`
- `git push -u origin docs/simplify-clearance-safehouse-aliases` (pre-push verify passed)

Agent session: `codex resume 019ed6fd-b3b8-7741-a3a7-f487fe5f08c5`

<sub>🤖 <code>commit-push-pr:created v1 core@3.9.0</code></sub>