### PR TITLE
refactor: dedupe and prune cb-review skill

### DIFF
--- a/plugins/core/skills/cb-review/SKILL.md
+++ b/plugins/core/skills/cb-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cb-review
-description: Code review of the current branch or a PR — single-pass by default, parallel reviewer agents that debate at high effort, plus a spec-compliance lens when the originating ticket or PRD is available; findings posted as anchored PR comments. Use when the user asks to review a diff, branch, or PR, or runs /cb-review [pr-number-or-url] [--effort low|high].
+description: Code review of a diff, branch, or PR, with findings posted as anchored PR comments. Use when the user asks to review a diff, branch, or PR, asks to check a change against its ticket/spec/PRD, or runs /cb-review [pr-number-or-url] [--effort low|high].
 argument-hint: "[pr-number-or-url] [--effort low|high]"
 ---
 
@@ -49,7 +49,7 @@ Determine **mode**:
 - PR exists and authors differ → **reviewer mode**.
 - No PR → **author mode**.
 
-**Persistence:** low effort holds everything in-context. High effort persists for subagents: diff → `/tmp/cb-review-diff.patch`, context → `/tmp/cb-review-context.md`, changed files → `/tmp/cb-review-files.txt`, metadata (PR number/url/base/author, viewer, head SHA, owner/repo, mode, `context_ref`, dispatched agent set) → `/tmp/cb-review-meta.json`.
+**Persistence:** low effort holds everything in-context. High effort persists for subagents: diff → `/tmp/cb-review-diff.patch`, context → `/tmp/cb-review-context.md`, changed files → `/tmp/cb-review-files.txt`, metadata (PR number/url/base/author, viewer, head SHA, owner/repo, mode, `context_ref`) → `/tmp/cb-review-meta.json`.
 
 ## Freshness preflight (mandatory before reading code)
 
@@ -111,9 +111,7 @@ When `context_ref = worktree (stale, user accepted risk)`:
 
 ## Cross-repo evidence policy
 
-A finding's evidence is "cross-repo" when its load-bearing claim depends on code in any repo other than the one containing the diff. **Never silently read external repos and never claim a downstream impact you have not verified** — speculating that "the FE will break" without reading the consumer is a top source of false-positive findings. Cap any cross-repo finding at **MAJOR** until verified.
-
-Read [references/cross-repo-evidence.md](references/cross-repo-evidence.md) before raising or finalizing any cross-repo finding — it has when the policy fires, the verify-or-downgrade procedure, the access-request template, and what "verify" means for contract/schema vs API-response changes.
+A finding's evidence is "cross-repo" when its load-bearing claim depends on code in any repo other than the one containing the diff. Read [references/cross-repo-evidence.md](references/cross-repo-evidence.md) before raising or finalizing any cross-repo finding — it has when the policy fires, the verify-or-downgrade procedure, the severity cap, the access-request template, and what "verify" means for contract/schema vs API-response changes.
 
 ## Diff classification (pick which lenses apply)
 
@@ -132,7 +130,7 @@ The rubric — severity ladder, `failure_mode` contract, do-not-raise list, NIT 
 
 ### Low effort
 
-Read the full rubric, then walk the diff once, applying the active lenses yourself. You're looking for _the smallest number of high-signal findings_, not exhaustive coverage. **No subagents** — if a finding needs deeper independent investigation than you can do confidently in-line, surface it as a flagged finding rather than guess.
+Read the full rubric, then walk the diff, applying the active lenses yourself — the walk is done only when every hunk has been read under each active lens. Exhaustive reading, selective output: report _the smallest number of high-signal findings_, not everything you noticed. **No subagents** — if a finding needs deeper independent investigation than you can do confidently in-line, surface it as a flagged finding rather than guess.
 
 ### High effort
 
@@ -143,12 +141,11 @@ Follow [references/multi-agent.md](references/multi-agent.md): dispatch one revi
 Low effort: apply to your own candidates. High effort: the moderator filter in multi-agent.md extends this list — apply that version.
 
 1. **Drop findings with empty or hypothetical `failure_mode`.** "A future caller might…", "in case someone…" → drop.
