### PR TITLE
fix(ai-rules): copy agent skills into action repos instead of symlinking

### DIFF
--- a/packages/ai-rules/scripts/sync.ts
+++ b/packages/ai-rules/scripts/sync.ts
@@ -149,6 +149,14 @@ async function syncAgentDirectory(
 
   await mkdir(path.dirname(destination), { recursive: true });
 
+  // Action repos are consumed via `uses:` with no `npm install`, so a symlink into
+  // node_modules would dangle. Copy real files there; symlink everywhere else.
+  if (await fileExists(path.join(PATHS.projectRoot, "action.yml"))) {
+    await cp(source, destination, { recursive: true });
+    console.log(`📋 Synced ${directoryName} to .agents/${directoryName}/`);
+    return "copied";
+  }
+
   const relativeSource = path.relative(path.dirname(destination), source);
   try {
     await symlink(relativeSource, destination, "dir");


### PR DESCRIPTION
Action repos are consumed via `uses:` without an `npm install`, so the committed `.agents/skills` symlink (into `node_modules/@clipboard-health/ai-rules`) dangles and breaks the action with `Could not find file .agents/skills`. I changed `syncAgentDirectory` to copy the real files when the repo root has an `action.yml`, and keep symlinking everywhere else, so service repos are unchanged.

I hit this while unblocking ClipboardHealth/template-nestjs#582 (DEVOP-5483), where action-terraform-run and action-run-ecs-task fail to resolve their skills.

Verified with `node --run verify` and `nx run-many -t build,lint,test -p ai-rules` — all green.