### PR TITLE
ci(core): automate plugin version bumps with nx release

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -73,7 +73,7 @@
       "commit": true,
       "commitMessage": "chore(release): publish {projectName} {version} [skip actions]"
     },
-    "projects": ["packages/*", "!packages/example-*"],
+    "projects": ["packages/*", "!packages/example-*", "core-plugin"],
     "projectsRelationship": "independent",
     "version": {
       "conventionalCommits": true,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "knip": "NX_DAEMON=false knip --no-config-hints",
     "lint": "oxlint",
     "markdown:lint": "markdownlint-cli2 \"**/*.md\"",
+    "plugin:version:check": "node scripts/embedPluginVersion.mts --check",
     "postinstall": "node --run sync-ai-rules",
     "prepare": "husky",
     "spell:check": "cspell --no-summary --no-progress --no-must-find-files",

--- a/plugins/core/package.json
+++ b/plugins/core/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@clipboard-health/core-plugin",
+  "version": "3.10.0",
+  "private": true,
+  "description": "Clipboard's core development tools."
+}

--- a/plugins/core/package.json
+++ b/plugins/core/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@clipboard-health/core-plugin",
   "version": "3.10.0",
-  "private": true,
-  "description": "Clipboard's core development tools."
+  "private": true
 }

--- a/plugins/core/project.json
+++ b/plugins/core/project.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "core-plugin",
+  "projectType": "library",
+  "tags": []
+}

