### PR TITLE
fix: publish ai-rules patch

### DIFF
--- a/packages/ai-rules/scripts/toErrorMessage.ts
+++ b/packages/ai-rules/scripts/toErrorMessage.ts
@@ -1,4 +1,4 @@
-// Prefer stack over message for Error instances to preserve debugging context.
+// Prefer stack over message for Error instances to preserve debugging context!
 export function toErrorMessage(error: unknown): string {
   return error instanceof Error ? (error.stack ?? error.message) : String(error);
 }


### PR DESCRIPTION
## Summary

Make a one-character code comment change in `packages/ai-rules` so Nx Release publishes a new patch version.

## Validation

- `npx nx run-many --projects=ai-rules --targets=lint,test,build`: lint and test passed; the build command was rerun successfully as `node --import tsx scripts/build.ts --outputPath=dist/packages/ai-rules` because this host blocks the `tsx` CLI IPC pipe.
- `node --run verify`: 9/10 checks passed; the blocked `embed:check` was rerun successfully through `node --import tsx` with identical arguments.
- Three simplification reviews: no findings.
- `cb-review --effort low --report`: no findings.

## Notes

Agent session: `codex resume 019f639b-84d4-7793-8143-dc0914994ee5`

<sub>🤖 <code>cb-ship:created v1 core@3.17.0</code></sub>