### PR TITLE
feat: run cb-review in subagents and wire a report mode into cb-ship

### DIFF
--- a/plugins/core/skills/cb-review/SKILL.md
+++ b/plugins/core/skills/cb-review/SKILL.md
@@ -1,21 +1,22 @@
 ---
 name: cb-review
 description: Code review of a diff, branch, or PR, with findings posted as anchored PR comments. Use when the user asks to review a diff, branch, or PR, asks to check a change against its ticket/spec/PRD, or runs /cb-review [pr-number-or-url] [--effort low|high].
-argument-hint: "[pr-number-or-url] [--effort low|high]"
+argument-hint: "[pr-number-or-url] [--effort low|high] [--report]"
 ---
 
 # CB Review
 
-Review a diff against one rubric, filter to the few findings worth raising, gate with the user, optionally post as anchored PR comments. Two engines share everything except how the rubric is applied:
+Review a diff against one rubric, filter to the few findings worth raising, gate with the user, optionally post as anchored PR comments. `--report` replaces the gates with a findings report for an agent caller. Two engines share everything except how the rubric is applied:
 
-- **low** — single pass by you (the main agent), no subagents. Default.
-- **high** — parallel reviewer agents, one debate round, moderator filter. For large or high-stakes diffs.
+- **low** — one reviewer subagent, single pass. Default.
+- **high** — parallel reviewer subagents, one debate round, moderator filter. For large or high-stakes diffs.
 
 ## Invocation
 
 - `/cb-review` — review the current branch (resolves the open PR for the branch if any, otherwise diffs against the default branch).
 - `/cb-review <pr-number-or-url>` — review that PR without checking it out; forces reviewer mode. Accepts a bare number (current repo) or full GitHub URL (identifies owner/repo).
 - `--effort low|high` — pick the engine explicitly. Phrases also select: "quick"/"fast" → low; "deep"/"thorough"/"multi-perspective" → high.
