### PR TITLE
feat(ACT-5543): allow success() with no argument

### DIFF
--- a/packages/util-ts/src/lib/functional/serviceResult.test.ts
+++ b/packages/util-ts/src/lib/functional/serviceResult.test.ts
@@ -9,6 +9,7 @@ import {
   isFailure,
   isSuccess,
   mapFailure,
+  type ServiceResult,
   type Success,
   success,
   tryCatch,
@@ -30,6 +31,15 @@ describe("ServiceResult", () => {
       expect(isFailure(actual)).toBe(false);
       expect(actual.isSuccess).toBe(true);
       expect((actual as Success<{ data: string }>).value).toStrictEqual(input);
+    });
+
+    it("creates a void success result with no argument", () => {
+      // Assigning to ServiceResult<void> compiles only if success() is typed as such.
+      const actual: ServiceResult<void> = success();
+
+      expect(isSuccess(actual)).toBe(true);
+      expect(actual.isSuccess).toBe(true);
+      expect((actual as Success<void>).value).toBeUndefined();
     });
   });
 

--- a/packages/util-ts/src/lib/functional/serviceResult.ts
+++ b/packages/util-ts/src/lib/functional/serviceResult.ts
@@ -27,8 +27,12 @@ export type ServiceResult<A> = SuccessResult<A> | FailureResult;
 
 /**
  * Creates a successful ServiceResult.
+ *
+ * Call with no argument for a `ServiceResult<void>`; the value is `undefined`.
  */
-export function success<A>(value: A): ServiceResult<A> {
+export function success(): ServiceResult<void>;
+export function success<A>(value: A): ServiceResult<A>;
+export function success<A>(value?: A): ServiceResult<A | void> {
   return Object.freeze({
     isRight: true,
     isSuccess: true,


### PR DESCRIPTION
## Summary
- Adds a no-arg overload to `success` so a void result can be written `success()` instead of `success(undefined)`.
- `success(undefined)` trips `unicorn/no-useless-undefined`, forcing an inline disable at every `ServiceResult<void>` return (12+ sites in `clipboard-health` alone, plus other consumers). `success()` removes the need for both the `undefined` and the disable.
- Backward-compatible: `success(value)` is unchanged in type and behavior. The runtime impl already stores `value` as-is, so no-arg simply yields `value: undefined` — exactly what `ServiceResult<void>` means.

Versioning is automatic via `nx release` (conventional commits); the `feat` scope produces a minor bump.

## Linear
https://linear.app/clipboardhealth/issue/ACT-5543/util-ts-allow-success-with-no-argument-for-serviceresultvoid

## Test plan
- [x] `nx build util-ts` (tsgo) passes — the overload and the `const x: ServiceResult<void> = success()` type-lock in the test compile.
- [x] `nx test util-ts` passes, including a new case asserting `success()` is a void success with `value === undefined`.
- [x] `nx lint util-ts` passes.
- [x] Existing `success(value)` test and all other suites unchanged.

Follow-up (separate, per consuming repo): bump `@clipboard-health/util-ts` and replace `success(undefined)` + the `no-useless-undefined` disable with `success()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)