### PR TITLE
feat(ACT-5370): add no-cross-contract-imports eslint rule

### DIFF
--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -167,6 +167,14 @@ module.exports = {
               "@clipboard-health/require-zod-import-in-contracts": "error",
             },
           },
+          {
+            // Self-scoped: no-ops unless the nearest package.json name matches
+            // the contract package pattern, so it is safe on every file.
+            files: ["**/*.ts", "**/*.tsx"],
+            rules: {
+              "@clipboard-health/no-cross-contract-imports": "error",
+            },
+          },
         ]
       : []),
   ],

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,10 +1,12 @@
 import enforceTsRestInControllers from "./lib/rules/enforce-ts-rest-in-controllers";
+import noCrossContractImports from "./lib/rules/no-cross-contract-imports";
 import requireHttpModuleFactory from "./lib/rules/require-http-module-factory";
 import requireRunValidatorsWithUpsert from "./lib/rules/require-run-validators-with-upsert";
 import requireZodImportInContracts from "./lib/rules/require-zod-import-in-contracts";
 
 export const rules = {
   "enforce-ts-rest-in-controllers": enforceTsRestInControllers,
+  "no-cross-contract-imports": noCrossContractImports,
   "require-http-module-factory": requireHttpModuleFactory,
   "require-run-validators-with-upsert": requireRunValidatorsWithUpsert,
   "require-zod-import-in-contracts": requireZodImportInContracts,

--- a/packages/eslint-plugin/src/lib/rules/no-cross-contract-imports/README.md
+++ b/packages/eslint-plugin/src/lib/rules/no-cross-contract-imports/README.md
@@ -1,0 +1,54 @@
+# no-cross-contract-imports
+
+ESLint rule that forbids contract packages (`@clipboard-health/contract-*`, `@clipboard-health/api-contract-*`, `@clipboard-health/flag-*`) from importing other contract packages. `@clipboard-health/contract-core` is the one allowed shared contract dependency.
+
+## Motivation
+
+Contracts own the shape of their inputs and outputs. When one contract package imports another, the imported contract becomes an exact-pinned dependency of the importer, which:
+
+- **Vendors duplicate copies into every consumer.** Contract packages pin exact versions, so the importer's copy of the imported contract almost never dedupes with the consumer's own copy. At its worst, cbh-mobile-app carried nine copies of `contract-core` and multiple full copies of `contract-backend-main` through this mechanism, constructing every Zod schema in each copy at boot (ACT-5337).
+- **Risks dependency cycles.** `contract-backend-main` and `contract-home-health-api` once imported each other; exact-pinned cycles structurally never dedupe and can only be fixed by removing an edge (ACT-5356/ACT-5357).
+- **Couples release trains.** The importer must bump every time the imported contract changes, even when nothing it uses changed.
+
+Type-only imports are banned too: they still force the imported package into `dependencies` so consumers can resolve the `.d.ts`, recreating the same coupling.
+
+Instead:
+
+- Import shared primitives (`dateTimeSchema`, `objectId`, enum helpers, `moneySchema`) from `@clipboard-health/contract-core`.
+- Duplicate the rare shared domain schema locally. Zod brands are structural, so duplicates stay type-compatible, and ts-rest response validation catches drift.
+- Do not re-export or pass through another contract's schemas or endpoints.
+
+See `rules/backend/restApiDesign.md` in `@clipboard-health/ai-rules` for the full guidance.
+
+## Rule Details
+
+The rule only applies inside contract packages: it walks up from the linted file to the nearest `package.json` that declares a `name` and checks it against the contract package pattern. In any other package the rule is a no-op, so it is safe to enable globally.
+
+Within a contract package it reports every reference to another contract package, in any form: `import`/`import type`, `export … from`/`export * from`/`export type … from`, dynamic `import()`, `require()`, and `import x = require()`.
+
+### ❌ Incorrect
+
+```ts
+import { WorkplaceIdSchema } from "@clipboard-health/contract-backend-main";
+import type { Shift } from "@clipboard-health/contract-backend-main";
+export * from "@clipboard-health/contract-home-health-api";
+const flags = require("@clipboard-health/flag-backend-main");
+```
+
+### ✅ Correct
+
+```ts
+import { dateTimeSchema, objectId } from "@clipboard-health/contract-core";
+
+// Duplicated from contract-backend-main rather than imported: Zod brands are
+// structural, so this stays type-identical to the upstream schema.
+export const WorkplaceIdSchema = objectId.brand("WorkplaceId");
+```
+
+## Options
+
+None.
+
+## When Not To Use It
+
+Only during a migration window while an existing cross-contract dependency is being removed — disable per line with an `eslint-disable-next-line` comment referencing the removal ticket rather than turning the rule off for the package.

--- a/packages/eslint-plugin/src/lib/rules/no-cross-contract-imports/fixtures/consumer-app/package.json
+++ b/packages/eslint-plugin/src/lib/rules/no-cross-contract-imports/fixtures/consumer-app/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@clipboard-health/fixture-consumer-app",
+  "private": true,
+  "description": "Test fixture: a regular app package (does not match the contract package name pattern)."
+}

