### PR TITLE
docs: add cb-ship git auth fallback

### DIFF
--- a/plugins/core/skills/cb-ship/SKILL.md
+++ b/plugins/core/skills/cb-ship/SKILL.md
@@ -7,6 +7,7 @@ argument-hint: "[--draft]"
 ## Setup
 
 - If `gh auth status` fails, stop and tell the user.
+- If `git fetch` or `git push` fails with public key or agent errors, retry the same operation via `git -c credential.helper='!gh auth git-credential' <cmd> https://github.com/<org>/<repo>.git` instead of stopping.
 - If `git rev-parse --verify origin/HEAD` fails, `origin/HEAD` is unset. Stop and tell the user to run `git remote set-head origin -a`.
 - If `git status --short`, `git log --oneline origin/HEAD..HEAD`, and `gh pr view --json url --jq .url 2>/dev/null` are all empty, stop and reply "nothing to ship."
 

--- a/plugins/core/skills/cb-ship/SKILL.md
+++ b/plugins/core/skills/cb-ship/SKILL.md
@@ -7,7 +7,7 @@ argument-hint: "[--draft]"
 ## Setup
 
 - If `gh auth status` fails, stop and tell the user.
-- If `git fetch` or `git push` fails with public key or agent errors, retry the same operation via `git -c credential.helper='!gh auth git-credential' <cmd> https://github.com/<org>/<repo>.git` instead of stopping.
+- If `git fetch` or `git push` fails with public key or agent errors, retry the same operation with `git -c credential.helper='!gh auth git-credential'` while preserving the original remote and branch mapping. For `git fetch`, keep the configured remote (e.g., `git -c credential.helper='!gh auth git-credential' fetch origin <same arguments>`) so `origin/*` refs update; for `git push`, use the same destination and branch mapping, substituting `https://github.com/<org>/<repo>.git` only when the configured remote URL is SSH.
 - If `git rev-parse --verify origin/HEAD` fails, `origin/HEAD` is unset. Stop and tell the user to run `git remote set-head origin -a`.
 - If `git status --short`, `git log --oneline origin/HEAD..HEAD`, and `gh pr view --json url --jq .url 2>/dev/null` are all empty, stop and reply "nothing to ship."
 


### PR DESCRIPTION
## Summary

Adds `cb-ship` setup guidance for retrying `git fetch` or `git push` public key or agent failures through GitHub CLI credential helper over HTTPS instead of stopping immediately.

## Validation

- `node --import tsx scripts/embedPluginVersion.mts`
- `node --import tsx packages/ai-rules/scripts/sync.ts common --exclude common/featureFlags`
- `git diff --check`
- `node --run spell:check -- plugins/core/skills/cb-ship/SKILL.md`
- `node --run markdown:lint -- plugins/core/skills/cb-ship/SKILL.md`
- `node --import tsx packages/embedex/src/bin/cli.ts --sourcesGlob 'packages/*/examples/**/*.{md,ts}' --check`
- `NX_DAEMON=false NX_ISOLATE_PLUGINS=false node --run verify` failed only on `embed:check` because this session cannot create the `tsx` CLI local IPC pipe (`listen EPERM`); the equivalent non-IPC embed check above passed.

## Notes

- `cb-review --effort low --report`: no actionable findings.
- Agent session: `codex resume 019f4459-0a60-74e2-a7da-94b5e859446b`

<sub>🤖 <code>cb-ship:created v1 core@3.16.1</code></sub>