### PR TITLE
docs: remove cb-work line limit guidance

### DIFF
--- a/plugins/core/skills/cb-work/SKILL.md
+++ b/plugins/core/skills/cb-work/SKILL.md
@@ -22,7 +22,6 @@ Unless instructed otherwise:
 The plan or request is the source of truth for scope:
 
 - Make exactly the changes requested, no extra refactors or cleanup.
-- Target ≤ ~500 changed lines per PR: if the work will clearly exceed that, stop and propose a split into separately shippable slices before implementing.
 - On any drift from the plan (e.g. referenced files or utilities missing, an assumption invalid, a constraint missed) stop and report. Do not silently rewrite the approach.
 - Do not modify the plan file itself unless asked.
 


### PR DESCRIPTION
## Summary

Remove the `cb-work` instruction that targeted a maximum changed-line count per PR, leaving the rest of the implementation-scope guidance unchanged.

## Validation

- `node --run sync-ai-rules`
- `node --run verify`
- pre-push hook: `node --run verify`
- `cb-review --effort low --report`: no findings

## Notes

Agent session: `codex resume 019f3fd3-276a-7e80-a93d-b4329d4706e6`

<sub>🤖 <code>cb-ship:created v1 core@3.16.1</code></sub>
