### PR TITLE
feat(contract-core)!: publish tree-shakeable dual CJS+ESM build

### DIFF
--- a/.knip.jsonc
+++ b/.knip.jsonc
@@ -18,7 +18,7 @@
   "webpack": false,
   "workspaces": {
     ".": {
-      "entry": ["scripts/prepareTsgoPackage.mts"],
+      "entry": ["scripts/buildEsmPackage.mts", "scripts/prepareTsgoPackage.mts"],
       "project": ["scripts/**/*.mts"],
     },
     "packages/analytics": {

--- a/nx.json
+++ b/nx.json
@@ -28,7 +28,8 @@
     "packageBuild": [
       "production",
       "{projectRoot}/*.md",
-      "{workspaceRoot}/scripts/prepareTsgoPackage.mts"
+      "{workspaceRoot}/scripts/prepareTsgoPackage.mts",
+      "{workspaceRoot}/scripts/buildEsmPackage.mts"
     ]
   },
   "nxCloudAccessToken": "Nzg3YTFkOGQtOWFmMi00MTQ2LThkNzQtOTRjN2NlMjBjYmQzfHJlYWQ=",

--- a/packages/contract-core/package.json
+++ b/packages/contract-core/package.json
@@ -16,6 +16,7 @@
     "directory": "packages/contract-core"
   },
   "type": "commonjs",
+  "sideEffects": false,
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",
   "publishConfig": {

--- a/packages/contract-core/package.json
+++ b/packages/contract-core/package.json
@@ -19,22 +19,22 @@
   "sideEffects": false,
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",
-  "exports": {
-    "./package.json": "./package.json",
-    ".": {
-      "types": "./src/index.d.ts",
-      "import": "./esm/src/index.js",
-      "require": "./src/index.js",
-      "default": "./src/index.js"
-    },
-    "./*": {
-      "types": "./src/lib/schemas/*.d.ts",
-      "import": "./esm/src/lib/schemas/*.js",
-      "require": "./src/lib/schemas/*.js",
-      "default": "./src/lib/schemas/*.js"
-    }
-  },
   "publishConfig": {
+    "exports": {
+      "./package.json": "./package.json",
+      ".": {
+        "types": "./src/index.d.ts",
+        "import": "./esm/src/index.js",
+        "require": "./src/index.js",
+        "default": "./src/index.js"
+      },
+      "./*": {
+        "types": "./src/lib/schemas/*.d.ts",
+        "import": "./esm/src/lib/schemas/*.js",
+        "require": "./src/lib/schemas/*.js",
+        "default": "./src/lib/schemas/*.js"
+      }
+    },
     "access": "public"
   },
   "dependencies": {

--- a/packages/contract-core/package.json
+++ b/packages/contract-core/package.json
@@ -19,6 +19,21 @@
   "sideEffects": false,
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./src/index.d.ts",
+      "import": "./esm/src/index.js",
+      "require": "./src/index.js",
+      "default": "./src/index.js"
+    },
+    "./*": {
+      "types": "./src/lib/schemas/*.d.ts",
+      "import": "./esm/src/lib/schemas/*.js",
+      "require": "./src/lib/schemas/*.js",
+      "default": "./src/lib/schemas/*.js"
+    }
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/contract-core/project.json
+++ b/packages/contract-core/project.json
@@ -6,11 +6,20 @@
   "tags": [],
   "targets": {
     "build": {
-      "dependsOn": ["prepare-build-package", "^build"],
+      "dependsOn": ["prepare-build-package", "build-esm", "^build"],
       "inputs": ["packageBuild", "^production"],
       "outputs": ["{workspaceRoot}/dist/packages/contract-core"],
       "options": {
         "forwardAllArgs": false
+      }
+    },
+    "build-esm": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["prepare-build-package", "^build"],
+      "inputs": ["packageBuild", "^production"],
+      "outputs": ["{workspaceRoot}/dist/packages/contract-core/esm"],
+      "options": {
+        "command": "env -u NO_COLOR tsx scripts/buildEsmPackage.mts packages/contract-core"
       }
     },
     "lint": {

--- a/packages/contract-core/tsconfig.lib.esm.json
+++ b/packages/contract-core/tsconfig.lib.esm.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "module": "ESNext",
+    "outDir": "../../dist/packages/contract-core/esm",
+    "tsBuildInfoFile": "../../.nx/tsbuildinfo/packages/contract-core/tsconfig.lib.esm.tsbuildinfo"
+  }
+}