+- `--report` — non-interactive: stop after Synthesize and return the findings to the caller. No user gates, no posting, no implementing. For agent callers (e.g. cb-ship's review step).
 
 **Effort auto-select** (no flag, no phrase): `high` when the diff exceeds 20 changed files or 600 changed lines, else `low`. Before reviewing, print one line — `Effort: <low|high> (<N> files, <M> lines; override with --effort <other>)` — so the user can interrupt.
 
@@ -49,7 +50,7 @@ Determine **mode**:
 - PR exists and authors differ → **reviewer mode**.
 - No PR → **author mode**.
 
-**Persistence:** low effort holds everything in-context. High effort persists for subagents: diff → `/tmp/cb-review-diff.patch`, context → `/tmp/cb-review-context.md`, changed files → `/tmp/cb-review-files.txt`, metadata (PR number/url/base/author, viewer, head SHA, owner/repo, mode, `context_ref`) → `/tmp/cb-review-meta.json`.
+**Persistence:** both efforts persist for subagents: diff → `/tmp/cb-review-diff.patch`, context → `/tmp/cb-review-context.md`, changed files → `/tmp/cb-review-files.txt`, metadata (PR number/url/base/author, viewer, head SHA, owner/repo, mode, `context_ref`) → `/tmp/cb-review-meta.json`.
 
 ## Freshness preflight (mandatory before reading code)
 
@@ -130,7 +131,7 @@ The rubric — severity ladder, `failure_mode` contract, do-not-raise list, NIT 
 
 ### Low effort
 
-Read the full rubric, then walk the diff, applying the active lenses yourself — the walk is done only when every hunk has been read under each active lens. Exhaustive reading, selective output: report _the smallest number of high-signal findings_, not everything you noticed. **No subagents** — if a finding needs deeper independent investigation than you can do confidently in-line, surface it as a flagged finding rather than guess.
+Dispatch **one** reviewer subagent — fresh eyes on the diff, and the bulk content stays out of your context. Its prompt carries the persisted file paths, the absolute path to references/review-rubric.md with the instruction to read it in full, the active lens list, and the two contracts from multi-agent.md §Dispatch mechanics (context-read, cross-repo evidence) verbatim. The subagent walks the diff, applying every active lens — the walk is done only when every hunk has been read under each active lens. Exhaustive reading, selective output: it returns _the smallest number of high-signal findings_ in the Round 1 output shape (multi-agent.md §Round 1), flagging anything that needs deeper investigation than it can do confidently rather than guessing. If the host cannot run subagents, do that same single pass yourself inline.
 
 ### High effort
 
@@ -138,7 +139,7 @@ Follow [references/multi-agent.md](references/multi-agent.md): dispatch one revi
 
 ## Filter (before synthesis)
 
-Low effort: apply to your own candidates. High effort: the moderator filter in multi-agent.md extends this list — apply that version.
+Low effort: apply to the reviewer subagent's candidates. High effort: the moderator filter in multi-agent.md extends this list — apply that version.
 
 1. **Drop findings with empty or hypothetical `failure_mode`.** "A future caller might…", "in case someone…" → drop.
 2. **Drop do-not-raise matches.** For every finding, ask: does it match a do-not-raise item (rubric §Admission)? If it matches a `slop:` tag and you can't write a concrete, product-specific cost in one sentence — drop it.
@@ -178,6 +179,10 @@ Do **not** print by default. Print only: _"N nit(s) available (M from convention
 ### Withdrawn
 
 Terse one-liners of items dropped by the filter. Transparency only.
+
+## Report mode (--report)
+
+Stop after Synthesize: print the Summary, the Actionable list, and the retained NITs as one-liners (the caller is an agent — the hide-nits default is for humans), then end. No user gates, no posting, no implementing; the caller triages every finding itself and owns any fixes.
 
 ## User gate 1 — select items
 

--- a/plugins/core/skills/cb-review/SKILL.md
+++ b/plugins/core/skills/cb-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cb-review
-description: Code review of a diff, branch, or PR, with findings posted as anchored PR comments. Use when the user asks to review a diff, branch, or PR, asks to check a change against its ticket/spec/PRD, or runs /cb-review [pr-number-or-url] [--effort low|high].
+description: Code review of a diff, branch, or PR, with findings posted as anchored PR comments. Use when the user asks to review a diff, branch, or PR, asks to check a change against its ticket/spec/PRD, or runs /cb-review [pr-number-or-url] [--effort low|high] [--report].
 argument-hint: "[pr-number-or-url] [--effort low|high] [--report]"
 ---
 
@@ -50,7 +50,7 @@ Determine **mode**:
 - PR exists and authors differ → **reviewer mode**.
 - No PR → **author mode**.
 
-**Persistence:** both efforts persist for subagents: diff → `/tmp/cb-review-diff.patch`, context → `/tmp/cb-review-context.md`, changed files → `/tmp/cb-review-files.txt`, metadata (PR number/url/base/author, viewer, head SHA, owner/repo, mode, `context_ref`) → `/tmp/cb-review-meta.json`.
+**Persistence:** both efforts persist for subagents into a fresh per-run directory — `RUN_DIR=$(mktemp -d "${TMPDIR:-/tmp}/cb-review.XXXXXX")` — so concurrent sessions never clobber each other: diff → `$RUN_DIR/diff.patch`, context → `$RUN_DIR/context.md`, changed files → `$RUN_DIR/files.txt`, metadata (PR number/url/base/author, viewer, head SHA, owner/repo, mode, `context_ref`) → `$RUN_DIR/meta.json`.
 
 ## Freshness preflight (mandatory before reading code)
 
@@ -131,7 +131,7 @@ The rubric — severity ladder, `failure_mode` contract, do-not-raise list, NIT 
 
 ### Low effort
 
-Dispatch **one** reviewer subagent — fresh eyes on the diff, and the bulk content stays out of your context. Its prompt carries the persisted file paths, the absolute path to references/review-rubric.md with the instruction to read it in full, the active lens list, and the two contracts from multi-agent.md §Dispatch mechanics (context-read, cross-repo evidence) verbatim. The subagent walks the diff, applying every active lens — the walk is done only when every hunk has been read under each active lens. Exhaustive reading, selective output: it returns _the smallest number of high-signal findings_ in the Round 1 output shape (multi-agent.md §Round 1), flagging anything that needs deeper investigation than it can do confidently rather than guessing. If the host cannot run subagents, do that same single pass yourself inline.
+Dispatch **one** reviewer subagent — fresh eyes on the diff, and the bulk content stays out of your context. Its prompt carries the persisted file paths, the absolute path to references/review-rubric.md with the instruction to read it in full, the active lens list, and the two contracts from multi-agent.md §Dispatch mechanics (context-read, cross-repo evidence) with `<context_ref>` substituted and the moderator/Round-2 sentence replaced by: emit `evidence_required` findings capped at MAJOR; the dispatching agent resolves them in the Filter's cross-repo audit. Finding ids use an `R` prefix in place of roster letters. The subagent walks the diff, applying every active lens — the walk is done only when every hunk has been read under each active lens. Exhaustive reading, selective output: it returns _the smallest number of high-signal findings_ in the Round 1 output shape (multi-agent.md §Round 1), flagging anything that needs deeper investigation than it can do confidently rather than guessing. If the host cannot run subagents, do that same single pass yourself inline.
 
 ### High effort
 
@@ -183,6 +183,8 @@ Terse one-liners of items dropped by the filter. Transparency only.
 ## Report mode (--report)
 
 Stop after Synthesize: print the Summary, the Actionable list, and the retained NITs as one-liners (the caller is an agent — the hide-nits default is for humans), then end. No user gates, no posting, no implementing; the caller triages every finding itself and owns any fixes.
+
+Earlier interactive checkpoints resolve to their safe defaults instead of prompting: the freshness preflight's stop-and-ask resolves as `use-origin` (fetch failure → return an error to the caller instead of findings), and cross-repo access requests resolve as `skip all` (downgrade per the cross-repo policy).
 
 ## User gate 1 — select items
 

--- a/plugins/core/skills/cb-review/references/multi-agent.md
+++ b/plugins/core/skills/cb-review/references/multi-agent.md
@@ -1,6 +1,6 @@
 # High-effort engine — parallel reviewers, one debate round, moderator filter
 
-Read this only when effort is `high`. Referenced from `SKILL.md`. The rubric in `review-rubric.md` is binding for every agent.
+Read this when effort is `high`; low effort borrows only the two dispatch contracts (§Dispatch mechanics) and the Round 1 output shape. Referenced from `SKILL.md`. The rubric in `review-rubric.md` is binding for every agent.
 
 ## Roster
 
@@ -21,7 +21,7 @@ Record the dispatched set in `/tmp/cb-review-meta.json` so Round 2 knows the ful
 
 ## Dispatch mechanics
 
-Use the host's parallel subagent mechanism (in Claude Code: the `Agent` tool with `subagent_type: general-purpose`, all calls in a single message so they run truly in parallel). Use fresh agents for every round. If one agent fails or returns malformed output, re-dispatch **that agent only** — do not restart the round. If the host cannot run subagents, high effort's independence guarantee is unattainable — fall back to the low-effort engine and tell the user why.
+Use the host's parallel subagent mechanism (in Claude Code: the `Agent` tool with `subagent_type: general-purpose`, all calls in a single message so they run truly in parallel). Use fresh agents for every round. If one agent fails or returns malformed output, re-dispatch **that agent only** — do not restart the round. If the host cannot run subagents, high effort's independence guarantee is unattainable — fall back to the low-effort engine (which then runs its single pass inline) and tell the user why.
 
 Keep large content on disk (`/tmp/cb-review-*`) so Round 2 prompts stay compact.
 

--- a/plugins/core/skills/cb-review/references/multi-agent.md
+++ b/plugins/core/skills/cb-review/references/multi-agent.md
@@ -27,7 +27,7 @@ Keep large content on disk (`$RUN_DIR/*`, from SKILL.md §Scope Persistence) so 
 
 Every agent prompt includes:
 
-- The file paths from Scope (`$RUN_DIR/diff.patch`, `context.md`, `files.txt`).
+- The file paths from Scope (`$RUN_DIR/diff.patch`, `$RUN_DIR/context.md`, `$RUN_DIR/files.txt`).
 - An instruction to read `review-rubric.md` **§Admission** plus the agent's own lens section (give the absolute path to this skill's `references/review-rubric.md`), and — for Spec — the spec source content or how to fetch it.
 - The two contracts below, verbatim (substitute `<context_ref>` from the freshness preflight):
 