-2. **Self-audit for slop.** For every finding, ask: does it match a slop pattern (asks-for-defensive-guard on an already-narrowed value — but only if an _enforced_ check narrows it, not merely a declared type or cast; hypothetical future caller; restating-obvious comment request; abstract refactor with no concrete cost-of-keeping; observability without named failure mode; test for trivially-verifiable code; defends against a state the product cannot produce)? If yes and you can't write a concrete, product-specific cost in one sentence — drop it.
-3. **Cross-repo audit.** Does the failure_mode reference a downstream actor or a contract/schema/public-artifact boundary? If you didn't actually read the external code, route through the cross-repo evidence policy (verify, ask for access, or downgrade to a labeled "speculative" MINOR).
-4. **Drop do-not-raise items** that slipped through.
-5. **Apply the NIT gate.** NITs that don't meet it → drop. Kept NITs stay internal, hidden by default.
-6. **Merge near-duplicates** under one finding (note which lens(es) surfaced it).
-7. **Apply hard caps.** 6 actionable, 8 NITs retained; rest summarized as "N additional items omitted; ask for the full list."
+2. **Drop do-not-raise matches.** For every finding, ask: does it match a do-not-raise item (rubric §Admission)? If it matches a `slop:` tag and you can't write a concrete, product-specific cost in one sentence — drop it.
+3. **Cross-repo audit.** Does the failure_mode reference a downstream actor or a contract/schema/public-artifact boundary you didn't actually read? Route through the cross-repo evidence policy.
+4. **Apply the NIT gate.** NITs that don't meet it → drop. Kept NITs stay internal, hidden by default.
+5. **Merge near-duplicates** under one finding (note which lens(es) surfaced it).
+6. **Apply hard caps.** 6 actionable, 8 NITs retained; rest summarized as "N additional items omitted; ask for the full list."
 
 Track dropped items in Withdrawn (one-liner each) so the user can see what was filtered.
 
@@ -194,6 +191,8 @@ Option-label format: `<id> - <short title> (<SEVERITY>)`. The `description` is t
 
 ## Branch on mode
 
+Gate 2 is mandatory in both modes — never auto-apply fixes and never auto-post reviews.
+
 ### Author mode
 
 **Plan.** For the selected ids only, produce an ordered implementation plan: steps, files touched per step, tests to add/update, verification commands. Do **not** edit files yet.
@@ -223,16 +222,3 @@ Skip the plan step — you are not implementing someone else's code.
 When the user approves items to post, submit a **single** review via the GitHub Reviews API (`event: COMMENT` — never `APPROVE`/`REQUEST_CHANGES`), with every selected item as an inline comment anchored to its diff line. Never use loose issue comments.
 
 Follow [references/posting-pr-review.md](references/posting-pr-review.md) exactly — it has the `gh api` call, the payload shape, the three-block review body, and the per-comment body budget and format. After posting, print the review `html_url` and a one-line summary of how many comments were posted (and fallback general-notes count if any).
-
-## Rules
-
-- The rubric file is binding for both engines: empty `failure_mode` → drop, NIT not meeting the gate → drop, do-not-raise items → drop, caps applied (6 actionable, 8 nits).
-- Issue independent `gh`/`git` commands in parallel (PR view, diff, files, viewer).
-- Freshness preflight is mandatory before reading code. Read repo context via `git show "<context_ref>:<path>"`, not the worktree filesystem, unless `context_ref = worktree (stale, user accepted risk)`.
-- Never run state-modifying git commands on the user's behalf (`checkout`, `stash`, `reset`, `clean`, `pull` with merge). Warn and ask. `git fetch` is allowed.
-- Cross-repo evidence: **never raise a "consumer will break" finding without reading the consumer.** Cap at MAJOR until verified; user `skip` → drop or keep as MINOR with a visible "speculative — assumes `<X>`" prefix.
-- Conditional lenses (Security/Database/Frontend/Spec) run only when classification matches.
-- Hide nits by default. Print only when the user selects the NIT toggle in gate 1.
-- Reviews are always `event: COMMENT`. Never approve or request changes on the user's behalf.
-- Both user gates are mandatory. Do not auto-apply recommendations and do not auto-post reviews.
-- If the diff is empty, stop with a one-line message — do not invent findings.