--- a/scripts/buildEsmPackage.mts
+++ b/scripts/buildEsmPackage.mts
@@ -1,0 +1,108 @@
+import { joinPathFragments, workspaceRoot } from "@nx/devkit";
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Emits an ESM build of a package to `dist/<projectRoot>/esm` alongside the
+ * default CJS build so bundlers can tree-shake it (see the `import` conditions
+ * written by scripts/prepareTsgoPackage.mts).
+ *
+ * tsgo emits ESM without rewriting relative specifiers that lack a file
+ * extension, which Node's ESM loader rejects, so this script rewrites them to
+ * explicit file paths and drops a `{"type":"module"}` marker package.json
+ * into `esm/`.
+ */
+async function main(): Promise<void> {
+  const [projectRootArgument] = process.argv.slice(2);
+
+  if (projectRootArgument === undefined) {
+    throw new Error("Usage: tsx scripts/buildEsmPackage.mts <projectRoot>");
+  }
+
+  const projectRoot = joinPathFragments(projectRootArgument);
+
+  if (!projectRoot.startsWith("packages/") || projectRoot.split("/").includes("..")) {
+    throw new Error(`Invalid projectRoot: ${projectRootArgument}`);
+  }
+
+  const esmTsconfigPath = joinPathFragments(projectRoot, "tsconfig.lib.esm.json");
+
+  if (!existsSync(joinPathFragments(workspaceRoot, esmTsconfigPath))) {
+    throw new Error(`Missing ${esmTsconfigPath}`);
+  }
+
+  compile({ esmTsconfigPath });
+
+  const esmOutputPath = joinPathFragments(workspaceRoot, "dist", projectRoot, "esm");
+  rewriteRelativeSpecifiers({ directory: esmOutputPath });
+  writeModuleTypeMarker({ esmOutputPath });
+}
+
+function compile({ esmTsconfigPath }: { esmTsconfigPath: string }): void {
+  const result = spawnSync(
+    joinPathFragments(workspaceRoot, "node_modules", ".bin", "tsgo"),
+    ["--project", esmTsconfigPath],
+    { cwd: workspaceRoot, stdio: "inherit" },
+  );
+
+  if (result.status !== 0) {
+    throw new Error(`tsgo failed for ${esmTsconfigPath}`);
+  }
+}
+
+function rewriteRelativeSpecifiers({ directory }: { directory: string }): void {
+  for (const filePath of listJavaScriptFiles({ directory })) {
+    const content = readFileSync(filePath, "utf8");
+    const rewritten = content.replaceAll(
+      /(\bfrom\s*|\bimport\s*\(?\s*)(["'])(\.\.?\/[^"']+)\2/g,
+      (match, prefix: string, quote: string, specifier: string) =>
+        `${prefix}${quote}${resolveSpecifier({ filePath, specifier })}${quote}`,
+    );
+
+    if (rewritten !== content) {
+      writeFileSync(filePath, rewritten);
+    }
+  }
+}
+
+function resolveSpecifier({
+  filePath,
+  specifier,
+}: {
+  filePath: string;
+  specifier: string;
+}): string {
+  const baseDirectory = path.dirname(filePath);
+
+  if (existsSync(path.join(baseDirectory, `${specifier}.js`))) {
+    return `${specifier}.js`;
+  }
+
+  if (existsSync(path.join(baseDirectory, specifier, "index.js"))) {
+    return `${specifier}/index.js`;
+  }
+
+  throw new Error(`Unresolvable relative specifier "${specifier}" in ${filePath}`);
+}
+
+function listJavaScriptFiles({ directory }: { directory: string }): string[] {
+  return readdirSync(directory, { recursive: true, withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".js"))
+    .map((entry) => path.join(entry.parentPath, entry.name));
+}
+
+function writeModuleTypeMarker({ esmOutputPath }: { esmOutputPath: string }): void {
+  // The nearest package.json wins for both Node's module-type resolution and
+  // webpack's sideEffects lookup, so the marker must re-declare sideEffects.
+  writeFileSync(
+    path.join(esmOutputPath, "package.json"),
+    `${JSON.stringify({ type: "module", sideEffects: false }, undefined, 2)}\n`,
+  );
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/prepareTsgoPackage.mts
+++ b/scripts/prepareTsgoPackage.mts
@@ -6,12 +6,11 @@ import {
   type ExecutorContext,
 } from "@nx/devkit";
 import { copyAssets as nxCopyAssets, getUpdatedPackageJsonContent } from "@nx/js";
-import { existsSync, readdirSync, rmSync } from "node:fs";
+import { rmSync } from "node:fs";
 import path from "node:path";
 
 type PackageJson = Parameters<typeof getUpdatedPackageJsonContent>[0];
 type Asset = Parameters<typeof nxCopyAssets>[0]["assets"][number];
-type ExportsMap = Exclude<NonNullable<PackageJson["exports"]>, string>;
 
 const EXTRA_ASSETS_BY_PROJECT_ROOT: Record<string, Asset[]> = {
   "packages/clearance": [
@@ -179,77 +178,9 @@ async function writePackageJson({
 
   packageJson.types ??= packageJson.typings;
   removeSourceExportCondition(packageJson);
-  addDualFormatExports({ packageJson, projectRoot });
 
   const packageJsonPath = joinPathFragments(workspaceRoot, outputPath, "package.json");
   writeJsonFile(packageJsonPath, packageJson);
-}
-
-/**
- * Packages with a tsconfig.lib.esm.json get a second, tree-shakeable ESM build
- * at `esm/` (see scripts/buildEsmPackage.mts). Point bundlers at it through an
- * `exports` map, with a subpath per module so consumers can also skip the
- * barrel entirely. Generated instead of hand-maintained so subpaths cannot
- * drift from the source tree.
- */
-function addDualFormatExports({
-  packageJson,
-  projectRoot,
-}: {
-  packageJson: PackageJson;
-  projectRoot: string;
-}): void {
-  if (!existsSync(joinPathFragments(workspaceRoot, projectRoot, "tsconfig.lib.esm.json"))) {
-    return;
-  }
-
-  const exports: ExportsMap = {
-    "./package.json": "./package.json",
-    ".": dualFormatExportEntry({ modulePath: "index" }),
-  };
-
-  for (const modulePath of listExportableModules({ projectRoot })) {
-    const subpath = `./${path.basename(modulePath)}`;
-
-    if (subpath in exports) {
-      throw new Error(
-        `Subpath ${subpath} (from ${modulePath}) collides with another module in ${projectRoot}`,
-      );
-    }
-
-    exports[subpath] = dualFormatExportEntry({ modulePath });
-  }
-
-  packageJson.exports = exports;
-}
-
-function dualFormatExportEntry({ modulePath }: { modulePath: string }): ExportsMap[string] {
-  return {
-    types: `./src/${modulePath}.d.ts`,
-    import: `./esm/src/${modulePath}.js`,
-    require: `./src/${modulePath}.js`,
-    default: `./src/${modulePath}.js`,
-  };
-}
-
-function listExportableModules({ projectRoot }: { projectRoot: string }): string[] {
-  const sourceRoot = joinPathFragments(workspaceRoot, projectRoot, "src");
-
-  return (
-    readdirSync(sourceRoot, { recursive: true, withFileTypes: true })
-      .filter(
-        (entry) =>
-          entry.isFile() &&
-          entry.name.endsWith(".ts") &&
-          !entry.name.endsWith(".test.ts") &&
-          entry.name !== "index.ts",
-      )
-      .map((entry) =>
-        path.relative(sourceRoot, path.join(entry.parentPath, entry.name)).replace(/\.ts$/, ""),
-      )
-      // eslint-disable-next-line unicorn/no-array-sort -- sorting a freshly mapped array; toSorted is not in scripts' lint lib
-      .sort()
-  );
 }
 
 function removeSourceExportCondition(packageJson: PackageJson): void {

--- a/scripts/prepareTsgoPackage.mts
+++ b/scripts/prepareTsgoPackage.mts
@@ -178,9 +178,28 @@ async function writePackageJson({
 
   packageJson.types ??= packageJson.typings;
   removeSourceExportCondition(packageJson);
+  promotePublishConfigExports(packageJson);
 
   const packageJsonPath = joinPathFragments(workspaceRoot, outputPath, "package.json");
   writeJsonFile(packageJsonPath, packageJson);
+}
+
+/**
+ * A top-level `exports` field in a source package.json breaks in-repo
+ * resolution of the workspace symlink (the mapped build outputs do not exist
+ * in the source tree), so packages author their published exports map under
+ * `publishConfig.exports` — inert for resolvers — and it is promoted here,
+ * mirroring pnpm's publishConfig convention.
+ */
+function promotePublishConfigExports(packageJson: PackageJson): void {
+  const publishConfig = packageJson["publishConfig"] as Record<string, unknown> | undefined;
+
+  if (publishConfig?.["exports"] === undefined) {
+    return;
+  }
+
+  packageJson.exports = publishConfig["exports"] as PackageJson["exports"];
+  delete publishConfig["exports"];
 }
 
 function removeSourceExportCondition(packageJson: PackageJson): void {

--- a/scripts/prepareTsgoPackage.mts
+++ b/scripts/prepareTsgoPackage.mts
@@ -6,11 +6,12 @@ import {
   type ExecutorContext,
 } from "@nx/devkit";
 import { copyAssets as nxCopyAssets, getUpdatedPackageJsonContent } from "@nx/js";
-import { rmSync } from "node:fs";
+import { existsSync, readdirSync, rmSync } from "node:fs";
 import path from "node:path";
 
 type PackageJson = Parameters<typeof getUpdatedPackageJsonContent>[0];
 type Asset = Parameters<typeof nxCopyAssets>[0]["assets"][number];
+type ExportsMap = Exclude<NonNullable<PackageJson["exports"]>, string>;
 
 const EXTRA_ASSETS_BY_PROJECT_ROOT: Record<string, Asset[]> = {
   "packages/clearance": [
@@ -178,9 +179,77 @@ async function writePackageJson({
 
   packageJson.types ??= packageJson.typings;
   removeSourceExportCondition(packageJson);
+  addDualFormatExports({ packageJson, projectRoot });
 
   const packageJsonPath = joinPathFragments(workspaceRoot, outputPath, "package.json");
   writeJsonFile(packageJsonPath, packageJson);
+}
+
+/**
+ * Packages with a tsconfig.lib.esm.json get a second, tree-shakeable ESM build
+ * at `esm/` (see scripts/buildEsmPackage.mts). Point bundlers at it through an
+ * `exports` map, with a subpath per module so consumers can also skip the
+ * barrel entirely. Generated instead of hand-maintained so subpaths cannot
+ * drift from the source tree.
+ */
+function addDualFormatExports({
+  packageJson,
+  projectRoot,
+}: {
+  packageJson: PackageJson;
+  projectRoot: string;
+}): void {
+  if (!existsSync(joinPathFragments(workspaceRoot, projectRoot, "tsconfig.lib.esm.json"))) {
+    return;
+  }
+
+  const exports: ExportsMap = {
+    "./package.json": "./package.json",
+    ".": dualFormatExportEntry({ modulePath: "index" }),
+  };
+
+  for (const modulePath of listExportableModules({ projectRoot })) {
+    const subpath = `./${path.basename(modulePath)}`;
+
+    if (subpath in exports) {
+      throw new Error(
+        `Subpath ${subpath} (from ${modulePath}) collides with another module in ${projectRoot}`,
+      );
+    }
+
+    exports[subpath] = dualFormatExportEntry({ modulePath });
+  }
+
+  packageJson.exports = exports;
+}
+
+function dualFormatExportEntry({ modulePath }: { modulePath: string }): ExportsMap[string] {
+  return {
+    types: `./src/${modulePath}.d.ts`,
+    import: `./esm/src/${modulePath}.js`,
+    require: `./src/${modulePath}.js`,
+    default: `./src/${modulePath}.js`,
+  };
+}
+
+function listExportableModules({ projectRoot }: { projectRoot: string }): string[] {
+  const sourceRoot = joinPathFragments(workspaceRoot, projectRoot, "src");
+
+  return (
+    readdirSync(sourceRoot, { recursive: true, withFileTypes: true })
+      .filter(
+        (entry) =>
+          entry.isFile() &&
+          entry.name.endsWith(".ts") &&
+          !entry.name.endsWith(".test.ts") &&
+          entry.name !== "index.ts",
+      )
+      .map((entry) =>
+        path.relative(sourceRoot, path.join(entry.parentPath, entry.name)).replace(/\.ts$/, ""),
+      )
+      // eslint-disable-next-line unicorn/no-array-sort -- sorting a freshly mapped array; toSorted is not in scripts' lint lib
+      .sort()
+  );
 }
 
 function removeSourceExportCondition(packageJson: PackageJson): void {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -61,6 +61,9 @@
     },
     {
       "path": "./packages/config"
+    },
+    {
+      "path": "./packages/clearance"
     }
   ]
 }


### PR DESCRIPTION
## Why

[ACT-5348](https://linear.app/clipboardhealth/issue/ACT-5348/make-clipboard-healthcontract-core-tree-shakeable)

`@clipboard-health/contract-core` publishes CJS only, with `main` pointing at a `__exportStar` barrel and no `exports` map or `sideEffects` flag. Bundlers (webpack in cbh-mobile-app, Vite in cbh-admin-frontend) cannot tree-shake it: any value import pulls the whole package into the boot bundle and constructs every Zod schema at module load. contract-core itself is small, but it is the base dependency of the whole contract family (contract-backend-main, contract-worker-app-bff, contract-documents-service, contract-payment-service, contract-home-health-api), so its packaging sets the pattern for the sibling ACT-5337 work (ClipboardHealth/clipboard-health#26642), which is directly implicated in mobile webview OOM pressure (~100 MB of Zod schemas measured in the boot heap).

## What

- **ESM build**: `tsconfig.lib.esm.json` emits a second compile to `esm/` in the published package. New generic `scripts/buildEsmPackage.mts` runs it, rewrites extensionless relative specifiers to Node-valid explicit paths, and writes an `esm/package.json` marker (`{"type":"module","sideEffects":false}` — the nearest-package.json rule applies to both Node module-type resolution and webpack's sideEffects lookup).
- **Static `exports` map with patterns**: authored directly in the source package.json — `.` routes bundlers to ESM (`import`) and Node/NestJS to the unchanged CJS (`require`), and a single `"./*"` pattern exposes every schema module as a subpath (e.g. `@clipboard-health/contract-core/money`) with `types`/`import`/`require` conditions. Patterns scale with the source tree, so there is nothing to generate or drift; `prepareTsgoPackage.mts` passes the map through unchanged.
- **`sideEffects: false`**: audited — all modules are pure schema declarations (no `process.env`, globals, or Zod registry mutations).

Note: tree-shaking itself comes from `sideEffects: false` + the ESM `import` condition; the `./*` subpaths are barrel-bypass entry points for dev-mode builds, tests, and the mobile app's deep-import migration.

## Compatibility

- **CJS consumers (20+ NestJS backends)**: the `require` condition resolves the exact same `./src/index.js` files as today's `main` — no behavioral change.
- **Bundlers**: the `import` condition + `sideEffects: false` enables tree-shaking; subpaths let consumers skip the barrel entirely.
- **Deep imports**: swept the org via Sourcegraph — zero deep imports into contract-core exist, so the exports map blocks nobody.
- **TS**: `node10` resolution keeps using `main`/`types` (unchanged); `bundler`/`node16` get pattern-resolved `types` conditions.

## Validation

- `node --run verify` passes (build, lint, test, knip, cpd, spell, format, syncpack, architecture).
- Smoke-tested the built artifact against a scratch consumer: `require()` → CJS ✓, dynamic `import()` under Node ESM → ESM ✓ (17 exports both), wildcard subpath `import "@clipboard-health/contract-core/money"` ✓.
- Installed the built artifact into the clipboard-health monorepo over the hoisted copy: `build:workspaces` (including contract-backend-main) clean, repo typecheck shows zero new errors vs baseline, runtime require/import/subpath all resolve.

## Areas of concern

- The `./*` pattern exposes all built files as subpaths, not just barrel exports — identical exposure to the pre-exports-map status quo.
- The dual-package hazard (one bundle loading both formats) is theoretical here: the package exports plain Zod schema values with no cross-instance `instanceof` checks.
- Single `.d.ts` set serves both formats; strict `node16` ESM consumers would see CJS-flavored types — we have none today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

BREAKING CHANGE: the package now declares an `exports` map. The root import and all published file paths are unchanged, but undeclared deep imports (e.g. `@clipboard-health/contract-core/src/...`) no longer resolve — use the package root or the `./<module>` subpaths instead. Org-wide sweep found zero such imports.
