### PR TITLE
docs: add backtest-derived guidance to the cb-review rubric

### DIFF
--- a/plugins/core/skills/cb-review/references/review-rubric.md
+++ b/plugins/core/skills/cb-review/references/review-rubric.md
@@ -19,7 +19,7 @@ Litmus test before keeping any candidate: _"What is the concrete, current, produ
 
 ### Evidence discipline
 
-Prose is a claim, not evidence. PR descriptions, code comments, docstrings, and commit messages assert intent — validate the assertion against the code in the diff (or via `${context_ref}` reads) before relying on it to admit **or drop** a finding. A claim the code contradicts is itself a finding (AntiSlop: tone/description mismatch); a claim you cannot check stays a claim — state that in the finding rather than treating it as fact.
+Prose is a claim, not evidence. PR descriptions, code comments, JSDoc, and commit messages assert intent — validate the assertion against the code in the diff (or via `${context_ref}` reads) before relying on it to admit **or drop** a finding. A claim the code contradicts is itself a finding (AntiSlop: tone/description mismatch); a claim you cannot check stays a claim — state that in the finding rather than treating it as fact.
 
 ### Do-not-raise list
 

--- a/plugins/core/skills/cb-review/references/review-rubric.md
+++ b/plugins/core/skills/cb-review/references/review-rubric.md
@@ -17,6 +17,10 @@ Every finding **must** include a `failure_mode`: one sentence on the concrete us
 
 Litmus test before keeping any candidate: _"What is the concrete, current, product-visible cost of leaving this code in?"_ If you can't answer in one sentence, drop it.
 
+### Evidence discipline
+
+Prose is a claim, not evidence. PR descriptions, code comments, docstrings, and commit messages assert intent — validate the assertion against the code in the diff (or via `${context_ref}` reads) before relying on it to admit **or drop** a finding. A claim the code contradicts is itself a finding (AntiSlop: tone/description mismatch); a claim you cannot check stays a claim — state that in the finding rather than treating it as fact.
+
 ### Do-not-raise list
 
 Drop candidates that match. The tagged items double as the slop taxonomy for the Filter (SKILL.md) and for AntiSlop's Round 2 audit of other agents' findings (multi-agent.md), which cites the tags verbatim.
@@ -56,6 +60,8 @@ For each change name a realistic input or condition that would expose a bug. If 
 - **Declared ≠ enforced — check what actually guarantees a precondition.** When new code performs an operation that faults on a missing or malformed input (destructuring, property/array access, non-null assertion, iteration, parsing, arithmetic), do not accept a declared type, function signature, cast, or `as` as proof the input is safe — those _label_ a value, they don't _check_ it. Ask what enforces the precondition on this path: a runtime validator, a preceding explicit check, or a constructor/factory invariant. If nothing does, trace the value to its origin — it can fault on real data even though it compiles. Look at the operation that would actually throw, not only the named field beside it.
 - **Asymmetric handling across sibling call sites is a likely bug, not a style nit.** When the diff guards, validates, converts, or error-wraps a value in one place but consumes the same value or shape bare elsewhere, exactly one side is usually right. Compare the call sites against each other instead of reviewing each in isolation, and resolve the inconsistency: guard missing where it's absent → bug; guard unnecessary everywhere → slop to remove.
 - Edge cases, error paths, observability of real failure modes.
