### PR TITLE
feat(util-ts): add isRecord type guard

### DIFF
--- a/packages/util-ts/src/index.ts
+++ b/packages/util-ts/src/index.ts
@@ -5,6 +5,7 @@ export * from "./lib/forceCast";
 export * from "./lib/functional";
 export type * from "./lib/logger";
 export * from "./lib/nullish";
+export * from "./lib/objects";
 export * from "./lib/strings";
 export * from "./lib/strings/parseJson";
 export type * from "./lib/types";

--- a/packages/util-ts/src/lib/objects/index.ts
+++ b/packages/util-ts/src/lib/objects/index.ts
@@ -1,0 +1,1 @@
+export * from "./isRecord";

--- a/packages/util-ts/src/lib/objects/isRecord.test.ts
+++ b/packages/util-ts/src/lib/objects/isRecord.test.ts
@@ -1,0 +1,20 @@
+import { isRecord } from "./isRecord";
+
+describe(isRecord, () => {
+  it.each([
+    { input: {}, expected: true },
+    { input: { a: 1 }, expected: true },
+    { input: Object.create(null) as unknown, expected: true },
+    { input: [], expected: false },
+    { input: [1, 2, 3], expected: false },
+    { input: null, expected: false },
+    { input: undefined, expected: false },
+    { input: "", expected: false },
+    { input: 0, expected: false },
+    { input: false, expected: false },
+  ])("returns $expected for $input", ({ input, expected }) => {
+    const actual = isRecord(input);
+
+    expect(actual).toBe(expected);
+  });
+});

--- a/packages/util-ts/src/lib/objects/isRecord.ts
+++ b/packages/util-ts/src/lib/objects/isRecord.ts
@@ -1,5 +1,6 @@
 /**
- * Type guard that checks if a value is a plain record: a non-null object that is not an array.
+ * Type guard that checks if a value is a non-null, non-array object (e.g. `{}`, `Date`, `Map`,
+ * a class instance) — narrowed to `Record<string, unknown>` for keyed property access.
  *
  * @param value - The value to check
  * @returns True if the value is a record, false otherwise

--- a/packages/util-ts/src/lib/objects/isRecord.ts
+++ b/packages/util-ts/src/lib/objects/isRecord.ts
@@ -1,0 +1,9 @@
+/**
+ * Type guard that checks if a value is a plain record: a non-null object that is not an array.
+ *
+ * @param value - The value to check
+ * @returns True if the value is a record, false otherwise
+ */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
Summary
  ===

  What changes were made?
  ---
  - Added a new `isRecord(value): value is Record<string, unknown>` type guard to `@clipboard-health/util-ts` at
  `packages/util-ts/src/lib/objects/isRecord.ts`, excluding arrays (and `null`)
  - Added a new `objects` category (`packages/util-ts/src/lib/objects/index.ts`) and exported it from the package
  root (`packages/util-ts/src/index.ts`)
  - Added `isRecord.test.ts` with 10 cases covering plain objects, `Object.create(null)`, arrays,
  `null`/`undefined`, and primitives

  Why were these changes made
  ---
  - ACT-5494: three near-identical `isRecord` guards are duplicated across `documents-service-backend`
  (`prisma.errors.ts`, `eligibility/json.utils.ts`, `object-query/types.ts`), flagged as a nit on PR #2175 since
  the correct home for a generic type guard is the shared `util-ts` package, not a feature module
  - Excludes arrays to match 2 of the 3 existing local implementations (only `prisma.errors.ts`'s version included
  arrays)
  - This is a standalone library change that unblocks the `documents-service-backend` cleanup — that repo's
  consolidation PR will follow once this is merged and released

  Notes
  ===

  Checklist :heavy_check_mark:
  ---
  - [x] I have added tests that prove my fix is effective or that my feature works.
  - [ ] I have added necessary documentation (if appropriate).

  Screenshots/Video :camera:
  ---
  - No UI changes — pure utility function addition to a shared library. 10 tests passing covering plain objects,
  `Object.create(null)`, arrays, nullish values, and primitives; package lint and build also verified clean.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/clipboardhealth/core-utils/pull/782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->