--- a/plugins/core/skills/cb-review/references/multi-agent.md
+++ b/plugins/core/skills/cb-review/references/multi-agent.md
@@ -17,17 +17,17 @@ One reviewer agent per active lens. **Refer to agents by name in everything the 
 | H      | AntiSlop    | §AntiSlop      | Always                 |
 | S      | Spec        | §Spec          | Spec source found      |
 
-Record the dispatched set in `/tmp/cb-review-meta.json` so Round 2 knows the full agent list.
+Record the dispatched set in `$RUN_DIR/meta.json` so Round 2 knows the full agent list.
 
 ## Dispatch mechanics
 
 Use the host's parallel subagent mechanism (in Claude Code: the `Agent` tool with `subagent_type: general-purpose`, all calls in a single message so they run truly in parallel). Use fresh agents for every round. If one agent fails or returns malformed output, re-dispatch **that agent only** — do not restart the round. If the host cannot run subagents, high effort's independence guarantee is unattainable — fall back to the low-effort engine (which then runs its single pass inline) and tell the user why.
 
-Keep large content on disk (`/tmp/cb-review-*`) so Round 2 prompts stay compact.
+Keep large content on disk (`$RUN_DIR/*`, from SKILL.md §Scope Persistence) so Round 2 prompts stay compact.
 
 Every agent prompt includes:
 