--- a/scripts/embedPluginVersion.mts
+++ b/scripts/embedPluginVersion.mts
@@ -100,7 +100,7 @@ export function syncPluginVersion(options: { check?: boolean; version?: string }
   return { version, changedFiles };
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const check = process.argv.includes("--check");
   const { version, changedFiles } = syncPluginVersion({ check });
   if (check && changedFiles.length > 0) {

--- a/scripts/embedPluginVersion.mts
+++ b/scripts/embedPluginVersion.mts
@@ -1,24 +1,36 @@
 /**
- * Embeds the plugins/core version into skill source files.
+ * Syncs the plugins/core version from its package.json into the plugin
+ * manifest and skill sentinels.
  *
- * Sentinels emitted by the babysit-pr and commit-push-pr skills carry a
- * `core@X.Y.Z` suffix so PR comments are traceable to the plugin version
- * that produced them. Substituting at build time (rather than reading
- * plugin.json at runtime) keeps the skills agent-agnostic — Codex,
- * Claude Code, and any other host see the same literal string without
- * needing path resolution to a Claude-specific plugin.json location.
+ * `plugins/core/package.json` is the source of truth that `nx release` bumps
+ * (it is private, so it is never published to npm). This script propagates
+ * that version to:
  *
- * Reads `version` from plugins/core/.claude-plugin/plugin.json and
- * rewrites every `core@<digits>.<digits>.<digits>` occurrence in
- * plugins/core/skills/**\/*.{md,sh} to match.
+ *   - `plugins/core/.claude-plugin/plugin.json` — the manifest Claude Code
+ *     reads at runtime.
+ *   - `core@<major>.<minor>.<patch>` sentinels in the babysit-pr and
+ *     commit-push-pr skills, so PR comments stay traceable to the plugin
+ *     version that produced them. Substituting here (rather than reading a
+ *     manifest at runtime) keeps the skills agent-agnostic: Codex, Claude
+ *     Code, and any other host see the same literal string without resolving
+ *     a Claude-specific manifest path.
+ *
+ * Idempotent: re-running with no version change rewrites nothing.
  */
 import { readdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
-const REPO_ROOT = path.resolve(import.meta.dirname, "..");
+// import.meta.dirname is undefined when tsx imports this module as CommonJS
+// (scripts/release.ts pulls it in via tsx); deriving the directory from
+// import.meta.url works under both native ESM (node) and tsx.
+// oxlint-disable-next-line unicorn/prefer-import-meta-properties
+const REPO_ROOT = path.resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
+const PACKAGE_JSON = path.join(REPO_ROOT, "plugins/core/package.json");
 const PLUGIN_JSON = path.join(REPO_ROOT, "plugins/core/.claude-plugin/plugin.json");
 const SKILLS_ROOT = path.join(REPO_ROOT, "plugins/core/skills");
-const VERSION_PATTERN = /core@\d+\.\d+\.\d+/g;
+const SENTINEL_PATTERN = /core@\d+\.\d+\.\d+/g;
+const MANIFEST_VERSION_PATTERN = /("version":\s*")\d+\.\d+\.\d+(")/;
 const SEMVER_PATTERN = /^\d+\.\d+\.\d+$/;
 
 function walk(directory: string): string[] {
@@ -34,23 +46,38 @@ function walk(directory: string): string[] {
   return result;
 }
 
-const { version } = JSON.parse(readFileSync(PLUGIN_JSON, "utf8")) as { version: unknown };
-if (typeof version !== "string" || !SEMVER_PATTERN.test(version)) {
-  throw new TypeError(`Invalid version in ${PLUGIN_JSON}: ${String(version)}`);
+export function syncPluginVersion(): { version: string; changedFiles: string[] } {
+  const { version } = JSON.parse(readFileSync(PACKAGE_JSON, "utf8")) as { version: unknown };
+  if (typeof version !== "string" || !SEMVER_PATTERN.test(version)) {
+    throw new TypeError(`Invalid version in ${PACKAGE_JSON}: ${String(version)}`);
+  }
+
+  const changedFiles: string[] = [];
+
+  const manifest = readFileSync(PLUGIN_JSON, "utf8");
+  const updatedManifest = manifest.replace(MANIFEST_VERSION_PATTERN, `$1${version}$2`);
+  if (updatedManifest !== manifest) {
+    writeFileSync(PLUGIN_JSON, updatedManifest);
+    changedFiles.push(PLUGIN_JSON);
+  }
+
+  const target = `core@${version}`;
+  for (const file of walk(SKILLS_ROOT)) {
+    const content = readFileSync(file, "utf8");
+    if (!content.includes("core@")) {
+      continue;
+    }
+    const replaced = content.replaceAll(SENTINEL_PATTERN, target);
+    if (replaced !== content) {
+      writeFileSync(file, replaced);
+      changedFiles.push(file);
+    }
+  }
+
+  return { version, changedFiles };
 }
 
-const target = `core@${version}`;
-let updated = 0;
-for (const file of walk(SKILLS_ROOT)) {
-  const content = readFileSync(file, "utf8");
-  if (!content.includes("core@")) {
-    continue;
-  }
-  const replaced = content.replaceAll(VERSION_PATTERN, target);
-  if (replaced !== content) {
-    writeFileSync(file, replaced);
-    updated += 1;
-  }
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const { version, changedFiles } = syncPluginVersion();
+  console.log(`✓ Synced core@${version} into ${changedFiles.length} file(s)`);
 }
-
-console.log(`✓ Embedded ${target} into ${updated} skill file(s)`);

--- a/scripts/embedPluginVersion.mts
+++ b/scripts/embedPluginVersion.mts
@@ -15,7 +15,9 @@
  *     Code, and any other host see the same literal string without resolving
  *     a Claude-specific manifest path.
  *
- * Idempotent: re-running with no version change rewrites nothing.
+ * Idempotent: re-running with no version change rewrites nothing. Pass
+ * `--check` to report drift without writing (exits non-zero when any file is
+ * out of sync); `verify` runs it that way so the three locations can't drift.
  */
 import { readdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
@@ -30,7 +32,6 @@ const PACKAGE_JSON = path.join(REPO_ROOT, "plugins/core/package.json");
 const PLUGIN_JSON = path.join(REPO_ROOT, "plugins/core/.claude-plugin/plugin.json");
 const SKILLS_ROOT = path.join(REPO_ROOT, "plugins/core/skills");
 const SENTINEL_PATTERN = /core@\d+\.\d+\.\d+/g;
-const MANIFEST_VERSION_PATTERN = /("version":\s*")\d+\.\d+\.\d+(")/;
 const SEMVER_PATTERN = /^\d+\.\d+\.\d+$/;
 
 function walk(directory: string): string[] {
@@ -46,7 +47,16 @@ function walk(directory: string): string[] {
   return result;
 }
 
-export function syncPluginVersion(): { version: string; changedFiles: string[] } {
+/**
+ * Propagates plugins/core/package.json's version into the plugin manifest and
+ * skill sentinels. With `check`, computes what would change but writes nothing,
+ * returning the would-be-changed files so callers can fail on drift.
+ */
+export function syncPluginVersion(options: { check?: boolean } = {}): {
+  version: string;
+  changedFiles: string[];
+} {
+  const { check = false } = options;
   const { version } = JSON.parse(readFileSync(PACKAGE_JSON, "utf8")) as { version: unknown };
   if (typeof version !== "string" || !SEMVER_PATTERN.test(version)) {
     throw new TypeError(`Invalid version in ${PACKAGE_JSON}: ${String(version)}`);
@@ -54,10 +64,12 @@ export function syncPluginVersion(): { version: string; changedFiles: string[] }
 
   const changedFiles: string[] = [];
 
-  const manifest = readFileSync(PLUGIN_JSON, "utf8");
-  const updatedManifest = manifest.replace(MANIFEST_VERSION_PATTERN, `$1${version}$2`);
-  if (updatedManifest !== manifest) {
-    writeFileSync(PLUGIN_JSON, updatedManifest);
+  const manifest = JSON.parse(readFileSync(PLUGIN_JSON, "utf8")) as { version?: string };
+  if (manifest.version !== version) {
+    if (!check) {
+      manifest.version = version;
+      writeFileSync(PLUGIN_JSON, `${JSON.stringify(manifest, null, 2)}\n`);
+    }
     changedFiles.push(PLUGIN_JSON);
   }
 
@@ -69,7 +81,9 @@ export function syncPluginVersion(): { version: string; changedFiles: string[] }
     }
     const replaced = content.replaceAll(SENTINEL_PATTERN, target);
     if (replaced !== content) {
-      writeFileSync(file, replaced);
+      if (!check) {
+        writeFileSync(file, replaced);
+      }
       changedFiles.push(file);
     }
   }
@@ -78,6 +92,18 @@ export function syncPluginVersion(): { version: string; changedFiles: string[] }
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1]).href) {
-  const { version, changedFiles } = syncPluginVersion();
-  console.log(`✓ Synced core@${version} into ${changedFiles.length} file(s)`);
+  const check = process.argv.includes("--check");
+  const { version, changedFiles } = syncPluginVersion({ check });
+  if (check && changedFiles.length > 0) {
+    const stale = changedFiles.map((file) => path.relative(REPO_ROOT, file)).join(", ");
+    console.error(
+      `✗ plugins/core version out of sync with package.json (core@${version}). Run \`node scripts/embedPluginVersion.mts\`. Stale: ${stale}`,
+    );
+    process.exit(1);
+  }
+  console.log(
+    check
+      ? `✓ plugins/core version in sync (core@${version})`
+      : `✓ Synced core@${version} into ${changedFiles.length} file(s)`,
+  );
 }

--- a/scripts/embedPluginVersion.mts
+++ b/scripts/embedPluginVersion.mts
@@ -47,19 +47,28 @@ function walk(directory: string): string[] {
   return result;
 }
 
+function readPackageJsonVersion(): string {
+  const { version } = JSON.parse(readFileSync(PACKAGE_JSON, "utf8")) as { version: unknown };
+  return typeof version === "string" ? version : String(version);
+}
+
 /**
- * Propagates plugins/core/package.json's version into the plugin manifest and
- * skill sentinels. With `check`, computes what would change but writes nothing,
+ * Propagates a version into the plugin manifest and skill sentinels.
+ *
+ * Pass `version` to use an explicit version (the release flow passes the version
+ * Nx just computed, so the sync does not depend on when Nx flushes package.json
+ * to disk); omit it to read the current version from package.json (the CLI and
+ * postinstall path). With `check`, computes what would change but writes nothing,
  * returning the would-be-changed files so callers can fail on drift.
  */
-export function syncPluginVersion(options: { check?: boolean } = {}): {
+export function syncPluginVersion(options: { check?: boolean; version?: string } = {}): {
   version: string;
   changedFiles: string[];
 } {
   const { check = false } = options;
-  const { version } = JSON.parse(readFileSync(PACKAGE_JSON, "utf8")) as { version: unknown };
-  if (typeof version !== "string" || !SEMVER_PATTERN.test(version)) {
-    throw new TypeError(`Invalid version in ${PACKAGE_JSON}: ${String(version)}`);
+  const version = options.version ?? readPackageJsonVersion();
+  if (!SEMVER_PATTERN.test(version)) {
+    throw new TypeError(`Invalid plugin version: ${JSON.stringify(version)}`);
   }
 
   const changedFiles: string[] = [];

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -192,10 +192,10 @@ async function createGitHubRelease(request: GitHubReleaseRequest): Promise<void>
 type ProjectsVersionData = Awaited<ReturnType<typeof releaseVersion>>["projectsVersionData"];
 
 /**
- * The core plugin's version lives in plugins/core/.claude-plugin/plugin.json and
- * in skill sentinels, not the package.json that Nx versions. Propagate the bump
- * into them after versioning and before the release commit, so they land in the
- * same commit. No-op when the plugin was not part of this release.
+ * Nx bumps plugins/core/package.json; plugin.json and the skill sentinels derive
+ * from it. Propagate the bump into them after versioning and before the release
+ * commit, so they land in the same commit. No-op when the plugin was not part of
+ * this release.
  */
 function syncCorePluginVersion(projectsVersionData: ProjectsVersionData, dryRun: boolean): void {
   const pluginVersion = projectsVersionData["core-plugin"]?.newVersion;

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -208,7 +208,10 @@ function syncCorePluginVersion(projectsVersionData: ProjectsVersionData, dryRun:
     return;
   }
 
-  const { changedFiles } = syncPluginVersion();
+  // Pass the version Nx just computed rather than re-reading package.json:
+  // Nx stages the bump without the working-tree read reflecting it yet, so a
+  // disk read here would see the old version and silently skip the sync.
+  const { changedFiles } = syncPluginVersion({ version: pluginVersion });
   if (changedFiles.length > 0) {
     execFileSync("git", ["add", ...changedFiles], { stdio: "inherit" });
   }

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -13,6 +13,8 @@ import { parseArgs } from "node:util";
 
 import { releaseChangelog, releaseVersion } from "nx/release";
 
+import { syncPluginVersion } from "./embedPluginVersion.mts";
+
 const MAX_RETRY_COUNT = 3;
 const INITIAL_BACKOFF_MILLISECONDS = 1000;
 const RETRYABLE_STATUS_CODES = new Set([500, 502, 503, 504]);
@@ -187,6 +189,35 @@ async function createGitHubRelease(request: GitHubReleaseRequest): Promise<void>
   }
 }
 
+type ProjectsVersionData = Awaited<ReturnType<typeof releaseVersion>>["projectsVersionData"];
+
+/**
+ * The core plugin's version lives in plugins/core/.claude-plugin/plugin.json and
+ * in skill sentinels, not the package.json that Nx versions. Propagate the bump
+ * into them after versioning and before the release commit, so they land in the
+ * same commit. No-op when the plugin was not part of this release.
+ */
+function syncCorePluginVersion(projectsVersionData: ProjectsVersionData, dryRun: boolean): void {
+  const pluginVersion = projectsVersionData["core-plugin"]?.newVersion;
+  if (typeof pluginVersion !== "string") {
+    return;
+  }
+
+  if (dryRun) {
+    log(`  [dry-run] Would sync plugin manifest and sentinels to ${pluginVersion}`);
+    return;
+  }
+
+  const { changedFiles } = syncPluginVersion();
+  if (changedFiles.length > 0) {
+    execFileSync("git", ["add", ...changedFiles], { stdio: "inherit" });
+  }
+
+  log(
+    `  Synced plugin manifest and sentinels to ${pluginVersion} (${changedFiles.length} file(s))`,
+  );
+}
+
 async function main(): Promise<void> {
   // Phase 1: Version bumping
   log("Phase 1: Bumping versions...");
@@ -211,6 +242,8 @@ async function main(): Promise<void> {
   for (const [name, data] of changedProjects) {
     verbose(`    ${name}: ${data.currentVersion} -> ${data.newVersion}`);
   }
+
+  syncCorePluginVersion(projectsVersionData, isDryRun);
 
   // Phase 2: Changelog generation
   log("Phase 2: Generating changelogs...");

--- a/scripts/verifyAll.mts
+++ b/scripts/verifyAll.mts
@@ -19,6 +19,7 @@ const CHECKS = [
   { cmd: "node --run knip", name: "knip" },
   { cmd: "node --run lint", name: "lint" },
   { cmd: "node --run markdown:lint", name: "markdown:lint" },
+  { cmd: "node --run plugin:version:check", name: "plugin:version:check" },
   { cmd: "node --run spell:check -- .", name: "spell:check" },
   { cmd: "node --run syncpack:lint", name: "syncpack:lint" },
 ] as const;


### PR DESCRIPTION
## Why

The core plugin's version was bumped by hand: edit `plugin.json`, run `sync-ai-rules`, commit (see #748). The packages already version automatically through `nx release` and conventional commits. This brings the plugin into that flow.

## Loom

https://www.loom.com/share/03bb22bea1574ff3b4c0f44486f4935d?from_recorder=1&focus_title=1

## What

Makes `plugins/core` a release-managed Nx project.

- Adds a private `plugins/core/package.json` as the version source `nx release` bumps. `"private": true` keeps it off npm, and it sits outside the `packages/*` workspace so syncpack and `npm install` ignore it.
- Adds `plugins/core/project.json` so Nx tracks the project (no build/lint/test targets).
- Adds `"core-plugin"` to `release.projects` in `nx.json`.
- Reworks `scripts/embedPluginVersion.mts`: it reads the version from `package.json`, writes it into `.claude-plugin/plugin.json`, and re-embeds the `core@X.Y.Z` skill sentinels. It exports `syncPluginVersion()` and still runs as a CLI (used by `sync-ai-rules` on postinstall).
- Calls `syncPluginVersion()` from `scripts/release.ts` right after versioning, so `plugin.json` and the sentinels land in the same release commit.

`package.json` is the source of truth; `plugin.json` and the sentinels derive from it.

## Baseline tag

`core-plugin@3.10.0` already exists on `origin/main`, so no manual tag is needed after merge. A merge dry-run against current `origin/main` resolves `core-plugin` from that tag and reports no new version; future plugin commits will version from that baseline.

## Validation

- `node --run verify`
- `node --input-type=module -e 'console.log("argv1=" + String(process.argv[1])); await import("./scripts/embedPluginVersion.mts"); console.log("imported")'` confirms the module can be imported when `process.argv[1]` is undefined.
- Temp merge validation: after merging the PR head into current `origin/main`, `npx tsx scripts/release.ts --dry-run --verbose` resolves `core-plugin` from the existing `core-plugin@3.10.0` tag and reports no new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wxdjx73M3vxCoRzDe9DBM

Agent session: `codex resume 019f1f32-b41a-73c1-a7f6-5b97d2f4f13f`


