### PR TITLE
fix: commit without gpg signing in cb-babysit

### DIFF
--- a/plugins/core/skills/cb-babysit/SKILL.md
+++ b/plugins/core/skills/cb-babysit/SKILL.md
@@ -67,10 +67,10 @@ If `mergeable == "CONFLICTING"` (or `mergeStateStatus == "DIRTY"`), merge the ba
 ```bash
 BASE=$(gh pr view --json baseRefName --jq .baseRefName)
 git fetch origin "$BASE"
-git merge --no-edit "origin/$BASE"
+git merge --no-edit --no-gpg-sign "origin/$BASE"
 ```
 
-Resolve directly only for lockfile/generated regenerations, additive non-overlapping edits, or trivial textual conflicts in PR-touched files. `git merge --abort` for anything semantic, ambiguous, or outside the PR's intentional surface, and skip to step 10 to exit **stuck** with a diagnosis. After a clean resolution, commit the merge and `git push origin HEAD`.
+Resolve directly only for lockfile/generated regenerations, additive non-overlapping edits, or trivial textual conflicts in PR-touched files. `git merge --abort` for anything semantic, ambiguous, or outside the PR's intentional surface, and skip to step 10 to exit **stuck** with a diagnosis. After a clean resolution, commit the merge with `git commit --no-gpg-sign` and `git push origin HEAD`.
 
 ### 3. Wait for CI
 

--- a/plugins/core/skills/cb-babysit/scripts/commitAndPush.sh
+++ b/plugins/core/skills/cb-babysit/scripts/commitAndPush.sh
@@ -9,7 +9,9 @@
 #
 # Does NOT use `git add -A` — the caller MUST name every file to stage, so the
 # skill never sweeps up unrelated uncommitted work. Does NOT skip hooks
-# (no --no-verify); a hook failure surfaces as a non-zero exit.
+# (no --no-verify); a hook failure surfaces as a non-zero exit. Commits with
+# --no-gpg-sign (cb-ship's convention) — agent runs can't service a signing
+# prompt, and a missing signer otherwise fails the commit after hooks pass.
 #
 # Exit 0 on success. Exit 1 on runtime errors. Exit 2 on usage errors.
 #
@@ -51,7 +53,7 @@ if git diff --cached --quiet; then
   exit 1
 fi
 
-git commit -m "$MSG"
+git commit --no-gpg-sign -m "$MSG"
 git push
 
 SHA="$(git rev-parse HEAD)"


### PR DESCRIPTION
## Summary

cb-babysit's commit paths now pass `--no-gpg-sign`, matching cb-ship's existing convention. Agent environments can't service an interactive signing prompt, so a configured signer (1Password in the observed failure) errors out after lint-staged hooks pass, aborting the commit: `error: 1Password: failed to fill whole buffer / fatal: failed to write commit object`. Both commit sites are covered: `commitAndPush.sh` and the merge-conflict resolution step in the skill doc (a clean `git merge` auto-commits, so it needs the flag too).

## Validation

- `node --run verify` passes.
- The failure mode was hit live while babysitting the previous PR: commitAndPush.sh failed at the signing step and the commit had to be redone manually with `--no-gpg-sign`.
- The ship-loop review pass caught the merge-conflict commit site after the initial script-only fix.

## Notes

Hooks are still never skipped — this only disables commit signing, which agent-created commits don't use anywhere else in these skills either.

Agent session: `claude --resume fcf2a976-cf25-4365-82e3-bd26cfd5c98a`

<sub>🤖 <code>cb-ship:created v1 core@3.14.0</code></sub>