-- The file paths from Scope (`/tmp/cb-review-diff.patch`, `-context.md`, `-files.txt`).
+- The file paths from Scope (`$RUN_DIR/diff.patch`, `context.md`, `files.txt`).
 - An instruction to read `review-rubric.md` **§Admission** plus the agent's own lens section (give the absolute path to this skill's `references/review-rubric.md`), and — for Spec — the spec source content or how to fetch it.
 - The two contracts below, verbatim (substitute `<context_ref>` from the freshness preflight):
 

--- a/plugins/core/skills/cb-review/references/review-rubric.md
+++ b/plugins/core/skills/cb-review/references/review-rubric.md
@@ -1,6 +1,6 @@
 # Review rubric (binding for both engines)
 
-Low effort: the main agent reads this whole file and walks every active lens. High effort: each reviewer agent reads **Admission** plus its own lens section. Referenced from `SKILL.md`.
+Low effort: the single reviewer subagent reads this whole file and walks every active lens. High effort: each reviewer agent reads **Admission** plus its own lens section. Referenced from `SKILL.md`.
 
 ## Admission
 
@@ -57,6 +57,8 @@ For each change name a realistic input or condition that would expose a bug. If 
 - **Asymmetric handling across sibling call sites is a likely bug, not a style nit.** When the diff guards, validates, converts, or error-wraps a value in one place but consumes the same value or shape bare elsewhere, exactly one side is usually right. Compare the call sites against each other instead of reviewing each in isolation, and resolve the inconsistency: guard missing where it's absent → bug; guard unnecessary everywhere → slop to remove.
 - Edge cases, error paths, observability of real failure modes.
 - Tests cover real risk, not lines.
+- A diff that changes runtime behavior with zero test delta is raisable when the repo's documented rules mandate tests (cite the rule) — "the new behavior ships unverified" is a concrete failure_mode, not a hypothetical.
+- Hard-coded environment-specific identifiers (pool/account IDs, environment URLs) in code, scripts, or docs meant for reuse.
 - Concurrency, performance at real scale, data integrity.
 - Backward compatibility, on-call implications, degraded-mode behavior.
 - Async/await ordering matches actual data dependencies.
@@ -66,6 +68,7 @@ For each change name a realistic input or condition that would expose a bug. If 
 - Schema/query changed → indexes for new patterns, N+1, cascade semantics, type fit (deep dive under Database).
 - Telemetry covers business/product value, not only engineering surface metrics.
 - Contract/backward-compat for any consumer-visible response shape change. **If you suspect a consumer break, the finding is cross-repo — follow the cross-repo evidence policy before raising it.**
+- Before raising a version/back-compat break on a published package, read its `package.json` at `${context_ref}` — 0.x caret semantics or a days-old package can refute the failure_mode.
 
 ## Minimalism (always)
 
@@ -74,6 +77,8 @@ The smallest diff that ships the intent is the best diff.
 - Unneeded abstractions, speculative generality, dead branches.
 - Redundant validation, defensive code at trusted internal boundaries.
 - Comments that restate code; new files/utilities that duplicate existing ones.
+- Near-duplicate tests or assertions within the diff; conditions or variables another hunk of the same diff makes unnecessary.
+- New docs or guidance lines that restate an adjacent existing line.
 - Tests that exercise the framework, not behavior.
 - Flags/config knobs without a concrete caller.
 - Duplicated error handlers in the same scope.

--- a/plugins/core/skills/cb-ship/SKILL.md
+++ b/plugins/core/skills/cb-ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cb-ship
-description: Ship changes. Simplify the diff, commit, push, and open or update a PR. Use when the user says 'ship it', 'commit and push', or wants a PR created or updated.
+description: Ship changes. Simplify the diff, commit, review, push, and open or update a PR. Use when the user says 'ship it', 'commit and push', or wants a PR created or updated.
 argument-hint: "[--draft]"
 ---
 
@@ -17,16 +17,18 @@ Resolve bundled "./references" paths relative to SKILL.md.
 1. Create a new branch if on the default branch (e.g., `feat/add-user-validation`, `fix/null-check-in-parser`).
 2. Use ./references/simplify.md on the full PR diff: `git diff $(git merge-base HEAD origin/HEAD)..HEAD` and any uncommitted changes.
 3. Inspect `git status --short`, identify intended files, ask if ambiguous, then git add them. If uncommitted changes, create a conventional commit with `git commit --no-gpg-sign`.