--- a/plugins/core/skills/cb-review/references/multi-agent.md
+++ b/plugins/core/skills/cb-review/references/multi-agent.md
@@ -53,15 +53,7 @@ Dispatch the same agent set, in parallel. Each agent receives **all Round 1 outp
 
 Output per item: `id`, `original_author` (agent **name**, not letter), `verdict` (keep | withdraw | agree | disagree | refine), `final_severity`, `final_title`, `final_failure_mode`, `reasoning`, `suggested_fix`, and rebuttals `[{from, stance, reasoning}]` (`from` is also a name).
 
-**AntiSlop plays an expanded Round 2 role**: beyond defending or withdrawing its own findings, it audits every other agent's finding for the slop patterns it scans code for, and marks matches `disagree` with a one-line `slop:` label in `reasoning`:
-
-- "Add a null check / try-catch / validation" on a value already typed, validated upstream, or guaranteed by a preceding call → `slop: asks for defensive guard on already-narrowed value`.
-- "What if a future caller / someone later…" with no current realistic input → `slop: hypothetical future caller — no current path`.
-- Comment/JSDoc requests where name + signature already convey intent → `slop: restating-the-obvious comment request`.
-- Refactor suggestions whose failure_mode is shape-of-the-code → `slop: refactor with no concrete cost-of-keeping`.
-- "Add a log/metric" without the specific failure it would debug → `slop: observability without named failure mode`.
-- Test demands on type-evident or already-exercised code → `slop: test for trivially-verifiable code`.
-- Worries about states the product cannot produce → `slop: defends against a state the product cannot produce`.
+**AntiSlop plays an expanded Round 2 role**: beyond defending or withdrawing its own findings, it audits every other agent's finding against the tagged do-not-raise items (rubric §Admission) and marks matches `disagree` with the item's `slop:` tag in `reasoning`.
 
 When an agent sees a slop tag on its own finding, it either rebuts with a concrete, product-specific `final_failure_mode` or withdraws — not both stand on the original framing. Even when AntiSlop's own Round 1 findings are sparse because the diff is clean, it must not under-spend on this audit — stopping slop _suggestions_ from polluting the review is often the bigger lever.
 

--- a/plugins/core/skills/cb-review/references/posting-pr-review.md
+++ b/plugins/core/skills/cb-review/references/posting-pr-review.md
@@ -2,12 +2,6 @@
 
 Read this once the user approves items to post. Referenced from `SKILL.md`.
 
-## Contents
-
-- API call and payload shape
-- Review body (top-level): attribution line, summary, apply-all prompt
-- Each comment body: budget, template, formatting rules
-
 ## API call and payload
 
 Post via the GitHub Reviews API as a **single** review with all selected actionable items as inline review comments anchored to specific diff lines. **Never** loose issue comments.

--- a/plugins/core/skills/cb-review/references/review-rubric.md
+++ b/plugins/core/skills/cb-review/references/review-rubric.md
@@ -19,13 +19,16 @@ Litmus test before keeping any candidate: _"What is the concrete, current, produ
 
 ### Do-not-raise list
 
