### PR TITLE
feat: sharpen simplify and humanize-prose review criteria

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -61,6 +61,7 @@
     "daterange",
     "datetime",
     "decamelize",
+    "declaratives",
     "dedupe",
     "defensiveness",
     "deliberator",

--- a/plugins/core/skills/cb-ship/references/simplify.md
+++ b/plugins/core/skills/cb-ship/references/simplify.md
@@ -18,15 +18,16 @@ Review each change for hacky patterns:
 
 1. **Redundant state** that duplicates existing state, cached values that could be derived, observers/effects that could be direct calls.
 2. **Parameter sprawl**: Adding new parameters to a function instead of generalizing or restructuring existing ones.
-3. **Copy-paste with slight variation**: near-duplicate code blocks that should be unified with a shared abstraction.
+3. **Copy-paste with slight variation**: near-duplicate code blocks that should be unified with a shared abstraction. Exempt intentional, structurally-parallel repetition that aids readability — test arrange/act/assert blocks are the common case.
 4. **Leaky abstractions**: exposing internal details that should be encapsulated, or breaking existing abstraction boundaries.
-5. **Stringly-typed code**: using raw strings where constants, enums (string unions), or branded types already exist in the codebase.
-6. **Unnecessary JSX nesting**: wrapper Boxes/elements that add no layout value. Check if inner component props (flexShrink, alignItems, etc.) already provide the needed behavior.
-7. **Nested conditionals**: ternary chains (`a ? x : b ? y : ...`), nested if/else, or nested switch 3+ levels deep. Flatten with early returns, guard clauses, a lookup table, or an if/else-if cascade.
-8. **Unnecessary comments**: Delete comments explaining WHAT the code does (well-named identifiers already do that), narrating the change, or referencing the task/caller. Keep only non-obvious WHY (hidden constraints, subtle invariants, workarounds).
-9. **Defensive code on trusted inputs**: null/empty/type guards on inputs already guaranteed upstream (a validated DTO, the type system, a controller that already checked), optional chaining where the types guarantee presence, fallbacks that mask bugs (`?? ''`, `|| []`, `?? 0` on values that should never be absent), and try/catch that only logs and rethrows or guards an impossible state. Leave guards at genuine trust boundaries (raw request bodies, webhook payloads, third-party responses) and any error handling around real I/O, network, parsing, or payments — removing those changes behavior.
-10. **Type escapes**: `as any`, `: any`, `as unknown as X`, gratuitous non-null `!`, `@ts-ignore`/`@ts-expect-error` added to dodge a type error — replace with the real type when it is determinable from the call site, the imported type, or the shape in use; if it is not, leave it and flag it rather than deleting it (breaks the build) or swapping in a TODO (more clutter).
-11. **Leftover debug statements**: stray `console.log`/print-style output used to debug; keep intentional logging that goes through the repo's logger.
+5. **Premature abstraction (YAGNI)**: an interface, wrapper, or config object introduced for a single caller — inline it until a second caller justifies it.
+6. **Stringly-typed code**: using raw strings where constants, enums (string unions), or branded types already exist in the codebase.
+7. **Unnecessary JSX nesting**: wrapper Boxes/elements that add no layout value. Check if inner component props (flexShrink, alignItems, etc.) already provide the needed behavior.
+8. **Nested conditionals**: ternary chains (`a ? x : b ? y : ...`), nested if/else, or nested switch 3+ levels deep. Flatten with early returns, guard clauses, a lookup table, or an if/else-if cascade.
+9. **Unnecessary comments**: Delete comments explaining WHAT the code does (well-named identifiers already do that), narrating the change, or referencing the task/caller. Keep only non-obvious WHY (hidden constraints, subtle invariants, workarounds).
+10. **Defensive code on trusted inputs**: null/empty/type guards on inputs already guaranteed upstream (a validated DTO, the type system, a controller that already checked), optional chaining where the types guarantee presence, fallbacks that mask bugs (`?? ''`, `|| []`, `?? 0` on values that should never be absent), and try/catch that only logs and rethrows or guards an impossible state. Leave guards at genuine trust boundaries (raw request bodies, webhook payloads, third-party responses) and any error handling around real I/O, network, parsing, or payments — removing those changes behavior.
+11. **Type escapes**: `as any`, `: any`, `as unknown as X`, gratuitous non-null `!`, `@ts-ignore`/`@ts-expect-error` added to dodge a type error — replace with the real type when it is determinable from the call site, the imported type, or the shape in use; if it is not, leave it and flag it rather than deleting it (breaks the build) or swapping in a TODO (more clutter).
+12. **Dead & leftover code**: unreachable branches and stray debug statements (`console.log`/print-style output) — delete outright rather than commenting out; keep intentional logging that goes through the repo's logger. Unused exports/symbols with no remaining references are already covered by `.rules/common/typeScript.md`'s Dead Code Cleanup rule.
 
 ### 3: Efficiency review
 