-4. Push changes to origin.
-5. Create or update the PR using ./references/pr-template.md:
+4. Invoke the `cb-review` skill with `--effort low --report` and triage each returned finding yourself: if it's real and in scope, apply it, rerun the repo's relevant checks, and commit; otherwise dismiss it with a one-line reason for the output. Skip this step when the session already ran cb-review over these same changes.
+5. Push changes to origin.
+6. Create or update the PR using ./references/pr-template.md:
    a. If the host exposes a session ID (e.g., CODEX_THREAD_ID, CLAUDE_CODE_SESSION_ID), include the resume command in the PR body in backticks: ``Agent session: `codex resume <id>` `` or ``Agent session: `claude --resume <id>` ``. Preserve existing `Agent session:` lines, append only.
    b. If a PR exists, update the title and body if the new changes aren't reflected.
    c. Otherwise, create one with `gh pr create`; make it a draft if the user passed `--draft`.
-6. Output:
+7. Output:
 
    ```plaintext
    - Directory: [Absolute path]
    - Branch: [Branch name]
-   - Session: [Resume command from 5a] (omit if none)
+   - Review: [N findings — M applied, K dismissed with a one-line reason each] (omit if step 4 skipped or found nothing)
+   - Session: [Resume command from 6a] (omit if none)
    - PR: [Complete url] (e.g., `https://github.com/clipboardhealth/core-utils/pull/123`)
    ```

--- a/plugins/core/skills/cb-work/SKILL.md
+++ b/plugins/core/skills/cb-work/SKILL.md
@@ -22,6 +22,7 @@ Unless instructed otherwise:
 The plan or request is the source of truth for scope:
 
 - Make exactly the changes requested, no extra refactors or cleanup.
+- Target ≤ ~500 changed lines per PR: if the work will clearly exceed that, stop and propose a split into separately shippable slices before implementing.
 - On any drift from the plan (e.g. referenced files or utilities missing, an assumption invalid, a constraint missed) stop and report. Do not silently rewrite the approach.
 - Do not modify the plan file itself unless asked.
 


### PR DESCRIPTION
## Summary

Adopts the review-in-the-ship-loop workflow validated by a 20-PR blind backtest of cb-review's low-effort engine. The backtest showed the review pass finds real bugs human review misses (three confirmed, including one still live on main) at a false-positive rate of about one in twelve findings, but four rubric gaps caused it to miss things our reviewers do ask for.

- cb-review now runs its review pass in subagents at both effort levels: one reviewer subagent at low effort (fresh eyes, and the diff stays out of the caller's context), the existing multi-agent flow at high. A new `--report` mode returns findings to a calling agent without user gates or PR posting, resolving earlier interactive checkpoints to safe defaults so headless callers never hang.
- cb-ship invokes `cb-review --effort low --report` after committing and triages each finding itself: apply if real and in scope, otherwise dismiss with a one-line reason surfaced in its output.
- cb-work targets ~500 changed lines or fewer per PR and proposes a split before implementing larger work.
- Four review-rubric amendments close the backtest's genuine-miss buckets: in-diff duplication cleanups (near-duplicate tests, conditions another hunk obsoletes, guidance restating an adjacent line), behavior changes shipped with zero test delta when repo rules mandate tests, hard-coded environment-specific identifiers, and a package.json version check before back-compat findings (the backtest's one hard false positive).

## Validation

- `node --run verify` passes.
- Dogfooded the new workflow on this PR: the cb-ship review step dispatched a reviewer subagent against the amended rubric, which returned four findings — all real, all applied in the second commit (report mode could still stop on freshness/cross-repo prompts; the borrowed dispatch contract referenced a moderator that doesn't exist at low effort; fixed /tmp paths would let concurrent sessions clobber each other; description frontmatter missed `--report`).
- Backtest method and per-case grading: 20 merged PRs (11 with substantive human feedback, 9 clean), review-time diffs reconstructed pre-fix, four blind judges with no access to outcomes, graded against post-merge history.

## Notes

- cb-ship pins `--effort low` rather than letting auto-select escalate: a ship-time gate should be fast and cheap; anyone wanting the multi-agent review can run `/cb-review --effort high` directly.
- The review step runs after the commit because cb-review never reviews uncommitted working-tree changes.
- The backtest also showed the review pass is a complement to human review, not a substitute — it matched 0 of 12 human review asks while finding different real bugs. Promotion beyond this default still warrants watching live noise rates on the next batch of PRs.

Agent session: `claude --resume fcf2a976-cf25-4365-82e3-bd26cfd5c98a`

<sub>🤖 <code>cb-ship:created v1 core@3.14.0</code></sub>