--- a/packages/eslint-plugin/src/lib/rules/no-cross-contract-imports/fixtures/contract-package/nested-no-name/package.json
+++ b/packages/eslint-plugin/src/lib/rules/no-cross-contract-imports/fixtures/contract-package/nested-no-name/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "sideEffects": false
+}

--- a/packages/eslint-plugin/src/lib/rules/no-cross-contract-imports/fixtures/contract-package/package.json
+++ b/packages/eslint-plugin/src/lib/rules/no-cross-contract-imports/fixtures/contract-package/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@clipboard-health/contract-fixture-service",
+  "private": true,
+  "description": "Test fixture: a contract package (matches the contract package name pattern)."
+}

--- a/packages/eslint-plugin/src/lib/rules/no-cross-contract-imports/index.test.ts
+++ b/packages/eslint-plugin/src/lib/rules/no-cross-contract-imports/index.test.ts
@@ -1,0 +1,156 @@
+import path from "node:path";
+
+import { TSESLint } from "@typescript-eslint/utils";
+
+import rule from "./index";
+
+// eslint-disable-next-line n/no-unpublished-require
+const parser = require.resolve("@typescript-eslint/parser");
+
+const ruleTester = new TSESLint.RuleTester({
+  parser,
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: "module",
+  },
+});
+
+const inContractPackage = path.join(
+  __dirname,
+  "fixtures",
+  "contract-package",
+  "src",
+  "foo.contract.ts",
+);
+const inNestedNamelessDirectory = path.join(
+  __dirname,
+  "fixtures",
+  "contract-package",
+  "nested-no-name",
+  "bar.contract.ts",
+);
+const inConsumerApp = path.join(__dirname, "fixtures", "consumer-app", "src", "worker.ts");
+
+// oxlint-disable-next-line vitest/expect-expect -- RuleTester validates declaratively
+ruleTester.run("no-cross-contract-imports", rule, {
+  valid: [
+    {
+      name: "contract-core import is the allowed shared dependency",
+      filename: inContractPackage,
+      code: `import { dateTimeSchema, objectId } from "@clipboard-health/contract-core";`,
+    },
+    {
+      name: "contract-core subpath import is allowed",
+      filename: inContractPackage,
+      code: `import { objectId } from "@clipboard-health/contract-core/objectId";`,
+    },
+    {
+      name: "non-contract @clipboard-health packages are allowed",
+      filename: inContractPackage,
+      code: `
+        import { isDefined } from "@clipboard-health/util-ts";
+        import { booleanString } from "@clipboard-health/json-api-nestjs";
+      `,
+    },
+    {
+      name: "third-party and relative imports are allowed",
+      filename: inContractPackage,
+      code: `
+        import { initContract } from "@ts-rest/core";
+        import { z } from "zod";
+        import { fooSchema } from "./foo.schemas";
+      `,
+    },
+    {
+      name: "outside a contract package the rule does not apply",
+      filename: inConsumerApp,
+      code: `
+        import { shiftContract } from "@clipboard-health/contract-backend-main";
+        export * from "@clipboard-health/api-contract-curated-shifts";
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: "value import of another contract package",
+      filename: inContractPackage,
+      code: `import { WorkplaceIdSchema } from "@clipboard-health/contract-backend-main";`,
+      errors: [{ messageId: "noCrossContractImport" }],
+    },
+    {
+      name: "type-only import still pins the dependency",
+      filename: inContractPackage,
+      code: `import type { Shift } from "@clipboard-health/contract-backend-main";`,
+      errors: [{ messageId: "noCrossContractImport" }],
+    },
+    {
+      name: "api-contract-* packages are banned",
+      filename: inContractPackage,
+      code: `import { shiftSchema } from "@clipboard-health/api-contract-curated-shifts";`,
+      errors: [{ messageId: "noCrossContractImport" }],
+    },
+    {
+      name: "flag-* packages are banned",
+      filename: inContractPackage,
+      code: `import { someFlag } from "@clipboard-health/flag-backend-main";`,
+      errors: [{ messageId: "noCrossContractImport" }],
+    },
+    {
+      name: "deep import of another contract package",
+      filename: inContractPackage,
+      code: `import { shiftSchema } from "@clipboard-health/contract-backend-main/dist/lib/shift.contract";`,
+      errors: [{ messageId: "noCrossContractImport" }],
+    },
+    {
+      name: "re-export passthrough of another contract package",
+      filename: inContractPackage,
+      code: `export * from "@clipboard-health/contract-home-health-api";`,
+      errors: [{ messageId: "noCrossContractImport" }],
+    },
+    {
+      name: "named re-export with source",
+      filename: inContractPackage,
+      code: `export { VisitSchema } from "@clipboard-health/contract-home-health-api";`,
+      errors: [{ messageId: "noCrossContractImport" }],
+    },
+    {
+      name: "type-only re-export",
+      filename: inContractPackage,
+      code: `export type { Visit } from "@clipboard-health/contract-home-health-api";`,
+      errors: [{ messageId: "noCrossContractImport" }],
+    },
+    {
+      name: "dynamic import",
+      filename: inContractPackage,
+      code: `const contract = await import("@clipboard-health/contract-payment-service");`,
+      errors: [{ messageId: "noCrossContractImport" }],
+    },
+    {
+      name: "require call",
+      filename: inContractPackage,
+      code: `const contract = require("@clipboard-health/contract-documents-service");`,
+      errors: [{ messageId: "noCrossContractImport" }],
+    },
+    {
+      name: "import-equals require",
+      filename: inContractPackage,
+      code: `import contract = require("@clipboard-health/contract-backend-main");`,
+      errors: [{ messageId: "noCrossContractImport" }],
+    },
+    {
+      name: "nameless build-marker package.json does not stop the package lookup",
+      filename: inNestedNamelessDirectory,
+      code: `import { shiftSchema } from "@clipboard-health/contract-backend-main";`,
+      errors: [{ messageId: "noCrossContractImport" }],
+    },
+    {
+      name: "multiple violations each report",
+      filename: inContractPackage,
+      code: `
+        import { a } from "@clipboard-health/contract-backend-main";
+        export * from "@clipboard-health/flag-backend-main";
+      `,
+      errors: [{ messageId: "noCrossContractImport" }, { messageId: "noCrossContractImport" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/lib/rules/no-cross-contract-imports/index.test.ts
+++ b/packages/eslint-plugin/src/lib/rules/no-cross-contract-imports/index.test.ts
@@ -62,6 +62,14 @@ ruleTester.run("no-cross-contract-imports", rule, {
       `,
     },
     {
+      name: "self-import of the package's own published name is allowed",
+      filename: inContractPackage,
+      code: `
+        import { fooSchema } from "@clipboard-health/contract-fixture-service";
+        import { barSchema } from "@clipboard-health/contract-fixture-service/foo.contract";
+      `,
+    },
+    {
       name: "outside a contract package the rule does not apply",
       filename: inConsumerApp,
       code: `

--- a/packages/eslint-plugin/src/lib/rules/no-cross-contract-imports/index.ts
+++ b/packages/eslint-plugin/src/lib/rules/no-cross-contract-imports/index.ts
@@ -1,0 +1,134 @@
+/**
+ * @fileoverview Forbid contract packages from importing other contract packages.
+ * Cross-contract dependencies pin one contract into another's dependencies,
+ * vendoring duplicate copies into every consumer and risking dependency cycles.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+
+import { createRule } from "../../createRule";
+
+const CONTRACT_PACKAGE_PATTERN = /^@clipboard-health\/(?:contract-|api-contract-|flag-)/;
+const SHARED_CONTRACT_PACKAGE = "@clipboard-health/contract-core";
+
+const packageNameCache = new Map<string, string | undefined>();
+
+/**
+ * Walks up from `directory` to the nearest package.json that declares a `name`.
+ * Skips nameless manifests (e.g. `{"type":"module"}` build-output markers).
+ */
+function nearestPackageName(directory: string): string | undefined {
+  if (packageNameCache.has(directory)) {
+    return packageNameCache.get(directory);
+  }
+
+  let name: string | undefined;
+  const manifestPath = path.join(directory, "package.json");
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- resolves the linted file's own package.json
+    const manifest: unknown = JSON.parse(readFileSync(manifestPath, "utf8"));
+    if (
+      typeof manifest === "object" &&
+      manifest !== null &&
+      "name" in manifest &&
+      typeof manifest.name === "string"
+    ) {
+      name = manifest.name;
+    }
+  } catch {
+    // No package.json in this directory; keep walking up.
+  }
+
+  if (name === undefined) {
+    const parent = path.dirname(directory);
+    name = parent === directory ? undefined : nearestPackageName(parent);
+  }
+
+  packageNameCache.set(directory, name);
+  return name;
+}
+
+function isBannedSpecifier(specifier: string): boolean {
+  return (
+    CONTRACT_PACKAGE_PATTERN.test(specifier) &&
+    specifier !== SHARED_CONTRACT_PACKAGE &&
+    !specifier.startsWith(`${SHARED_CONTRACT_PACKAGE}/`)
+  );
+}
+
+const rule = createRule({
+  name: "no-cross-contract-imports",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Forbid contract packages from importing other contract packages; contracts own the shape of their inputs and outputs",
+    },
+    schema: [],
+    messages: {
+      noCrossContractImport:
+        "Contract packages must not depend on '{{specifier}}'. Cross-contract imports (including type-only imports and re-exports) pin another contract into this package's dependencies, vendoring duplicate copies into every consumer and risking dependency cycles. Import shared primitives from @clipboard-health/contract-core, or duplicate the schema locally — type-checking and response validation catch drift.",
+    },
+  },
+
+  create(context) {
+    const packageName = nearestPackageName(path.dirname(context.filename));
+    if (packageName === undefined || !CONTRACT_PACKAGE_PATTERN.test(packageName)) {
+      return {};
+    }
+
+    function checkSpecifier(node: TSESTree.Node, specifier: string): void {
+      if (isBannedSpecifier(specifier)) {
+        context.report({
+          node,
+          messageId: "noCrossContractImport",
+          data: { specifier },
+        });
+      }
+    }
+
+    return {
+      ImportDeclaration(node) {
+        checkSpecifier(node, node.source.value);
+      },
+      ExportNamedDeclaration(node) {
+        if (node.source) {
+          checkSpecifier(node, node.source.value);
+        }
+      },
+      ExportAllDeclaration(node) {
+        checkSpecifier(node, node.source.value);
+      },
+      ImportExpression(node) {
+        if (node.source.type === AST_NODE_TYPES.Literal && typeof node.source.value === "string") {
+          checkSpecifier(node, node.source.value);
+        }
+      },
+      CallExpression(node) {
+        const [argument] = node.arguments;
+        if (
+          node.callee.type === AST_NODE_TYPES.Identifier &&
+          node.callee.name === "require" &&
+          argument?.type === AST_NODE_TYPES.Literal &&
+          typeof argument.value === "string"
+        ) {
+          checkSpecifier(node, argument.value);
+        }
+      },
+      TSImportEqualsDeclaration(node) {
+        if (
+          node.moduleReference.type === AST_NODE_TYPES.TSExternalModuleReference &&
+          node.moduleReference.expression.type === AST_NODE_TYPES.Literal &&
+          typeof node.moduleReference.expression.value === "string"
+        ) {
+          checkSpecifier(node, node.moduleReference.expression.value);
+        }
+      },
+    };
+  },
+});
+
+export default rule;

--- a/packages/eslint-plugin/src/lib/rules/no-cross-contract-imports/index.ts
+++ b/packages/eslint-plugin/src/lib/rules/no-cross-contract-imports/index.ts
@@ -75,13 +75,16 @@ const rule = createRule({
   },
 
   create(context) {
-    const packageName = nearestPackageName(path.dirname(context.filename));
+    // context.filename requires ESLint >=8.40; fall back for older 8.x hosts.
+    const filename = (context as Partial<typeof context>).filename ?? context.getFilename();
+    const packageName = nearestPackageName(path.dirname(filename));
     if (packageName === undefined || !CONTRACT_PACKAGE_PATTERN.test(packageName)) {
       return {};
     }
 
     function checkSpecifier(node: TSESTree.Node, specifier: string): void {
-      if (isBannedSpecifier(specifier)) {
+      const isSelfImport = specifier === packageName || specifier.startsWith(`${packageName}/`);
+      if (!isSelfImport && isBannedSpecifier(specifier)) {
         context.report({
           node,
           messageId: "noCrossContractImport",


### PR DESCRIPTION
## Summary

[ACT-5370](https://linear.app/clipboardhealth/issue/ACT-5370/eslint-rule-no-cross-contract-imports-block-contract-packages)

Enforcement layer for the contract-ownership guidance in #765: contract packages (`contract-*`, `api-contract-*`, `flag-*`) must not import other contract packages. `@clipboard-health/contract-core` is the one allowed shared contract dependency.

## How it works

- **Every reference form is flagged**: `import` / `import type` (statement- and specifier-level), `export … from` / `export * from` / `export type … from` (the passthrough case), dynamic `import()`, `require()`, and `import x = require()`.
- **Self-scoped by package name**: the rule walks up from the linted file to the nearest `package.json` that declares a `name` (skipping nameless build-output markers) and only enforces when the name matches the contract pattern. File globs can't scope this — contract packages run `eslint .` from their own directory — so self-scoping is what lets `eslint-config` enable the rule on every file safely; it no-ops everywhere else. Lookups are cached per directory.
- **Type-only imports are banned too**: they still force the imported contract into `dependencies` for `.d.ts` resolution, recreating the exact-pin version coupling.
- Wired into `eslint-config` as `error` alongside the existing contract rules (outside-core-utils block).

## Why

Cross-contract exact pins vendor duplicate copies into every consumer — cbh-mobile-app carried nine `contract-core` copies at peak, and `contract-backend-main` ⇄ `contract-home-health-api` formed a cycle that could only be fixed by removing an edge (ACT-5337 / ACT-5356 / ACT-5357). The last remaining cross-contract edge is `contract-worker-app-bff` → backend-main + curated-shifts; existing violations get `eslint-disable-next-line` with the removal ticket during migration.

## Validation

- 18 new RuleTester cases (60 plugin tests total) incl. real-filesystem fixtures for the package-name scoping and the nameless-marker walk-past
- `nx run-many -t lint,test,build -p eslint-plugin eslint-config` green; cspell/oxfmt clean

## Real-repo evidence

Ran the built rule against two repos by overlaying `dist/packages/eslint-plugin` into their `node_modules` and enabling the rule via `--rule` (existing shared config otherwise untouched):

**clipboard-health (post-ACT-5357, home-health edge removed) — all three contract packages clean:**

| Package | Result |
|---|---|
| `contract-backend-main` | ✅ 0 violations (passes because the home-health import was removed) |
| `flag-backend-main` | ✅ 0 violations (only imports the allowlisted `contract-core`) |
| `message-backend-main` | ✅ 0 violations |

**worker-app-bff (not yet decoupled) — flags exactly the known cross-contract edges, nothing else:**

```text
src/lib/contracts/shiftAuctionBids.contract.ts
  1:1  error  Contract packages must not depend on '@clipboard-health/contract-backend-main' ...
src/lib/contracts/shiftAuctionInstantBook.contract.ts
  1:1  error  Contract packages must not depend on '@clipboard-health/contract-backend-main' ...
src/lib/contracts/shiftModals.contract.ts
  1:1  error  Contract packages must not depend on '@clipboard-health/contract-backend-main' ...
src/lib/contracts/workerPaySurveys.contract.ts
  1:1  error  Contract packages must not depend on '@clipboard-health/api-contract-curated-shifts' ...

x 4 problems (4 errors, 0 warnings)
```

- `@clipboard-health/money` imports were correctly **not** flagged (intentionally outside the banned pattern).
- Negative control: app-level worker-app-bff files that import `contract-backend-main` directly produced **0 violations** — the package-name self-scoping keeps the rule inert outside contract packages while enabled on every file.
- These 4 files are the migration worklist for the worker-app-bff decoupling; they take `eslint-disable-next-line` with the ticket reference until that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