--- a/plugins/core/skills/humanize-prose/SKILL.md
+++ b/plugins/core/skills/humanize-prose/SKILL.md
@@ -1,26 +1,25 @@
 ---
 name: humanize-prose
-description: Strip AI writing tells from prose you draft or clean: PR descriptions, Slack messages, docs, emails, commit messages. Cuts hedging, throat-clearing, marketing adjectives, bullet bloat, connective filler, and em-dashes. Use whenever the user asks to "humanize" text, "remove the AI slop" from writing, "make this not sound AI-generated", "deslop this PR description", or runs /humanize-prose. Also applies implicitly: any prose you draft for the user must already satisfy these rules.
+description: Strip AI writing tells from prose you draft or clean: PR descriptions, Slack messages, docs, emails, commit messages. Use whenever the user asks to "humanize" or "deslop" text, or runs /humanize-prose. Also applies implicitly: any prose you draft for the user must already satisfy these rules.
 ---
 
-# Humanize prose
+Strip AI writing tells out of prose, whether cleaning existing text or generating it. Edit in place, change as little as possible, preserve meaning. When a change would alter meaning, leave it and flag it.
 
-Strip AI writing tells out of prose, whether cleaning existing text or generating it. Edit in place, change as little as possible, preserve meaning. When a change would alter meaning, or you cannot tell which of two conflicting statements is correct, leave it and flag it.
-
-Applies to PR descriptions, Slack messages, docs, and emails.
-
-Cut:
+Cut, across the whole text, not just the first instance of each:
 
 - Throat-clearing openers: "In this PR, I've...", "This change introduces...", "I wanted to...".
 - Hedging filler: "it's worth noting", "it's important to", "generally speaking", "as you may know".
 - Marketing adjectives and trendy intensifiers: robust, seamless, comprehensive, powerful, leverage, streamline, delve, load-bearing.
 - Rule-of-three padding and restating the obvious.
-- Connective tissue that links sentences without adding content: "That said", "With that in mind", "To that end", "As such", "Moreover", "Furthermore", "Additionally", "It follows that". Drop the phrase or replace it with a full stop.
+- Connective tissue that links sentences without adding content: "That said", "With that in mind", "To that end", "As such", "Moreover", "Furthermore", "Additionally", "It follows that", "What this means is...". Drop the phrase or replace it with a full stop.
 - Duplicated information: a point already made earlier in different words, a closing line that repeats the opening, a sentence that restates its own heading. Keep it once.
 - Contradictory information: two statements in the same text that conflict (a number, a claim, or a recommendation stated one way then another). Keep the version that is correct and flag the contradiction; do not silently pick one if you cannot tell which is right.
 - Bullet bloat where two sentences of prose are tighter; bold-everything formatting.
 - Summary-of-the-summary closers: "In conclusion...", "Overall, this...".
 - Em-dashes and double hyphens (use a comma, colon, or full stop instead).
+- False agency: passive constructions or abstract/inanimate subjects performing human actions ("the complaint becomes a fix", "mistakes were made", "the decision emerges"). Name the actor.
+- Binary-contrast crutch: manufactured "not X, it's Y" framing standing in for a direct claim.
+- Vague declaratives and hollow absolutes: unsupported generalizations ("the implications are significant") and lazy extremes ("always", "never", "every") doing the work a specific claim should.
 
 Keep it concrete: what changed, why, what to check. Match the channel (a PR body is not a Slack one-liner).
 


### PR DESCRIPTION
## Summary

Adds YAGNI (premature single-caller abstraction) and dead-code checks to the ship-time `simplify` review (`plugins/core/skills/cb-ship/references/simplify.md`), and extends `humanize-prose` to catch false agency, binary-contrast crutch framing, and hollow absolutes. Both files were then reviewed against the `writing-great-skills` and `simplify` skills themselves: one added rule turned out to duplicate the existing Dead Code Cleanup rule in `.rules/common/typeScript.md` (now points there instead of restating it), two overlapping rules were merged, and an overly narrow test-file exemption was generalized to cover any intentional structurally-parallel repetition.

## Validation

- `node --run verify`: all checks passed (architecture, lint, format, markdown lint, spell check, syncpack, duplicate-code check).

Agent session: `claude --resume 183fb9be-6023-4d64-a364-4cf2491ddb90`

<sub>🤖 <code>commit-push-pr:created v1 core@3.6.0</code></sub>