### PR TITLE
feat(ai-rules): forbid contract packages from depending on other contract packages

### DIFF
--- a/packages/ai-rules/rules/backend/restApiDesign.md
+++ b/packages/ai-rules/rules/backend/restApiDesign.md
@@ -55,7 +55,9 @@ GET /shifts?filter[verified]=true&sort=startDate,-urgency&page[cursor]=abc&page[
 
 - Add contracts to `contract-<microservice-name>` package
 - Use `ts-rest` with composable Zod schemas (enforced by `enforce-ts-rest-in-controllers`)
-- Do not add other contract packages (`contract-*`, `api-contract-*`, `flag-*`) to a contract package's `dependencies` — cross-contract exact pins force vendored duplicate copies into every consumer's bundle and can create dependency cycles that never dedupe. Import shared primitives from `@clipboard-health/contract-core`; for the rare shared domain shape, duplicate the schema definition locally instead of importing it (Zod brands are structural, so duplicates stay type-compatible, and response validation catches drift)
+- Own the shape of your inputs and outputs — do not depend on other contract packages (`contract-*`, `api-contract-*`, `flag-*`); `@clipboard-health/contract-core` is the only shared contract dependency
+- Duplicate schemas from other contracts locally when needed — type-checking and response validation catch drift
+- Do not re-export or pass through another contract's schemas or endpoints
 
 ### Schema rules
 

--- a/packages/ai-rules/rules/backend/restApiDesign.md
+++ b/packages/ai-rules/rules/backend/restApiDesign.md
@@ -55,6 +55,7 @@ GET /shifts?filter[verified]=true&sort=startDate,-urgency&page[cursor]=abc&page[
 
 - Add contracts to `contract-<microservice-name>` package
 - Use `ts-rest` with composable Zod schemas (enforced by `enforce-ts-rest-in-controllers`)
+- Do not add other contract packages (`contract-*`, `api-contract-*`, `flag-*`) to a contract package's `dependencies` — cross-contract exact pins force vendored duplicate copies into every consumer's bundle and can create dependency cycles that never dedupe. Import shared primitives from `@clipboard-health/contract-core`; for the rare shared domain shape, duplicate the schema definition locally instead of importing it (Zod brands are structural, so duplicates stay type-compatible, and response validation catches drift)
 
 ### Schema rules
 


### PR DESCRIPTION
Follow-up to the contract tree-shaking work (ACT-5337 / ACT-5344 / ACT-5355) and the contract dependency-graph investigation. We are also working to unravel the existing dependencies

## Why

Nothing in the rules addressed contract-on-contract dependencies, and the org-wide graph shows why that matters:

- Cross-contract **exact pins** force npm to vendor duplicate copies into every consumer — the direct root cause of the cbh-mobile-app webview OOM (~70 MB of duplicate Zod schemas came from `contract-worker-app-bff`'s vendored `contract-backend-main` + `api-contract-curated-shifts`).
- Mutual exact pins create **cycles that can never dedupe**: `contract-backend-main` ⇄ `contract-home-health-api` pin each other today over a single one-line schema (`WorkplaceIdSchema`), permanently nesting stale copies in every consumer's lockfile ([clipboard-health#26657](https://github.com/ClipboardHealth/clipboard-health/pull/26657) documents the residual).
- How that rendered downstream, concretely: cbh-mobile-app pinned `contract-backend-main@60.58.2` directly, `contract-worker-app-bff` vendored a second full copy at `60.61.3`, and the `contract-home-health-api@0.7.8` leg of the cycle vendored a third at `60.8.2` — **three complete copies of the ~4,300-schema backend-main barrel** (each dragging its own stale `contract-core`), all CJS, all constructed at webview boot on the signed-out page. Collapsing exactly this chain is where the ACT-5355 result came from (152k → 19.5k Zod instances, 760 MB → 323 MB webview footprint).

## What

One bullet in `rules/backend/restApiDesign.md` → Contracts: contract packages must not depend on other contract packages; import shared primitives from `@clipboard-health/contract-core`, and duplicate the rare shared domain shape locally (Zod brands are structural, so duplicates stay type-compatible; ts-rest response validation catches drift).

## Validation

- `nx test ai-rules` green; `oxfmt --check` on rules markdown clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
