### PR TITLE
feat(ai-rules): no ticket refs in code; UI visibility assertions

### DIFF
--- a/.rules/common/typeScript.md
+++ b/.rules/common/typeScript.md
@@ -17,6 +17,7 @@ description: "Writing ANY TypeScript code"
 
 ## Core Rules
 
+- Do not add ticket or issue numbers (e.g. Linear, Jira IDs) to code, variable names, or comments unless explicitly asked
 - Avoid type assertions (`as`, `!`) unless absolutely necessary
 - Use `function` keyword for declarations, not `const`
 - Prefer `undefined` over `null`

--- a/packages/ai-rules/rules/common/typeScript.md
+++ b/packages/ai-rules/rules/common/typeScript.md
@@ -17,6 +17,7 @@ description: "Writing ANY TypeScript code"
 
 ## Core Rules
 
+- Do not add ticket or issue numbers (e.g. Linear, Jira IDs) to code, variable names, or comments unless explicitly asked
 - Avoid type assertions (`as`, `!`) unless absolutely necessary
 - Use `function` keyword for declarations, not `const`
 - Prefer `undefined` over `null`

--- a/packages/ai-rules/rules/frontend/testing.md
+++ b/packages/ai-rules/rules/frontend/testing.md
@@ -14,6 +14,11 @@ Focus on integration tests—test how components work together as users experien
 
 Prefer user-centric queries in priority order: `getByRole`, `getByLabelText`, `getByText`; use `getByTestId` only as a last resort.
 
+## Visibility Assertions
+
+- Use `toBeVisible()` to assert an element is visible in the DOM (rendered and not hidden)
+- Use `not.toBeInTheDocument()` to assert an element does not exist in the DOM — do not use `not.toBeVisible()` for this case, as it passes even when the element is present but hidden
+
 ## MSW Handlers
 
 Export factory functions, not static handlers:


### PR DESCRIPTION
## Summary

Adds two new rules to `@clipboard-health/ai-rules`:

- **No ticket/issue numbers in code or comments** (`common/typeScript.md`): Agents must not embed Linear or Jira IDs in code, variable names, or comments unless the user explicitly asks. Applies to all TypeScript code via the `common` profile.
- **UI visibility assertion guidance** (`frontend/testing.md`): Clarifies the distinction between `toBeVisible()` (element is visible) and `not.toBeInTheDocument()` (element does not exist). Prevents the common mistake of using `not.toBeVisible()` to assert absence — it passes even when the element is present but hidden.

## Validation

- Source rules edited in `packages/ai-rules/rules/`
- `.rules/common/typeScript.md` updated in-repo (committed output for the `common` profile)
- Frontend rule propagates to consumer repos on `npm ci` via the `frontend`/`fullstack` profiles

## Notes

Agent session: `claude --resume 7fd64d69-8957-46e4-b37e-39625ef009d7`

<sub>🤖 <code>cb-ship:created v1 core@3.16.1</code></sub>