-- Speculative defensiveness at trusted internal boundaries (only where the boundary's guarantee is actually _enforced_ — a declared or cast type is not enforcement; see AntiSlop).
-- Restating the obvious ("consider a comment explaining what this does").
-- Hypothetical future-caller scenarios with no current caller.
+Drop candidates that match. The tagged items double as the slop taxonomy for the Filter (SKILL.md) and for AntiSlop's Round 2 audit of other agents' findings (multi-agent.md), which cites the tags verbatim.
+
+- `slop: asks for defensive guard on already-narrowed value` — speculative defensiveness at a boundary whose guarantee is actually _enforced_; a declared or cast type is not enforcement (see AntiSlop).
+- `slop: hypothetical future caller — no current path` — future-caller scenarios with no current caller.
+- `slop: restating-the-obvious comment request` — comment/JSDoc requests where name + signature already convey intent.
+- `slop: refactor with no concrete cost-of-keeping` — abstract SOLID-style "consider extracting…" with no concrete failure mode.
+- `slop: observability without named failure mode` — "add a log/metric" without the specific failure it would debug.
+- `slop: test for trivially-verifiable code` — test demands on type-evident or already-exercised code.
+- `slop: defends against a state the product cannot produce`.
 - Style/formatting a linter or formatter covers.
-- Test-coverage demands on trivially-verifiable code.
-- "Add observability" without naming a concrete failure mode it would help debug.
-- Abstract SOLID-style "consider extracting…" without a concrete failure mode.
 - Aesthetic naming preferences — only raise names that mislead about behavior.
 
 ### Caps


### PR DESCRIPTION
## Summary

Applies six findings from a skill-writing review of `plugins/core/skills/cb-review/`, cutting duplication and sharpening the skill's weakest completion criterion. No behavior is added; each meaning now has a single source of truth.

- **Delete the `## Rules` section** — ~90% of its lines restated rules already stated in place (freshness preflight, git safety, COMMENT-only reviews, nit hiding, empty-diff stop, caps). The one near-unique clause ("never auto-apply / never auto-post") moved to the `## Branch on mode` intro.
- **Single-source the slop taxonomy** — the same seven patterns lived in the rubric's do-not-raise list, the rubric's AntiSlop lens, SKILL.md Filter item 2, and multi-agent.md's Round 2 tag list. The do-not-raise list now carries the `slop:` tags as the one authoritative taxonomy; the Filter and Round 2 audit reference it instead of restating it (Filter items 2 and 4 merged as a result).
- **Dedupe the cross-repo policy** — the severity cap and never-claim-unverified rule were stated inline, in Filter item 3, in the Rules section, and in `cross-repo-evidence.md`. Inline now keeps only the definition plus the pointer; the procedure lives solely in the reference.
- **Rewrite the description to triggers only** — dropped engine mechanics and identity already in the body; added the previously buried "check a change against its ticket/spec/PRD" trigger. (`--effort low|high` naming kept as-is after discussion.)
- **Sharpen the low-effort completion criterion** — "walk the diff once" left the coverage bar soft, inviting skimming on large diffs; now "done only when every hunk has been read under each active lens," with output selectivity kept.
- **Minor prunes** — posting-pr-review.md's Contents TOC; "dispatched agent set" removed from the Scope-time metadata list (it isn't known until dispatch; multi-agent.md already records it).

Net: −25 lines, four fewer double-maintenance sites.

## Validation

- `node --run verify` — all 10 checks pass (architecture, cpd, embed, format, knip, lint, markdown, plugin version, spell, syncpack).
- `node --run sync-ai-rules` — rule sync clean (its final `npx oxfmt` step fails in this environment because the pmg `npx` shim refuses to exec from `sh`; ran the local `node_modules/.bin/oxfmt` directly instead, and `format:check` passes).
- Grepped the skill folder for stale cross-references to the removed content — none.

## Notes

One deliberate deviation from the review's letter: the slop tag list merged into rubric **§Admission** (do-not-raise) rather than §AntiSlop, because every high-effort reviewer agent reads §Admission but only the AntiSlop agent reads §AntiSlop — placing it there would have hidden the taxonomy from the agents whose findings it filters.

Agent session: `claude --resume 67d13a8b-34ea-4767-a427-a28ba07a3095`

<sub>🤖 <code>cb-ship:created v1 core@3.12.0</code></sub>