+- **Order of operations: cheap gates before expensive work.** When a short-circuit exists on a path (feature flag, config kill-switch, precondition, early return), check what runs before it: work that executes ahead of a gate that could have skipped it — DB reads, network calls, heavy computation — is a raisable finding when the gate's inputs are available before that work (a gate keyed on data the work loads cannot move); name the wasted work in the `failure_mode`. Confirm the gate's name reflects its actual scope: a global kill-switch named like a per-entity property misleads about blast radius.
+- **A kept failure path must be debuggable.** Where an error is caught and execution correctly continues — the surrounding flow requires it, e.g. per-item batch processing where one failure must not abort the batch — the log or telemetry must carry the identifiers needed to act on a recurrence (entity/job IDs, not just the error object); a bare error log there is raisable, and its failure_mode is already named: a recurring failure is undiagnosable from logs. Where nothing requires continuing, the catch itself is the finding (AntiSlop: logs-and-swallows), not the log. Everywhere else `slop: observability without named failure mode` still applies.
 - Tests cover real risk, not lines.
 - A diff that changes runtime behavior with zero test delta is raisable when the repo's documented rules mandate tests (cite the rule) — "the new behavior ships unverified" is a concrete failure_mode, not a hypothetical.
 - Hard-coded environment-specific identifiers (pool/account IDs, environment URLs) in code, scripts, or docs meant for reuse.
@@ -112,6 +118,8 @@ You are the convention owner — validate against what the repo actually documen
 - Package READMEs in the touched paths.
 
 Flag only violations of what those sources document — do not import conventions from other repos or from memory. One check needs no documented rule: **internal inconsistency within the diff itself** (e.g. half of imports from one package family, half from upstream; same persisted shape written three different ways across three call sites).
+
+Deprecations count: new diff code calling an API the consulted sources document as deprecated or superseded is a `[CONVENTION]` finding even when it still works — the failure_mode is concrete: the diff enlarges the migration surface of an API the repo has already decided to retire.
 
 This lens owns all documented-rule checking, whatever domains the table covers (common, backend, frontend, data). Tag every convention finding with `[CONVENTION]` in the title. Cap severity at MAJOR (only when behavior diverges as a result) or MINOR otherwise.
 


### PR DESCRIPTION
## Summary

Amendments from a blind backtest of cb-review against 14 merged clipboard-health PRs, graded against the human and AI review comments those PRs actually received. The rubric caught the cohort's severe defects (including a silent payment-skip data-loss bug) with zero fabricated findings, but missed two findings human reviewers raised. Each amendment generalizes the underlying gap rather than encoding the specific case:

- **Admission › Evidence discipline** (new subsection): prose — PR descriptions, code comments, commit messages — is a claim, not evidence; validate against the code before admitting *or dropping* a finding. (Miss: the reviewer accepted the PR body's "cost-ordered branches" framing instead of reading the order in the diff.)
- **Engineering › cheap gates before expensive work**: a short-circuit placed after DB reads/network calls it could have skipped is raisable when the gate's inputs are available before that work; gate names must match their actual scope. (Miss: global flag gate evaluated after two DB reads, with a per-workplace-sounding name.)
- **Engineering › kept failure paths must be debuggable**: where continuing after a caught error is structurally required (per-item batch processing), the log must carry entity/job IDs; where nothing requires continuing, the catch itself is the finding. (Miss: log-and-continue catch with no shift IDs.)
- **Conventions › deprecations count**: new diff code calling a documented-deprecated API is a `[CONVENTION]` finding, with the migration-surface cost as its concrete failure_mode.

## Validation

- `npx markdownlint-cli2@0.23.0 plugins/core/skills/cb-review/references/review-rubric.md` — 0 errors.
- cb-review (low effort, report mode) run on this diff: 3 MINOR internal-consistency findings, all applied (movable-gate qualifier; structural "by design" criterion replacing prose-dependent judgment; litmus-passing failure_mode for the deprecations rule).

## Notes

Backtest design: assembler/judge separation with sanitized pre-review diffs, so verdicts never saw outcomes. Headline numbers: caught 2 of the 4 strong human findings plus the single most severe bug; 0 hard false positives across 5 clean-PR controls; the misses that motivated these edits were the only two genuine rubric gaps (the rest of the miss set was nit-tier content the rubric filters by design). Historical labels are noisy — promotion of cb-review to any gating role still needs a live shadow run.

Agent session: `claude --resume f1bdb2cf-bf6f-46a2-ac82-95e1d4237edb`

<sub>🤖 <code>cb-ship:created v1 core@3.15.0</code></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yc8sM4GAzx7AVqqi6EX9b