### PR TITLE
feat: add Playwright anti-flake toolkit (STAFF-1814)

### DIFF
--- a/.rules/common/coreLibraries.md
+++ b/.rules/common/coreLibraries.md
@@ -30,12 +30,12 @@ When a bug traces into a `@clipboard-health/*` library, read the source code in 
 - **execution-context**: A lightweight Node.js utility for managing execution contexts and metadata aggregation using AsyncLocalStorage.
 - **json-api**: TypeScript-friendly utilities for adhering to the JSON:API specification.
 - **json-api-nestjs**: TypeScript-friendly utilities for adhering to the JSON:API specification with NestJS.
-- **mongo-jobs**: MongoDB-powered background jobs.
 - **notifications**: Send notifications through third-party providers.
 - **nx-plugin**: An Nx plugin with generators to manage libraries and applications.
 - **oxlint-config**: Shared Oxlint configuration for Clipboard Health repositories.
 - **phone-number**: Phone number utility functions.
 - **playwright-reporter-llm**: Playwright reporter that outputs structured JSON for LLM agents. Minimal console output, flat schema, easy to filter to failures.
+- **playwright-toolkit**: Shared anti-flake primitives for Clipboard Health Playwright suites.
 - **rules-engine**: A pure functional rules engine to keep logic-dense code simple, reliable, understandable, and explainable.
 - **testing-core**: TypeScript-friendly testing utilities.
 - **util-ts**: TypeScript utilities.

--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@
 - [execution-context](./packages/execution-context/README.md): A lightweight Node.js utility for managing execution contexts and metadata aggregation using AsyncLocalStorage.
 - [json-api](./packages/json-api/README.md): TypeScript-friendly utilities for adhering to the JSON:API specification.
 - [json-api-nestjs](./packages/json-api-nestjs/README.md): TypeScript-friendly utilities for adhering to the JSON:API specification with NestJS.
-- [mongo-jobs](./packages/mongo-jobs/README.md): MongoDB-powered background jobs.
 - [notifications](./packages/notifications/README.md): Send notifications through third-party providers.
 - [nx-plugin](./packages/nx-plugin/README.md): An Nx plugin with generators to manage libraries and applications.
 - [oxlint-config](./packages/oxlint-config/README.md): Shared Oxlint configuration for Clipboard Health repositories.
 - [phone-number](./packages/phone-number/README.md): Phone number utility functions.
 - [playwright-reporter-llm](./packages/playwright-reporter-llm/README.md): Playwright reporter that outputs structured JSON for LLM agents. Minimal console output, flat schema, easy to filter to failures.
+- [playwright-toolkit](./packages/playwright-toolkit/README.md): Shared anti-flake primitives for Clipboard Health Playwright suites.
 - [rules-engine](./packages/rules-engine/README.md): A pure functional rules engine to keep logic-dense code simple, reliable, understandable, and explainable.
 - [testing-core](./packages/testing-core/README.md): TypeScript-friendly testing utilities.
 - [util-ts](./packages/util-ts/README.md): TypeScript utilities.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2986,6 +2986,10 @@
       "resolved": "packages/playwright-reporter-llm",
       "link": true
     },
+    "node_modules/@clipboard-health/playwright-toolkit": {
+      "resolved": "packages/playwright-toolkit",
+      "link": true
+    },
     "node_modules/@clipboard-health/rules-engine": {
       "resolved": "packages/rules-engine",
       "link": true
@@ -35008,6 +35012,21 @@
       "version": "2.5.11",
       "license": "MIT",
       "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "devDependencies": {
+        "@playwright/test": "1.61.1"
+      },
+      "peerDependencies": {
+        "@playwright/test": ">=1.50.0"
+      }
+    },
+    "packages/playwright-toolkit": {
+      "name": "@clipboard-health/playwright-toolkit",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@clipboard-health/util-ts": "5.11.0",
         "tslib": "2.8.1"
       },
       "devDependencies": {

--- a/packages/ai-rules/rules/common/coreLibraries.md
+++ b/packages/ai-rules/rules/common/coreLibraries.md
@@ -30,12 +30,12 @@ When a bug traces into a `@clipboard-health/*` library, read the source code in 
 - **execution-context**: A lightweight Node.js utility for managing execution contexts and metadata aggregation using AsyncLocalStorage.
 - **json-api**: TypeScript-friendly utilities for adhering to the JSON:API specification.
 - **json-api-nestjs**: TypeScript-friendly utilities for adhering to the JSON:API specification with NestJS.
-- **mongo-jobs**: MongoDB-powered background jobs.
 - **notifications**: Send notifications through third-party providers.
 - **nx-plugin**: An Nx plugin with generators to manage libraries and applications.
 - **oxlint-config**: Shared Oxlint configuration for Clipboard Health repositories.
 - **phone-number**: Phone number utility functions.
 - **playwright-reporter-llm**: Playwright reporter that outputs structured JSON for LLM agents. Minimal console output, flat schema, easy to filter to failures.
+- **playwright-toolkit**: Shared anti-flake primitives for Clipboard Health Playwright suites.
 - **rules-engine**: A pure functional rules engine to keep logic-dense code simple, reliable, understandable, and explainable.
 - **testing-core**: TypeScript-friendly testing utilities.
 - **util-ts**: TypeScript utilities.

--- a/packages/playwright-toolkit/.eslintrc.json
+++ b/packages/playwright-toolkit/.eslintrc.json
@@ -1,0 +1,21 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*", "**/*.json", "!**/package.json"],
+  "parserOptions": {
+    "project": "packages/playwright-toolkit/tsconfig.lint.json"
+  },
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {
+        "security/detect-non-literal-fs-filename": "off",
+        "unicorn/filename-case": ["error", { "case": "camelCase" }]
+      }
+    }
+  ],
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  }
+}

--- a/packages/playwright-toolkit/README.md
+++ b/packages/playwright-toolkit/README.md
@@ -1,0 +1,221 @@
+# `@clipboard-health/playwright-toolkit`
+
+Shared anti-flake primitives for Clipboard Health Playwright suites.
+
+The package owns retry policy, APM correlation, shared admin-token caching, deployed-asset checks, Mailpit polling, Cognito login diagnostics, and setup retry classification. Consuming repositories keep only configuration and domain-specific matching.
+
+## Install
+
+```bash
+npm install --save-dev @clipboard-health/playwright-toolkit
+```
+
+`@playwright/test` is a peer dependency. The package supports Playwright 1.50 and newer.
+
+## API map
+
+| Local capability                        | Package replacement                                                                      |
+| --------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `retryWithBail`                         | `runWithRetry({ mode: { kind: "classified", ... } })`                                    |
+| `retryUntilPassOrTimeout`               | `runWithRetry({ mode: { kind: "poll", ... } })`                                          |
+| Copy-pasted traceparent page fixture    | `createTraceparentFixtures()`                                                            |
+| Admin token promise cache and file lock | `generateAdminAuthToken()` or `getOrCreateAdminAuthToken()`                              |
+| Deployed frontend/mobile asset loops    | `verifyDeployedAssets()` and `waitForDeployedAssets()`                                   |
+| Mailpit search/fetch loops              | `createMailpitClient()`, `fetchMagicLinkFromMailpit()`, `fetchEmailOtpCodeFromMailpit()` |
+| Cognito OTP redirect debugging          | `fillOtpAndWaitForCognitoRedirect()`                                                     |
+| Setup HTTP and identity retry checks    | `classifySetupRetry()` and `isRetryableHttpStatus()`                                     |
+
+## Retry contract
+
+`runWithRetry` is the only retry abstraction in this package. It has two modes because retries and polling answer different questions.
+
+### Classified retry
+
+Use classified retry for an operation that should normally pass on the first attempt. The caller must provide `isTransient`. There is no default that retries arbitrary failures.
+
+```typescript
+import { runWithRetry } from "@clipboard-health/playwright-toolkit";
+
+const result = await runWithRetry({
+  operationName: "create shift offer",
+  operation: async () => await createShiftOffer(),
+  mode: {
+    kind: "classified",
+    maxAttempts: 4,
+    delayMs: 2000,
+    isTransient: ({ error }) => isKnownCdcReadinessError(error),
+  },
+});
+
+const shiftOffer = result.value;
+```
+
+A legal classified retry satisfies the flaky-critic B1 contract:
+
+- The operation is safe to repeat.
+- `isTransient` positively identifies a known transient condition.
+- Validation, permission, and other deterministic failures return `false`.
+- The retry has a fixed attempt budget.
+- Exhaustion throws `RetryError` with the attempt count, elapsed time, terminal reason, and last cause.
+
+Do not use a broad status such as every `422` as the predicate. Match the specific readiness message or service condition that can resolve without changing the request.
+
+### Poll until pass
+
+Use poll mode for an idempotent readiness probe where failure means "not ready yet."
+
+```typescript
+const result = await runWithRetry({
+  operationName: "wait for worker profile",
+  operation: async () => await assertWorkerProfileReady(),
+  mode: {
+    kind: "poll",
+    timeoutMs: 90_000,
+    intervalsMs: [1000, 2000, 3000, 5000],
+  },
+});
+```
+
+Set `mode.isTransient` when the probe can also throw deterministic failures. Returning `false` stops immediately with `reason: "non-transient"`.
+
+Poll mode races each attempt against the remaining timeout budget and aborts the attempt's `signal` when the deadline expires. Pass that signal to network calls so timed-out work is cancelled:
+
+```typescript
+operation: async ({ signal }) =>
+  await fetch(readinessUrl, {
+    signal,
+  });
+```
+
+## Per-test traceparent fixture
+
+Extend the repository's existing Playwright test object once:
+
+```typescript
+import { test as base } from "@playwright/test";
+import {
+  createTraceparentFixtures,
+  type TraceparentFixtures,
+} from "@clipboard-health/playwright-toolkit";
+
+export const test = base.extend<TraceparentFixtures>(createTraceparentFixtures());
+```
+
+The auto fixture creates one non-zero W3C `traceparent`, preserves project-level `extraHTTPHeaders`, installs the merged headers on the browser context before the test body runs, and adds a `traceparent` test annotation. Pass existing headers to `installTraceparentForTest` if a custom fixture installs the header manually.
+
+## Admin tokens
+
+`generateAdminAuthToken` runs `cbh auth gentoken user`, retries only approved transient CLI signatures, redacts the admin email from errors, and caches the bearer token behind an atomic filesystem lock.
+
+```typescript
+const tokenEntry = await generateAdminAuthToken({
+  adminEmail: adminUser.email,
+  apiEnvironmentName: "staging",
+  clientName: "admin-app",
+  cacheDurationMs: 10 * 60 * 1000,
+});
+
+const adminAuthToken = tokenEntry.authToken;
+```
+
+The cache key contains the environment and a SHA-256 email digest, not the email. The cache and lock files use mode `0600`. A process that acquires the lock re-reads the cache before generating, which prevents duplicate token mints across Playwright workers and shards.
+
+Use `getOrCreateAdminAuthToken` when the repository needs a different token command:
+
+```typescript
+const tokenEntry = await getOrCreateAdminAuthToken({
+  adminEmail,
+  apiEnvironmentName,
+  cacheDurationMs: 10 * 60 * 1000,
+  createToken: async () => await generateTokenWithRepositoryCli(),
+});
+```
+
+## Deployed assets
+
+Repository wrappers still discover assets and decide which files are runtime or fingerprinted. The package owns request concurrency, timeouts, cache busting, content-type checks, transient HTTP retries, attempt diagnostics, and stable-window polling.
+
+```typescript
+const report = await waitForDeployedAssets({
+  checks: localAssetManifest.map((asset) => ({
+    path: asset.path,
+    url: new URL(asset.path, deploymentBaseUrl).toString(),
+    method: asset.isFingerprintNamedJavaScript ? "GET" : "HEAD",
+    cacheMode: asset.isRuntimeAsset ? "cache-busted" : "normal",
+    expectedContentTypes: [asset.contentType],
+  })),
+  timeoutMs: 10 * 60 * 1000,
+  pollIntervalMs: 10_000,
+  stableWindowMs: 30_000,
+});
+```
+
+HTTP `408`, `425`, `429`, and `5xx` responses are transient for asset delivery. Content-type mismatches and failed custom validators are deterministic unless the validator returns `isTransient: true`.
+
+Use `validateResponse` for repository-specific checks such as `build-info.json` commit matching. The verifier does not consume a successful response body before calling the wrapper, so the callback can read it directly.
+
+## Mailpit
+
+Create a client from repository configuration, then use the typed pollers:
+
+```typescript
+const mailpit = createMailpitClient({
+  password: process.env.MAILPIT_PASSWORD ?? "",
+});
+
+const code = await fetchEmailOtpCodeFromMailpit({
+  client: mailpit,
+  email,
+  sentAfter: codeRequestedAt,
+  excludeCodes: [previousCode],
+});
+
+await page.getByLabel("Verification Code").fill(code.value);
+```
+
+The pollers search newest-first, tolerate incomplete dates in search results, fetch at most three candidates per probe, and retry Mailpit network errors, `404`, `408`, `429`, and `5xx`. They return both the extracted value and source message ID.
+
+## Cognito OTP and login diagnostics
+
+`fillOtpAndWaitForCognitoRedirect` monitors `RespondToAuthChallenge` requests for `SMS_OTP` and `EMAIL_OTP` while it waits for the expected redirect.
+
+```typescript
+await fillOtpAndWaitForCognitoRedirect({
+  page,
+  testInfo,
+  otp,
+  expectedUrl: /\/dashboard/,
+});
+```
+
+On failure, the error includes the sanitized Cognito request summary, response or request-failure detail, current URL, and visible page-text sample. When `testInfo` is provided, it attaches a redacted screenshot. `sanitizeCognitoDiagnosticText` and `isCognitoOtpChallengeRequest` are public for repository-specific login flows.
+
+## Setup retry classification
+
+`classifySetupRetry` separates identity collisions from transient infrastructure failures:
+
+```typescript
+const classification = classifySetupRetry({
+  error,
+  isIdentityCollision: ({ error: candidate }) => isWorkerCreationPhoneCollision(candidate),
+});
+```
+
+The result follows the flaky-critic C1 contract:
+
+| Classification       | Decision              | Identity behavior                                             |
+| -------------------- | --------------------- | ------------------------------------------------------------- |
+| `identity-collision` | `regenerate-identity` | Generate a fresh phone, email, or ID before the next attempt. |
+| `transient`          | `retry-same-identity` | Repeat the same request and identity.                         |
+| `deterministic`      | `do-not-retry`        | Fail immediately.                                             |
+
+`isRetryableHttpStatus` returns `true` only for `408`, `429`, and `5xx`. A repository can add a narrow `isTransientError` predicate for a known non-HTTP transient signature.
+
+## Migration checklist
+
+1. Replace the local helper import with the package export.
+2. Move repository-specific URLs, selectors, asset discovery, and error-message matching into a thin wrapper.
+3. Keep retry classification narrow. Record why the operation is safe to repeat.
+4. For identity collisions, generate the identity inside the retry operation so each collision attempt gets a fresh value.
+5. Delete the local helper and port its boundary tests to the wrapper.
+6. Run the consuming repository's Playwright unit tests and E2E setup checks.

--- a/packages/playwright-toolkit/package.json
+++ b/packages/playwright-toolkit/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@clipboard-health/playwright-toolkit",
+  "version": "0.1.0",
+  "description": "Shared anti-flake primitives for Clipboard Health Playwright suites.",
+  "keywords": [
+    "cognito",
+    "e2e",
+    "flaky-tests",
+    "mailpit",
+    "playwright",
+    "retry",
+    "testing",
+    "traceparent"
+  ],
+  "bugs": "https://github.com/ClipboardHealth/core-utils/issues",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ClipboardHealth/core-utils.git",
+    "directory": "packages/playwright-toolkit"
+  },
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "typings": "./src/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@clipboard-health/util-ts": "5.11.0",
+    "tslib": "2.8.1"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.61.1"
+  },
+  "peerDependencies": {
+    "@playwright/test": ">=1.50.0"
+  }
+}

--- a/packages/playwright-toolkit/project.json
+++ b/packages/playwright-toolkit/project.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "playwright-toolkit",
+  "projectType": "library",
+  "sourceRoot": "packages/playwright-toolkit/src",
+  "tags": [],
+  "targets": {
+    "build": {
+      "dependsOn": ["prepare-build-package", "^build"],
+      "inputs": ["packageBuild", "^production"],
+      "outputs": ["{workspaceRoot}/dist/packages/playwright-toolkit"],
+      "options": {
+        "forwardAllArgs": false
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "options": {
+        "lintFilePatterns": ["packages/playwright-toolkit/**/*.[jt]s?(x)"],
+        "maxWarnings": 0
+      },
+      "outputs": ["{options.outputFile}"]
+    },
+    "test": {
+      "executor": "@nx/vitest:test",
+      "options": {
+        "configFile": "packages/playwright-toolkit/vitest.config.ts"
+      }
+    },
+    "prepare-build-package": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "env -u NO_COLOR node --import tsx scripts/prepareTsgoPackage.mts packages/playwright-toolkit"
+      }
+    }
+  }
+}

--- a/packages/playwright-toolkit/src/index.ts
+++ b/packages/playwright-toolkit/src/index.ts
@@ -1,0 +1,7 @@
+export * from "./lib/adminAuthToken";
+export * from "./lib/cognitoDiagnostics";
+export * from "./lib/deployedAssets";
+export * from "./lib/mailpit";
+export * from "./lib/retry";
+export * from "./lib/setupRetry";
+export * from "./lib/traceparent";

--- a/packages/playwright-toolkit/src/lib/adminAuthToken.test.ts
+++ b/packages/playwright-toolkit/src/lib/adminAuthToken.test.ts
@@ -71,6 +71,29 @@ describe("getOrCreateAdminAuthToken", () => {
     });
   });
 
+  it("keeps cache entries distinct when environment names sanitize identically", async () => {
+    const commonInput = {
+      adminEmail: "e2e@clipboardhealth.com",
+      cacheDirectory,
+      cacheDurationMs: 60_000,
+    };
+
+    const slashEnvironment = await getOrCreateAdminAuthToken({
+      ...commonInput,
+      apiEnvironmentName: "pr/123",
+      createToken: async () => "Bearer slash-environment",
+    });
+    const underscoreEnvironment = await getOrCreateAdminAuthToken({
+      ...commonInput,
+      apiEnvironmentName: "pr_123",
+      createToken: async () => "Bearer underscore-environment",
+    });
+
+    expect(slashEnvironment.authToken).toBe("Bearer slash-environment");
+    expect(underscoreEnvironment.authToken).toBe("Bearer underscore-environment");
+    await expect(readdir(cacheDirectory)).resolves.toHaveLength(2);
+  });
+
   it("rejects malformed generated tokens without caching them", async () => {
     const input = {
       adminEmail: "e2e@clipboardhealth.com",

--- a/packages/playwright-toolkit/src/lib/adminAuthToken.test.ts
+++ b/packages/playwright-toolkit/src/lib/adminAuthToken.test.ts
@@ -1,0 +1,164 @@
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  type AdminAuthTokenCommandRunner,
+  generateAdminAuthToken,
+  getOrCreateAdminAuthToken,
+} from "../index";
+
+describe("getOrCreateAdminAuthToken", () => {
+  let cacheDirectory: string;
+
+  beforeEach(async () => {
+    cacheDirectory = await mkdtemp(path.join(tmpdir(), "playwright-toolkit-token-"));
+  });
+
+  afterEach(async () => {
+    await rm(cacheDirectory, { force: true, recursive: true });
+  });
+
+  it("serializes concurrent token generation through the shared lock", async () => {
+    let resolveToken: ((value: string) => void) | undefined;
+    const tokenPromise = new Promise<string>((resolve) => {
+      resolveToken = resolve;
+    });
+    const mockCreateToken = vi.fn<() => Promise<string>>(async () => await tokenPromise);
+    const input = {
+      adminEmail: "e2e@clipboardhealth.com",
+      apiEnvironmentName: "staging",
+      cacheDirectory,
+      cacheDurationMs: 60_000,
+      createToken: mockCreateToken,
+      lockRetryDelayMs: 1,
+      lockRetryJitterMs: 0,
+    };
+
+    const firstPromise = getOrCreateAdminAuthToken(input);
+    const secondPromise = getOrCreateAdminAuthToken(input);
+    await vi.waitFor(() => {
+      expect(mockCreateToken).toHaveBeenCalledTimes(1);
+    });
+    resolveToken?.("Bearer shared-token");
+
+    const [first, second] = await Promise.all([firstPromise, secondPromise]);
+
+    expect(first).toEqual(second);
+    expect(first.authToken).toBe("Bearer shared-token");
+    expect(mockCreateToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not expose the admin email in cache file names", async () => {
+    await getOrCreateAdminAuthToken({
+      adminEmail: "e2e@clipboardhealth.com",
+      apiEnvironmentName: "pr/123",
+      cacheDirectory,
+      cacheDurationMs: 60_000,
+      createToken: async () => "Bearer generated-token",
+    });
+
+    const cacheDirectoryEntries = await readdir(cacheDirectory);
+    const cacheFileNames = cacheDirectoryEntries.filter((fileName) => fileName.endsWith(".json"));
+    expect(cacheFileNames).toHaveLength(1);
+    const [cacheFileName = ""] = cacheFileNames;
+    const fileContents = await readFile(path.join(cacheDirectory, cacheFileName), "utf8");
+
+    expect(cacheFileName).not.toContain("e2e@clipboardhealth.com");
+    expect(cacheFileName).toContain("pr_123");
+    expect(JSON.parse(fileContents)).toMatchObject({
+      authToken: "Bearer generated-token",
+    });
+  });
+
+  it("rejects malformed generated tokens without caching them", async () => {
+    const input = {
+      adminEmail: "e2e@clipboardhealth.com",
+      apiEnvironmentName: "staging",
+      cacheDirectory,
+      cacheDurationMs: 60_000,
+      createToken: vi
+        .fn<() => Promise<string>>()
+        .mockResolvedValueOnce("invalid-token")
+        .mockResolvedValueOnce("Bearer recovered-token"),
+    };
+
+    await expect(getOrCreateAdminAuthToken(input)).rejects.toThrow(
+      "Generated admin auth token is malformed",
+    );
+    await expect(getOrCreateAdminAuthToken(input)).resolves.toMatchObject({
+      authToken: "Bearer recovered-token",
+    });
+  });
+
+  it("retries approved transient CLI failures and caches the generated token", async () => {
+    const mockCommandRunner = vi
+      .fn<AdminAuthTokenCommandRunner>()
+      .mockRejectedValueOnce(
+        new Error("Error initiating custom challenge MAKE_TEST_TOKEN: Too many requests"),
+      )
+      .mockResolvedValueOnce({ stdout: "generated-token\n", stderr: "" });
+
+    const actual = await generateAdminAuthToken({
+      adminEmail: "e2e@clipboardhealth.com",
+      apiEnvironmentName: "staging",
+      cacheDirectory,
+      cacheDurationMs: 60_000,
+      commandRunner: mockCommandRunner,
+      sleepImplementation: async () => {
+        await Promise.resolve();
+      },
+      retryJitterMs: 0,
+    });
+
+    expect(actual.authToken).toBe("Bearer generated-token");
+    expect(mockCommandRunner).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries CLI timeouts reported through an error cause", async () => {
+    const timeoutCause = {
+      code: "ETIMEDOUT",
+      killed: true,
+      signal: "SIGTERM",
+    };
+    const mockCommandRunner = vi
+      .fn<AdminAuthTokenCommandRunner>()
+      .mockRejectedValueOnce(new Error("Command failed", { cause: timeoutCause }))
+      .mockResolvedValueOnce({ stdout: "generated-token\n", stderr: "" });
+
+    const actual = await generateAdminAuthToken({
+      adminEmail: "e2e@clipboardhealth.com",
+      apiEnvironmentName: "staging",
+      cacheDirectory,
+      cacheDurationMs: 60_000,
+      commandRunner: mockCommandRunner,
+      sleepImplementation: async () => {
+        await Promise.resolve();
+      },
+      retryJitterMs: 0,
+    });
+
+    expect(actual.authToken).toBe("Bearer generated-token");
+    expect(mockCommandRunner).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry or expose the admin email for deterministic CLI failures", async () => {
+    const mockCommandRunner = vi
+      .fn<AdminAuthTokenCommandRunner>()
+      .mockRejectedValue(new Error("invalid request for user"));
+
+    const actualPromise = generateAdminAuthToken({
+      adminEmail: "e2e@clipboardhealth.com",
+      apiEnvironmentName: "staging",
+      cacheDirectory,
+      cacheDurationMs: 60_000,
+      commandRunner: mockCommandRunner,
+      sleepImplementation: async () => {
+        await Promise.resolve();
+      },
+    });
+
+    await expect(actualPromise).rejects.not.toThrow("e2e@clipboardhealth.com");
+    expect(mockCommandRunner).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/playwright-toolkit/src/lib/adminAuthToken.ts
+++ b/packages/playwright-toolkit/src/lib/adminAuthToken.ts
@@ -294,8 +294,10 @@ function getCachePaths(params: GetOrCreateAdminAuthTokenParams): AdminAuthTokenC
   const cacheDirectoryPath =
     params.cacheDirectory ?? path.join(tmpdir(), DEFAULT_CACHE_DIRECTORY_NAME);
   const environmentSegment = params.apiEnvironmentName.replaceAll(/[^a-zA-Z0-9._-]/g, "_");
-  const emailHash = createDeterministicHash(params.adminEmail).slice(0, 16);
-  const cacheFileName = `admin-auth-token-${environmentSegment}-${emailHash}.json`;
+  const cacheKeyHash = createDeterministicHash(
+    `${params.apiEnvironmentName}\0${params.adminEmail}`,
+  ).slice(0, 16);
+  const cacheFileName = `admin-auth-token-${environmentSegment}-${cacheKeyHash}.json`;
 
   return {
     cacheDirectoryPath,

--- a/packages/playwright-toolkit/src/lib/adminAuthToken.ts
+++ b/packages/playwright-toolkit/src/lib/adminAuthToken.ts
@@ -1,0 +1,544 @@
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createDeterministicHash, isRecord } from "@clipboard-health/util-ts";
+
+import { runWithRetry } from "./retry";
+
+// cspell:ignore defineauthchallenge getparameters maketesttoken
+const DEFAULT_CACHE_DIRECTORY_NAME = "clipboard-health-playwright-admin-auth";
+const DEFAULT_LOCK_STALE_AFTER_MS = 5 * 60 * 1000;
+const DEFAULT_LOCK_WAIT_TIMEOUT_MS = 6 * 60 * 1000;
+const DEFAULT_LOCK_RETRY_DELAY_MS = 250;
+const DEFAULT_LOCK_RETRY_JITTER_MS = 250;
+const BEARER_TOKEN_PREFIX = "Bearer ";
+const DEFAULT_COMMAND_TIMEOUT_MS = 30_000;
+const DEFAULT_GENERATION_MAX_ATTEMPTS = 4;
+const DEFAULT_GENERATION_RETRY_DELAY_MS = 2000;
+const DEFAULT_GENERATION_RETRY_JITTER_MS = 1000;
+const REDACTED_USER_LABEL = "[redacted-user]";
+
+export interface AdminAuthTokenCacheEntry {
+  authToken: string;
+  expiresAtMs: number;
+}
+
+export interface GetOrCreateAdminAuthTokenParams {
+  adminEmail: string;
+  apiEnvironmentName: string;
+  cacheDurationMs: number;
+  createToken: () => Promise<string>;
+  cacheDirectory?: string | undefined;
+  lockStaleAfterMs?: number | undefined;
+  lockWaitTimeoutMs?: number | undefined;
+  lockRetryDelayMs?: number | undefined;
+  lockRetryJitterMs?: number | undefined;
+  nowImplementation?: (() => number) | undefined;
+  randomImplementation?: (() => number) | undefined;
+  sleepImplementation?: ((params: { durationMs: number }) => Promise<void>) | undefined;
+}
+
+export interface AdminAuthTokenCommandResult {
+  stdout: string;
+  stderr: string;
+}
+
+export interface AdminAuthTokenCommandRunnerParams {
+  executable: string;
+  arguments: readonly string[];
+  timeoutMs: number;
+}
+
+export type AdminAuthTokenCommandRunner = (
+  params: AdminAuthTokenCommandRunnerParams,
+) => Promise<AdminAuthTokenCommandResult>;
+
+export interface GenerateAdminAuthTokenParams extends Omit<
+  GetOrCreateAdminAuthTokenParams,
+  "createToken"
+> {
+  clientName?: string | undefined;
+  commandExecutable?: string | undefined;
+  commandRunner?: AdminAuthTokenCommandRunner | undefined;
+  commandTimeoutMs?: number | undefined;
+  generationMaxAttempts?: number | undefined;
+  generationRetryDelayMs?: number | undefined;
+  retryJitterMs?: number | undefined;
+}
+
+interface StoredAdminAuthTokenCacheEntry {
+  authToken: string;
+  expiresAtMs: number;
+}
+
+interface AdminAuthTokenCachePaths {
+  cacheDirectoryPath: string;
+  cacheFilePath: string;
+  lockFilePath: string;
+}
+
+interface AdminAuthTokenLock {
+  ownerId: string;
+  createdAtMs: number;
+  pid: number;
+}
+
+/**
+ * Returns a valid cached admin token or creates one while holding an atomic
+ * filesystem lock shared by Playwright workers, shards, and local processes.
+ */
+export async function getOrCreateAdminAuthToken(
+  params: GetOrCreateAdminAuthTokenParams,
+): Promise<AdminAuthTokenCacheEntry> {
+  validateParams(params);
+
+  const cachePaths = getCachePaths(params);
+  const nowImplementation = params.nowImplementation ?? Date.now;
+
+  await mkdir(cachePaths.cacheDirectoryPath, { recursive: true });
+
+  const cachedEntry = await readCachedEntry({
+    cacheFilePath: cachePaths.cacheFilePath,
+    nowImplementation,
+  });
+  if (cachedEntry !== undefined) {
+    return cachedEntry;
+  }
+
+  return await getOrCreateWithLock({
+    ...params,
+    cachePaths,
+    nowImplementation,
+  });
+}
+
+/**
+ * Generates an admin token with classified CLI retries, redacted errors, and
+ * the lock-serialized cross-process cache.
+ */
+export async function generateAdminAuthToken(
+  params: GenerateAdminAuthTokenParams,
+): Promise<AdminAuthTokenCacheEntry> {
+  return await getOrCreateAdminAuthToken({
+    ...params,
+    createToken: async () => {
+      const result = await runWithRetry({
+        operationName: "generate admin auth token",
+        operation: async () => {
+          try {
+            const commandResult = await (params.commandRunner ?? runAdminAuthTokenCommand)({
+              executable: params.commandExecutable ?? "cbh",
+              arguments: getTokenCommandArguments(params),
+              timeoutMs: params.commandTimeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS,
+            });
+            const rawToken = commandResult.stdout.split("\n")[0]?.trim();
+
+            if (rawToken === undefined || rawToken.length === 0) {
+              throw new Error("Token generation returned an empty token");
+            }
+
+            return `${BEARER_TOKEN_PREFIX}${rawToken}`;
+          } catch (error: unknown) {
+            throw createSafeAdminAuthTokenError({
+              adminEmail: params.adminEmail,
+              commandTimeoutMs: params.commandTimeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS,
+              error,
+            });
+          }
+        },
+        mode: {
+          kind: "classified",
+          maxAttempts: params.generationMaxAttempts ?? DEFAULT_GENERATION_MAX_ATTEMPTS,
+          delayMs: ({ attemptNumber }) =>
+            (params.generationRetryDelayMs ?? DEFAULT_GENERATION_RETRY_DELAY_MS) * attemptNumber +
+            Math.floor(
+              (params.randomImplementation?.() ?? Math.random()) *
+                (params.retryJitterMs ?? DEFAULT_GENERATION_RETRY_JITTER_MS),
+            ),
+          isTransient: ({ error }) => isRetryableAdminAuthTokenGenerationError({ error }),
+        },
+        sleepImplementation: params.sleepImplementation,
+        nowImplementation: params.nowImplementation,
+      });
+
+      return result.value;
+    },
+  });
+}
+
+export function isRetryableAdminAuthTokenGenerationError(params: { error: unknown }): boolean {
+  if (!(params.error instanceof Error)) {
+    return false;
+  }
+
+  const normalizedMessage = params.error.message.toLowerCase();
+
+  if (normalizedMessage.includes("timed out after")) {
+    return true;
+  }
+
+  if (normalizedMessage.includes("too many requests")) {
+    return true;
+  }
+
+  if (
+    normalizedMessage.includes("defineauthchallenge failed") &&
+    normalizedMessage.includes("ssm:getparameters") &&
+    normalizedMessage.includes("s2s-external-client/zendesk-auto-login/client_id")
+  ) {
+    return true;
+  }
+
+  return (
+    (normalizedMessage.includes("maketesttoken") ||
+      normalizedMessage.includes("make_test_token")) &&
+    normalizedMessage.includes("incorrect username or password")
+  );
+}
+
+export function isAdminAuthTokenExpired(params: {
+  cacheEntry: Pick<AdminAuthTokenCacheEntry, "expiresAtMs">;
+  nowMs?: number;
+}): boolean {
+  return (params.nowMs ?? Date.now()) >= params.cacheEntry.expiresAtMs;
+}
+
+async function getOrCreateWithLock(
+  params: GetOrCreateAdminAuthTokenParams & {
+    cachePaths: AdminAuthTokenCachePaths;
+    nowImplementation: () => number;
+  },
+): Promise<AdminAuthTokenCacheEntry> {
+  const waitStartedAtMs = params.nowImplementation();
+  const lockWaitTimeoutMs = params.lockWaitTimeoutMs ?? DEFAULT_LOCK_WAIT_TIMEOUT_MS;
+  const sleepImplementation = params.sleepImplementation ?? sleep;
+
+  /* eslint-disable no-await-in-loop -- Lock acquisition and ownership checks are sequential. */
+  while (params.nowImplementation() - waitStartedAtMs < lockWaitTimeoutMs) {
+    const lock = await tryAcquireLock({
+      lockFilePath: params.cachePaths.lockFilePath,
+      nowImplementation: params.nowImplementation,
+    });
+
+    if (lock !== undefined) {
+      try {
+        const cachedEntry = await readCachedEntry({
+          cacheFilePath: params.cachePaths.cacheFilePath,
+          nowImplementation: params.nowImplementation,
+        });
+        if (cachedEntry !== undefined) {
+          return cachedEntry;
+        }
+
+        const authToken = await params.createToken();
+        if (!isValidBearerToken(authToken)) {
+          throw new Error("Generated admin auth token is malformed");
+        }
+
+        const storedEntry = {
+          authToken,
+          expiresAtMs: params.nowImplementation() + params.cacheDurationMs,
+        };
+        await writeCachedEntry({
+          cacheFilePath: params.cachePaths.cacheFilePath,
+          storedEntry,
+        });
+
+        return storedEntry;
+      } finally {
+        await releaseLock({
+          lockFilePath: params.cachePaths.lockFilePath,
+          ownerId: lock.ownerId,
+        });
+      }
+    }
+
+    await removeStaleLock({
+      lockFilePath: params.cachePaths.lockFilePath,
+      lockStaleAfterMs: params.lockStaleAfterMs ?? DEFAULT_LOCK_STALE_AFTER_MS,
+      nowImplementation: params.nowImplementation,
+    });
+    const retryDelayMs =
+      (params.lockRetryDelayMs ?? DEFAULT_LOCK_RETRY_DELAY_MS) +
+      Math.floor(
+        (params.randomImplementation?.() ?? Math.random()) *
+          (params.lockRetryJitterMs ?? DEFAULT_LOCK_RETRY_JITTER_MS),
+      );
+    await sleepImplementation({ durationMs: retryDelayMs });
+  }
+  /* eslint-enable no-await-in-loop */
+
+  throw new Error(
+    `Timed out waiting for admin auth token cache lock: ${params.cachePaths.lockFilePath}`,
+  );
+}
+
+function validateParams(params: GetOrCreateAdminAuthTokenParams): void {
+  if (params.adminEmail.trim().length === 0) {
+    throw new Error("adminEmail must not be empty");
+  }
+
+  if (params.apiEnvironmentName.trim().length === 0) {
+    throw new Error("apiEnvironmentName must not be empty");
+  }
+
+  if (!Number.isFinite(params.cacheDurationMs) || params.cacheDurationMs <= 0) {
+    throw new Error("cacheDurationMs must be positive");
+  }
+}
+
+function getCachePaths(params: GetOrCreateAdminAuthTokenParams): AdminAuthTokenCachePaths {
+  const cacheDirectoryPath =
+    params.cacheDirectory ?? path.join(tmpdir(), DEFAULT_CACHE_DIRECTORY_NAME);
+  const environmentSegment = params.apiEnvironmentName.replaceAll(/[^a-zA-Z0-9._-]/g, "_");
+  const emailHash = createDeterministicHash(params.adminEmail).slice(0, 16);
+  const cacheFileName = `admin-auth-token-${environmentSegment}-${emailHash}.json`;
+
+  return {
+    cacheDirectoryPath,
+    cacheFilePath: path.join(cacheDirectoryPath, cacheFileName),
+    lockFilePath: path.join(cacheDirectoryPath, `${cacheFileName}.lock`),
+  };
+}
+
+async function readCachedEntry(params: {
+  cacheFilePath: string;
+  nowImplementation: () => number;
+}): Promise<StoredAdminAuthTokenCacheEntry | undefined> {
+  try {
+    const contents = await readFile(params.cacheFilePath, "utf8");
+    const parsed: unknown = JSON.parse(contents);
+
+    if (!isStoredCacheEntry(parsed)) {
+      return undefined;
+    }
+
+    if (params.nowImplementation() >= parsed.expiresAtMs) {
+      return undefined;
+    }
+
+    return parsed;
+  } catch (error: unknown) {
+    if (isNodeErrorWithCode({ error, code: "ENOENT" }) || error instanceof SyntaxError) {
+      return undefined;
+    }
+
+    throw error;
+  }
+}
+
+function isStoredCacheEntry(value: unknown): value is StoredAdminAuthTokenCacheEntry {
+  return (
+    isRecord(value) &&
+    typeof value["authToken"] === "string" &&
+    isValidBearerToken(value["authToken"]) &&
+    typeof value["expiresAtMs"] === "number" &&
+    Number.isFinite(value["expiresAtMs"])
+  );
+}
+
+async function writeCachedEntry(params: {
+  cacheFilePath: string;
+  storedEntry: StoredAdminAuthTokenCacheEntry;
+}): Promise<void> {
+  const temporaryFilePath = `${params.cacheFilePath}.${process.pid}.${randomUUID()}.tmp`;
+
+  try {
+    await writeFile(temporaryFilePath, JSON.stringify(params.storedEntry), {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    await rename(temporaryFilePath, params.cacheFilePath);
+  } finally {
+    await rm(temporaryFilePath, { force: true });
+  }
+}
+
+async function tryAcquireLock(params: {
+  lockFilePath: string;
+  nowImplementation: () => number;
+}): Promise<AdminAuthTokenLock | undefined> {
+  const lock = {
+    ownerId: `${process.pid}-${randomUUID()}`,
+    createdAtMs: params.nowImplementation(),
+    pid: process.pid,
+  };
+
+  try {
+    await writeFile(params.lockFilePath, JSON.stringify(lock), {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
+    return lock;
+  } catch (error: unknown) {
+    if (isNodeErrorWithCode({ error, code: "EEXIST" })) {
+      return undefined;
+    }
+
+    throw error;
+  }
+}
+
+async function removeStaleLock(params: {
+  lockFilePath: string;
+  lockStaleAfterMs: number;
+  nowImplementation: () => number;
+}): Promise<void> {
+  try {
+    const lock = await readLock(params.lockFilePath);
+    const lockFileStats = await stat(params.lockFilePath);
+    const lockCreatedAtMs = lock?.createdAtMs ?? lockFileStats.mtimeMs;
+
+    if (params.nowImplementation() - lockCreatedAtMs < params.lockStaleAfterMs) {
+      return;
+    }
+
+    if (lock === undefined) {
+      await rm(params.lockFilePath, { force: true });
+      return;
+    }
+
+    await releaseLock({
+      lockFilePath: params.lockFilePath,
+      ownerId: lock.ownerId,
+    });
+  } catch (error: unknown) {
+    if (!isNodeErrorWithCode({ error, code: "ENOENT" })) {
+      throw error;
+    }
+  }
+}
+
+async function releaseLock(params: { lockFilePath: string; ownerId: string }): Promise<void> {
+  const currentLock = await readLock(params.lockFilePath);
+
+  if (currentLock?.ownerId === params.ownerId) {
+    await rm(params.lockFilePath, { force: true });
+  }
+}
+
+async function readLock(lockFilePath: string): Promise<AdminAuthTokenLock | undefined> {
+  try {
+    const contents = await readFile(lockFilePath, "utf8");
+    const parsed: unknown = JSON.parse(contents);
+
+    return isAdminAuthTokenLock(parsed) ? parsed : undefined;
+  } catch (error: unknown) {
+    if (isNodeErrorWithCode({ error, code: "ENOENT" }) || error instanceof SyntaxError) {
+      return undefined;
+    }
+
+    throw error;
+  }
+}
+
+function isAdminAuthTokenLock(value: unknown): value is AdminAuthTokenLock {
+  return (
+    isRecord(value) &&
+    typeof value["ownerId"] === "string" &&
+    typeof value["createdAtMs"] === "number" &&
+    Number.isFinite(value["createdAtMs"]) &&
+    typeof value["pid"] === "number" &&
+    Number.isFinite(value["pid"])
+  );
+}
+
+function isValidBearerToken(authToken: string): boolean {
+  return (
+    authToken === authToken.trim() &&
+    authToken.startsWith(BEARER_TOKEN_PREFIX) &&
+    authToken.length > BEARER_TOKEN_PREFIX.length
+  );
+}
+
+function isNodeErrorWithCode(params: { error: unknown; code: string }): boolean {
+  return isRecord(params.error) && params.error["code"] === params.code;
+}
+
+async function sleep(params: { durationMs: number }): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, params.durationMs);
+  });
+}
+
+function getTokenCommandArguments(params: GenerateAdminAuthTokenParams): string[] {
+  const argumentsList = [
+    "auth",
+    "gentoken",
+    "user",
+    params.apiEnvironmentName,
+    params.adminEmail,
+    "--quiet",
+  ];
+
+  if (params.clientName !== undefined) {
+    argumentsList.push("-n", params.clientName);
+  }
+
+  return argumentsList;
+}
+
+async function runAdminAuthTokenCommand(
+  params: AdminAuthTokenCommandRunnerParams,
+): Promise<AdminAuthTokenCommandResult> {
+  return await new Promise<AdminAuthTokenCommandResult>((resolve, reject) => {
+    execFile(
+      params.executable,
+      [...params.arguments],
+      {
+        encoding: "utf8",
+        // oxlint-disable-next-line node/no-process-env -- The CLI needs inherited AWS credentials and config.
+        env: { ...process.env, DOTENV_CONFIG_QUIET: "true" },
+        timeout: params.timeoutMs,
+      },
+      (error, stdout, stderr) => {
+        if (error !== null) {
+          reject(new Error(error.message, { cause: error }));
+          return;
+        }
+
+        resolve({ stdout, stderr });
+      },
+    );
+  });
+}
+
+function createSafeAdminAuthTokenError(params: {
+  adminEmail: string;
+  commandTimeoutMs: number;
+  error: unknown;
+}): Error {
+  const sourceMessage = params.error instanceof Error ? params.error.message : String(params.error);
+  const redactedMessage = sourceMessage.split(params.adminEmail).join(REDACTED_USER_LABEL);
+  const timeoutSuffix = isCommandTimeoutError({ error: params.error })
+    ? `\nTimed out after ${params.commandTimeoutMs}ms`
+    : "";
+
+  return new Error(`${redactedMessage}${timeoutSuffix}`);
+}
+
+function isCommandTimeoutError(params: { error: unknown }): boolean {
+  const inspectedErrors = new Set<unknown>();
+  let error = params.error;
+
+  while (isRecord(error) && !inspectedErrors.has(error)) {
+    inspectedErrors.add(error);
+
+    if (
+      error["killed"] === true &&
+      (error["code"] === "ETIMEDOUT" ||
+        error["signal"] === "SIGTERM" ||
+        error["signal"] === "SIGKILL")
+    ) {
+      return true;
+    }
+
+    error = error["cause"];
+  }
+
+  return false;
+}

--- a/packages/playwright-toolkit/src/lib/cognitoDiagnostics.test.ts
+++ b/packages/playwright-toolkit/src/lib/cognitoDiagnostics.test.ts
@@ -1,0 +1,159 @@
+import type { Page, Request, Response, TestInfo } from "@playwright/test";
+
+import {
+  type CognitoRequestLike,
+  fillOtpAndWaitForCognitoRedirect,
+  isCognitoOtpChallengeRequest,
+  sanitizeCognitoDiagnosticText,
+} from "../index";
+
+describe("Cognito diagnostics", () => {
+  it.each(["SMS_OTP", "EMAIL_OTP"])(
+    "matches %s RespondToAuthChallenge requests",
+    (challengeName) => {
+      const input: CognitoRequestLike = {
+        headers: () => ({
+          "x-amz-target": "AWSCognitoIdentityProviderService.RespondToAuthChallenge",
+        }),
+        method: () => "POST",
+        postDataJSON: () => ({ ChallengeName: challengeName }),
+        url: () => "https://cognito-idp.us-west-2.amazonaws.com/",
+      };
+
+      expect(isCognitoOtpChallengeRequest({ request: input })).toBe(true);
+    },
+  );
+
+  it("redacts OTPs, phone numbers, emails, sessions, and tokens", () => {
+    const input =
+      'user@example.test +14155551234 code=123456 "Session":"secret" Bearer abc.def.ghi';
+
+    const actual = sanitizeCognitoDiagnosticText({ text: input });
+
+    expect(actual).not.toContain("user@example.test");
+    expect(actual).not.toContain("+14155551234");
+    expect(actual).not.toContain("123456");
+    expect(actual).not.toContain("secret");
+    expect(actual).not.toContain("abc.def.ghi");
+  });
+
+  it("fills the OTP and returns the successful redirect URL", async () => {
+    const mockFill = vi.fn<(value: string) => Promise<void>>().mockResolvedValue();
+    const mockPage = createMockPage({
+      fill: mockFill,
+      waitForUrl: async () => {
+        await Promise.resolve();
+      },
+    });
+
+    const actual = await fillOtpAndWaitForCognitoRedirect({
+      expectedUrl: /dashboard/,
+      otp: "123456",
+      page: mockPage,
+    });
+
+    expect(actual).toEqual({ redirectUrl: "https://app.example.test/dashboard" });
+    expect(mockFill).toHaveBeenCalledWith("123456");
+  });
+
+  it("attaches sanitized Cognito response diagnostics when redirect fails", async () => {
+    const listeners = new Map<string, (value: Request | Response) => Promise<void> | void>();
+    const mockRequest = createMockPlaywrightRequest();
+    const mockResponse = {
+      request: () => mockRequest,
+      status: () => 400,
+      statusText: () => "Bad Request",
+      text: async () =>
+        await Promise.resolve(
+          '{"message":"Invalid code for user@example.test","Session":"secret-session"}',
+        ),
+    } as unknown as Response;
+    const mockAttach = vi
+      .fn<(name: string, attachment: unknown) => Promise<void>>()
+      .mockResolvedValue();
+    const mockPage = createMockPage({
+      listeners,
+      waitForUrl: async () => {
+        await getListener({ eventName: "response", listeners })(mockResponse);
+        throw new Error("redirect timed out");
+      },
+    });
+
+    const actualPromise = fillOtpAndWaitForCognitoRedirect({
+      expectedUrl: /dashboard/,
+      otp: "123456",
+      page: mockPage,
+      testInfo: { attach: mockAttach } as unknown as TestInfo,
+    });
+
+    await expect(actualPromise).rejects.toThrow("status=400 Bad Request");
+    await expect(actualPromise).rejects.not.toThrow("secret-session");
+    expect(mockAttach).toHaveBeenCalledWith(
+      "cognito-otp-diagnostics",
+      expect.objectContaining({ contentType: "image/png" }),
+    );
+  });
+});
+
+function createMockPage(params: {
+  fill?: (value: string) => Promise<void> | void;
+  listeners?: Map<string, (value: Request | Response) => Promise<void> | void>;
+  waitForUrl: () => Promise<void>;
+}): Page {
+  const listeners = params.listeners ?? new Map();
+
+  return {
+    evaluate: vi.fn<() => Promise<void>>(async () => {
+      await Promise.resolve();
+    }),
+    getByLabel: vi.fn<() => { fill: (value: string) => Promise<void> | void }>(() => ({
+      fill: params.fill ?? vi.fn<(value: string) => void>(),
+    })),
+    locator: vi.fn<() => { textContent: () => Promise<string> }>(() => ({
+      textContent: vi.fn<() => Promise<string>>(
+        async () => await Promise.resolve("Code invalid for user@example.test"),
+      ),
+    })),
+    off: vi.fn<(eventName: string) => void>((eventName) => {
+      listeners.delete(eventName);
+    }),
+    on: vi.fn<
+      (eventName: string, listener: (value: Request | Response) => Promise<void> | void) => void
+    >((eventName, listener) => {
+      listeners.set(eventName, listener);
+    }),
+    screenshot: vi.fn<() => Promise<Buffer>>(
+      async () => await Promise.resolve(Buffer.from("screenshot")),
+    ),
+    url: vi.fn<() => string>(() => "https://app.example.test/dashboard"),
+    waitForURL: vi.fn<() => Promise<void>>(params.waitForUrl),
+  } as unknown as Page;
+}
+
+function createMockPlaywrightRequest(): Request {
+  return {
+    failure: vi.fn<() => null>(() => null),
+    headers: vi.fn<() => Record<string, string>>(() => ({
+      "x-amz-target": "AWSCognitoIdentityProviderService.RespondToAuthChallenge",
+    })),
+    method: vi.fn<() => string>(() => "POST"),
+    postDataJSON: vi.fn<() => unknown>(() => ({
+      ChallengeName: "SMS_OTP",
+      Session: "secret-session",
+    })),
+    url: vi.fn<() => string>(() => "https://cognito-idp.us-west-2.amazonaws.com/?token=secret"),
+  } as unknown as Request;
+}
+
+function getListener(params: {
+  eventName: string;
+  listeners: Map<string, (value: Request | Response) => Promise<void> | void>;
+}): (value: Request | Response) => Promise<void> | void {
+  const listener = params.listeners.get(params.eventName);
+
+  if (listener === undefined) {
+    throw new Error(`Missing listener for ${params.eventName}`);
+  }
+
+  return listener;
+}

--- a/packages/playwright-toolkit/src/lib/cognitoDiagnostics.test.ts
+++ b/packages/playwright-toolkit/src/lib/cognitoDiagnostics.test.ts
@@ -93,11 +93,41 @@ describe("Cognito diagnostics", () => {
       expect.objectContaining({ contentType: "image/png" }),
     );
   });
+
+  it("redacts the final redirect error, URL path, and retained cause", async () => {
+    const sensitiveEmail = "sensitive-user@example.test";
+    const mockPage = createMockPage({
+      url: `https://app.example.test/login/${sensitiveEmail}?token=secret-token`,
+      waitForUrl: async () => {
+        throw new Error(`redirect failed for ${sensitiveEmail} with code 123456`);
+      },
+    });
+    let actualError: unknown;
+
+    try {
+      await fillOtpAndWaitForCognitoRedirect({
+        expectedUrl: `https://app.example.test/dashboard/${sensitiveEmail}`,
+        otp: "123456",
+        page: mockPage,
+        expectedUrlTimeoutMs: 10,
+      });
+    } catch (error: unknown) {
+      actualError = error;
+    }
+
+    expect(actualError).toBeInstanceOf(Error);
+    expect(String(actualError)).not.toContain(sensitiveEmail);
+    expect(String(actualError)).not.toContain("123456");
+    expect(actualError).toMatchObject({ cause: expect.any(Error) });
+    expect(String((actualError as Error).cause)).not.toContain(sensitiveEmail);
+    expect(String((actualError as Error).cause)).not.toContain("123456");
+  });
 });
 
 function createMockPage(params: {
   fill?: (value: string) => Promise<void> | void;
   listeners?: Map<string, (value: Request | Response) => Promise<void> | void>;
+  url?: string;
   waitForUrl: () => Promise<void>;
 }): Page {
   const listeners = params.listeners ?? new Map();
@@ -125,7 +155,7 @@ function createMockPage(params: {
     screenshot: vi.fn<() => Promise<Buffer>>(
       async () => await Promise.resolve(Buffer.from("screenshot")),
     ),
-    url: vi.fn<() => string>(() => "https://app.example.test/dashboard"),
+    url: vi.fn<() => string>(() => params.url ?? "https://app.example.test/dashboard"),
     waitForURL: vi.fn<() => Promise<void>>(params.waitForUrl),
   } as unknown as Page;
 }

--- a/packages/playwright-toolkit/src/lib/cognitoDiagnostics.ts
+++ b/packages/playwright-toolkit/src/lib/cognitoDiagnostics.ts
@@ -1,0 +1,447 @@
+// cspell:ignore requestfailed
+import { isRecord, toErrorMessage as getErrorMessage } from "@clipboard-health/util-ts";
+import type { Page, Request, Response, TestInfo } from "@playwright/test";
+
+const COGNITO_HOST_PATTERN = /^cognito-idp\.[^.]+\.amazonaws\.com$/;
+const RESPOND_TO_AUTH_CHALLENGE_TARGET = "AWSCognitoIdentityProviderService.RespondToAuthChallenge";
+const OTP_CHALLENGE_NAMES = new Set(["EMAIL_OTP", "SMS_OTP"]);
+const DEFAULT_REDIRECT_TIMEOUT_MS = 30_000;
+const DIAGNOSTIC_SAMPLE_MAX_LENGTH = 700;
+const SCREENSHOT_ATTACHMENT_NAME = "cognito-otp-diagnostics";
+
+type ExpectedUrl = Parameters<Page["waitForURL"]>[0];
+
+export interface CognitoRequestLike {
+  headers(): Record<string, string>;
+  method(): string;
+  postDataJSON(): unknown;
+  url(): string;
+}
+
+export interface CognitoRequestSummary {
+  action: string;
+  challengeName: string;
+  method: string;
+  target: string;
+  url: string;
+}
+
+export interface FillOtpAndWaitForCognitoRedirectParams {
+  expectedUrl: ExpectedUrl;
+  otp: string;
+  page: Page;
+  testInfo?: TestInfo | undefined;
+  expectedUrlTimeoutMs?: number | undefined;
+  inputLabel?: string | RegExp | undefined;
+}
+
+type CognitoChallengeAttempt =
+  | {
+      request: CognitoRequestSummary;
+      responseBodySample: string;
+      status: number;
+      statusText: string;
+      type: "response";
+    }
+  | {
+      failureText: string;
+      request: CognitoRequestSummary;
+      type: "request-failure";
+    }
+  | {
+      timeoutMs: number;
+      type: "not-observed";
+    };
+
+interface CognitoChallengeMonitor {
+  result: Promise<CognitoChallengeAttempt>;
+  dispose(): void;
+}
+
+/**
+ * Fills an OTP and waits for the login redirect. On failure it reports the
+ * observed Cognito challenge, sanitized response/page text, current URL, and
+ * an optional redacted screenshot attachment.
+ */
+export async function fillOtpAndWaitForCognitoRedirect(
+  params: FillOtpAndWaitForCognitoRedirectParams,
+): Promise<{ redirectUrl: string }> {
+  const timeoutMs = params.expectedUrlTimeoutMs ?? DEFAULT_REDIRECT_TIMEOUT_MS;
+  const monitor = createCognitoChallengeMonitor({
+    page: params.page,
+    timeoutMs,
+  });
+
+  try {
+    await params.page
+      .getByLabel(params.inputLabel ?? "Verification Code", { exact: true })
+      .fill(params.otp);
+  } catch (error: unknown) {
+    monitor.dispose();
+    throw error;
+  }
+
+  try {
+    await params.page.waitForURL(params.expectedUrl, { timeout: timeoutMs });
+    monitor.dispose();
+    return { redirectUrl: params.page.url() };
+  } catch (error: unknown) {
+    const diagnostics = await getFailureDiagnostics({
+      attemptPromise: monitor.result,
+      page: params.page,
+      testInfo: params.testInfo,
+    });
+
+    throw new Error(
+      `Post-OTP redirect did not reach ${formatExpectedUrl(params.expectedUrl)} ` +
+        `within ${timeoutMs}ms. ${diagnostics} Last error: ${getErrorMessage(error)}`,
+      { cause: error },
+    );
+  }
+}
+
+export function isCognitoOtpChallengeRequest(params: { request: CognitoRequestLike }): boolean {
+  const { request } = params;
+
+  if (request.method() !== "POST" || !isCognitoIdpUrl({ rawUrl: request.url() })) {
+    return false;
+  }
+
+  if (request.headers()["x-amz-target"] !== RESPOND_TO_AUTH_CHALLENGE_TARGET) {
+    return false;
+  }
+
+  const challengeName = getStringProperty({
+    value: getRequestPostDataJson({ request }),
+    propertyName: "ChallengeName",
+  });
+
+  return challengeName !== undefined && OTP_CHALLENGE_NAMES.has(challengeName);
+}
+
+export function summarizeCognitoAuthRequest(params: {
+  request: CognitoRequestLike;
+}): CognitoRequestSummary {
+  const target = params.request.headers()["x-amz-target"] ?? "unknown";
+  const targetParts = target.split(".");
+  const postData = getRequestPostDataJson({ request: params.request });
+
+  return {
+    action: targetParts.at(-1) ?? target,
+    challengeName:
+      getStringProperty({ value: postData, propertyName: "ChallengeName" }) ?? "unknown",
+    method: params.request.method(),
+    target,
+    url: sanitizeUrl({ rawUrl: params.request.url() }),
+  };
+}
+
+export function sanitizeCognitoDiagnosticText(params: { text: string }): string {
+  return params.text
+    .replaceAll(/Bearer\s+[A-Za-z0-9._-]+/gi, "Bearer [redacted-token]")
+    .replaceAll(/eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g, "[redacted-jwt]")
+    .replaceAll(
+      /("(?:[^"]*(?:authorization|challengeResponse|code|email|password|phone|session|token)[^"]*)"\s*:\s*)"[^"]*"/gi,
+      '$1"[redacted]"',
+    )
+    .replaceAll(
+      /\b(?:authorization|challengeResponse|code|email|password|phone|session|token)=\S+/gi,
+      (match) => match.replace(/[=].*/, "=[redacted]"),
+    )
+    .replaceAll(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[redacted-email]")
+    .replaceAll(/\+?\d[\d\s().-]{5,}\d/g, "[redacted-number]")
+    .replaceAll(/\b\d{4,}\b/g, "[redacted-number]");
+}
+
+function createCognitoChallengeMonitor(params: {
+  page: Page;
+  timeoutMs: number;
+}): CognitoChallengeMonitor {
+  let complete: ((attempt: CognitoChallengeAttempt) => void) | undefined;
+
+  const result = new Promise<CognitoChallengeAttempt>((resolve) => {
+    let isComplete = false;
+    const timeout = setTimeout(() => {
+      completeAttempt({ timeoutMs: params.timeoutMs, type: "not-observed" });
+    }, params.timeoutMs);
+
+    function completeAttempt(attempt: CognitoChallengeAttempt): void {
+      if (isComplete) {
+        return;
+      }
+
+      isComplete = true;
+      clearTimeout(timeout);
+      params.page.off("response", handleResponse);
+      params.page.off("requestfailed", handleRequestFailure);
+      resolve(attempt);
+    }
+
+    complete = completeAttempt;
+
+    async function handleResponse(response: Response): Promise<void> {
+      if (!isCognitoOtpChallengeRequest({ request: response.request() })) {
+        return;
+      }
+
+      try {
+        completeAttempt(await buildResponseAttempt({ response }));
+      } catch (error: unknown) {
+        completeAttempt({
+          request: summarizeCognitoAuthRequest({ request: response.request() }),
+          responseBodySample: `unavailable: ${sanitizeCognitoDiagnosticText({
+            text: getErrorMessage(error),
+          })}`,
+          status: response.status(),
+          statusText: response.statusText(),
+          type: "response",
+        });
+      }
+    }
+
+    function handleRequestFailure(request: Request): void {
+      if (!isCognitoOtpChallengeRequest({ request })) {
+        return;
+      }
+
+      completeAttempt({
+        failureText: sanitizeCognitoDiagnosticText({
+          text: request.failure()?.errorText ?? "unknown request failure",
+        }),
+        request: summarizeCognitoAuthRequest({ request }),
+        type: "request-failure",
+      });
+    }
+
+    params.page.on("response", handleResponse);
+    params.page.on("requestfailed", handleRequestFailure);
+  });
+
+  return {
+    result,
+    dispose() {
+      complete?.({ timeoutMs: params.timeoutMs, type: "not-observed" });
+    },
+  };
+}
+
+async function buildResponseAttempt(params: {
+  response: Response;
+}): Promise<CognitoChallengeAttempt> {
+  return {
+    request: summarizeCognitoAuthRequest({
+      request: params.response.request(),
+    }),
+    responseBodySample: await getResponseBodySample({
+      response: params.response,
+    }),
+    status: params.response.status(),
+    statusText: params.response.statusText(),
+    type: "response",
+  };
+}
+
+async function getFailureDiagnostics(params: {
+  attemptPromise: Promise<CognitoChallengeAttempt>;
+  page: Page;
+  testInfo: TestInfo | undefined;
+}): Promise<string> {
+  const [attempt, pageTextSample, screenshotStatus] = await Promise.all([
+    params.attemptPromise,
+    getVisiblePageTextSample({ page: params.page }),
+    attachSanitizedScreenshot({ page: params.page, testInfo: params.testInfo }),
+  ]);
+
+  return [
+    `Cognito OTP challenge: ${formatAttempt(attempt)}.`,
+    `Current URL: ${sanitizeUrl({ rawUrl: params.page.url() })}.`,
+    `Visible page text sample: "${pageTextSample}".`,
+    `Screenshot: ${screenshotStatus}.`,
+  ].join(" ");
+}
+
+function formatAttempt(attempt: CognitoChallengeAttempt): string {
+  if (attempt.type === "not-observed") {
+    return `not observed within ${attempt.timeoutMs}ms`;
+  }
+
+  const request = [
+    `method=${attempt.request.method}`,
+    `url=${attempt.request.url}`,
+    `target=${attempt.request.target}`,
+    `action=${attempt.request.action}`,
+    `challengeName=${attempt.request.challengeName}`,
+  ].join("; ");
+
+  if (attempt.type === "request-failure") {
+    return `${request}; failureText="${attempt.failureText}"`;
+  }
+
+  const status =
+    attempt.statusText.length === 0
+      ? `${attempt.status}`
+      : `${attempt.status} ${attempt.statusText}`;
+
+  return `${request}; status=${status}; responseBodySample="${attempt.responseBodySample}"`;
+}
+
+async function getResponseBodySample(params: { response: Response }): Promise<string> {
+  if (params.response.status() >= 200 && params.response.status() < 400) {
+    return "omitted because successful Cognito responses can include tokens";
+  }
+
+  try {
+    return truncateDiagnosticText({
+      text: sanitizeCognitoDiagnosticText({
+        text: await params.response.text(),
+      }),
+    });
+  } catch (error: unknown) {
+    return `unavailable: ${sanitizeCognitoDiagnosticText({ text: getErrorMessage(error) })}`;
+  }
+}
+
+async function getVisiblePageTextSample(params: { page: Page }): Promise<string> {
+  try {
+    const bodyText = (await params.page.locator("body").textContent({ timeout: 1000 })) ?? "";
+    return truncateDiagnosticText({
+      text: sanitizeCognitoDiagnosticText({ text: bodyText }),
+    });
+  } catch (error: unknown) {
+    return `unavailable: ${sanitizeCognitoDiagnosticText({ text: getErrorMessage(error) })}`;
+  }
+}
+
+async function attachSanitizedScreenshot(params: {
+  page: Page;
+  testInfo: TestInfo | undefined;
+}): Promise<string> {
+  if (params.testInfo === undefined) {
+    return "not attached; testInfo unavailable";
+  }
+
+  try {
+    await redactPageForScreenshot({ page: params.page });
+    const screenshot = await params.page.screenshot({ fullPage: true });
+    await params.testInfo.attach(SCREENSHOT_ATTACHMENT_NAME, {
+      body: screenshot,
+      contentType: "image/png",
+    });
+    return `attached as ${SCREENSHOT_ATTACHMENT_NAME}`;
+  } catch (error: unknown) {
+    return `unavailable: ${sanitizeCognitoDiagnosticText({ text: getErrorMessage(error) })}`;
+  }
+}
+
+async function redactPageForScreenshot(params: { page: Page }): Promise<void> {
+  await params.page.evaluate(() => {
+    // eslint-disable-next-line unicorn/consistent-function-scoping -- Serialized into the browser context.
+    function redact(value: string): string {
+      return value
+        .replaceAll(/Bearer\s+[A-Za-z0-9._-]+/gi, "Bearer [redacted-token]")
+        .replaceAll(/eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g, "[redacted-jwt]")
+        .replaceAll(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[redacted-email]")
+        .replaceAll(/\+?\d[\d\s().-]{5,}\d/g, "[redacted-number]")
+        .replaceAll(/\b\d{4,}\b/g, "[redacted-number]");
+    }
+
+    if (document.body === null) {
+      return;
+    }
+
+    const treeWalker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+    let currentNode = treeWalker.nextNode();
+
+    while (currentNode !== null) {
+      const originalText = currentNode.textContent ?? "";
+      const redactedText = redact(originalText);
+
+      if (redactedText !== originalText) {
+        currentNode.textContent = redactedText;
+      }
+
+      currentNode = treeWalker.nextNode();
+    }
+
+    const fields = document.querySelectorAll<HTMLInputElement | HTMLTextAreaElement>(
+      "input, textarea",
+    );
+
+    for (const field of fields) {
+      const redactedValue = redact(field.value);
+      if (redactedValue !== field.value) {
+        field.value = redactedValue;
+      }
+
+      const valueAttribute = field.getAttribute("value");
+      if (valueAttribute !== null) {
+        const redactedValueAttribute = redact(valueAttribute);
+
+        if (redactedValueAttribute !== valueAttribute) {
+          field.setAttribute("value", redactedValueAttribute);
+        }
+      }
+    }
+  });
+}
+
+function getRequestPostDataJson(params: { request: CognitoRequestLike }): unknown {
+  try {
+    return params.request.postDataJSON();
+  } catch {
+    return undefined;
+  }
+}
+
+function getStringProperty(params: { value: unknown; propertyName: string }): string | undefined {
+  if (!isRecord(params.value)) {
+    return undefined;
+  }
+
+  const propertyValue = params.value[params.propertyName];
+  return typeof propertyValue === "string" ? propertyValue : undefined;
+}
+
+function isCognitoIdpUrl(params: { rawUrl: string }): boolean {
+  try {
+    return COGNITO_HOST_PATTERN.test(new URL(params.rawUrl).hostname);
+  } catch {
+    return false;
+  }
+}
+
+function sanitizeUrl(params: { rawUrl: string }): string {
+  try {
+    const url = new URL(params.rawUrl);
+    return [
+      url.origin,
+      url.pathname,
+      url.search.length === 0 ? "" : "?[redacted-query]",
+      url.hash.length === 0 ? "" : "#[redacted-hash]",
+    ].join("");
+  } catch {
+    return truncateDiagnosticText({
+      text: sanitizeCognitoDiagnosticText({ text: params.rawUrl }),
+    });
+  }
+}
+
+function formatExpectedUrl(expectedUrl: ExpectedUrl): string {
+  if (typeof expectedUrl === "string") {
+    return sanitizeUrl({ rawUrl: expectedUrl });
+  }
+
+  if (expectedUrl instanceof RegExp) {
+    return expectedUrl.toString();
+  }
+
+  return "[URL predicate]";
+}
+
+function truncateDiagnosticText(params: { text: string }): string {
+  const normalizedText = params.text.replaceAll(/\s+/g, " ").trim();
+
+  return normalizedText.length <= DIAGNOSTIC_SAMPLE_MAX_LENGTH
+    ? normalizedText
+    : `${normalizedText.slice(0, DIAGNOSTIC_SAMPLE_MAX_LENGTH)}...`;
+}

--- a/packages/playwright-toolkit/src/lib/cognitoDiagnostics.ts
+++ b/packages/playwright-toolkit/src/lib/cognitoDiagnostics.ts
@@ -91,11 +91,15 @@ export async function fillOtpAndWaitForCognitoRedirect(
       page: params.page,
       testInfo: params.testInfo,
     });
+    const finalErrorMessage = sanitizeCognitoDiagnosticText({
+      text: getErrorMessage(error),
+    });
 
+    // oxlint-disable-next-line preserve-caught-error -- Raw Playwright errors may contain OTPs or account PII.
     throw new Error(
       `Post-OTP redirect did not reach ${formatExpectedUrl(params.expectedUrl)} ` +
-        `within ${timeoutMs}ms. ${diagnostics} Last error: ${getErrorMessage(error)}`,
-      { cause: error },
+        `within ${timeoutMs}ms. ${diagnostics} Last error: ${finalErrorMessage}`,
+      { cause: new Error(finalErrorMessage) },
     );
   }
 }
@@ -415,7 +419,7 @@ function sanitizeUrl(params: { rawUrl: string }): string {
     const url = new URL(params.rawUrl);
     return [
       url.origin,
-      url.pathname,
+      url.pathname === "/" ? "/" : "/[redacted-path]",
       url.search.length === 0 ? "" : "?[redacted-query]",
       url.hash.length === 0 ? "" : "#[redacted-hash]",
     ].join("");
@@ -432,7 +436,7 @@ function formatExpectedUrl(expectedUrl: ExpectedUrl): string {
   }
 
   if (expectedUrl instanceof RegExp) {
-    return expectedUrl.toString();
+    return sanitizeCognitoDiagnosticText({ text: expectedUrl.toString() });
   }
 
   return "[URL predicate]";

--- a/packages/playwright-toolkit/src/lib/deployedAssets.test.ts
+++ b/packages/playwright-toolkit/src/lib/deployedAssets.test.ts
@@ -194,8 +194,11 @@ describe("deployed asset verification", () => {
 
   it.each([
     ["text/javascript", "application/javascript"],
+    ["application/javascript", "text/javascript"],
     ["application/manifest+json", "application/json"],
+    ["application/json", "application/manifest+json"],
     ["image/vnd.microsoft.icon", "image/x-icon"],
+    ["image/x-icon", "image/vnd.microsoft.icon"],
   ])("treats expected %s as equivalent to actual %s", async (expected, actualContentType) => {
     const actual = await verifyDeployedAssets({
       checks: [

--- a/packages/playwright-toolkit/src/lib/deployedAssets.test.ts
+++ b/packages/playwright-toolkit/src/lib/deployedAssets.test.ts
@@ -1,0 +1,158 @@
+import { verifyDeployedAssets, waitForDeployedAssets } from "../index";
+
+describe("deployed asset verification", () => {
+  it("retries transient responses and returns attempt diagnostics", async () => {
+    const sleepDurations: number[] = [];
+    const mockFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(undefined, {
+          status: 503,
+          headers: { "content-type": "application/javascript" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(undefined, {
+          status: 200,
+          headers: { "content-type": "application/javascript" },
+        }),
+      );
+
+    const actual = await verifyDeployedAssets({
+      checks: [
+        {
+          expectedContentTypes: ["application/javascript"],
+          method: "HEAD",
+          path: "assets/app.js",
+          url: "https://example.test/assets/app.js",
+        },
+      ],
+      fetchImplementation: mockFetch,
+      retry: {
+        maxAttempts: 3,
+        delayMs: 50,
+      },
+      sleepImplementation: async ({ durationMs }) => {
+        sleepDurations.push(durationMs);
+      },
+    });
+
+    expect(actual.summary).toEqual({ failureCount: 0, passedCount: 1, totalCount: 1 });
+    expect(actual.results[0]?.attempts).toHaveLength(2);
+    expect(sleepDurations).toEqual([50]);
+  });
+
+  it("does not retry deterministic content-type mismatches", async () => {
+    const mockFetch = vi.fn<typeof fetch>(
+      async () =>
+        new Response("not javascript", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        }),
+    );
+
+    const actual = await verifyDeployedAssets({
+      checks: [
+        {
+          expectedContentTypes: ["application/javascript"],
+          method: "GET",
+          path: "assets/app.js",
+          url: "https://example.test/assets/app.js",
+        },
+      ],
+      fetchImplementation: mockFetch,
+    });
+
+    expect(actual.summary.failureCount).toBe(1);
+    expect(actual.results[0]?.errorMessage).toContain("expected content-type");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry deterministic fetch configuration errors", async () => {
+    const mockFetch = vi.fn<typeof fetch>().mockRejectedValue(new TypeError("Invalid URL"));
+
+    const actual = await verifyDeployedAssets({
+      checks: [
+        {
+          path: "assets/app.js",
+          url: "not-a-url",
+        },
+      ],
+      fetchImplementation: mockFetch,
+      retry: { maxAttempts: 3 },
+    });
+
+    expect(actual.summary.failureCount).toBe(1);
+    expect(actual.results[0]?.errorMessage).toContain("Invalid URL");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("requires a healthy stable window when polling a deployment", async () => {
+    let currentTimeMs = 0;
+    const mockFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(undefined, { status: 200 }))
+      .mockResolvedValueOnce(new Response(undefined, { status: 503 }))
+      .mockResolvedValue(new Response(undefined, { status: 200 }));
+
+    const actual = await waitForDeployedAssets({
+      checks: [{ path: "index.html", url: "https://example.test/index.html" }],
+      fetchImplementation: mockFetch,
+      nowImplementation: () => currentTimeMs,
+      pollIntervalMs: 100,
+      retry: { maxAttempts: 1 },
+      stableWindowMs: 200,
+      timeoutMs: 1000,
+      sleepImplementation: async ({ durationMs }) => {
+        currentTimeMs += durationMs;
+      },
+    });
+
+    expect(actual.summary.failureCount).toBe(0);
+    expect(actual.wait).toMatchObject({
+      isStableWindowSatisfied: true,
+      attempts: 5,
+    });
+  });
+
+  it("supports cache-busted runtime checks with custom body validation", async () => {
+    const requestedUrls: string[] = [];
+
+    const actual = await verifyDeployedAssets({
+      checks: [
+        {
+          cacheMode: "cache-busted",
+          method: "GET",
+          path: "build-info.json",
+          url: "https://example.test/build-info.json",
+          validateResponse: async ({ response }) => {
+            const responseText = await response.text();
+
+            return {
+              isValid: responseText === JSON.stringify({ commitHash: "expected-commit" }),
+              message: "commit mismatch",
+            };
+          },
+        },
+      ],
+      fetchImplementation: vi.fn<typeof fetch>(async (url) => {
+        requestedUrls.push(formatFetchInput(url));
+        return new Response(JSON.stringify({ commitHash: "expected-commit" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }),
+    });
+
+    expect(actual.summary.failureCount).toBe(0);
+    expect(requestedUrls[0]).toContain("cbhAssetVerifier=");
+  });
+});
+
+function formatFetchInput(input: string | URL | Request): string {
+  if (typeof input === "string") {
+    return input;
+  }
+
+  return input instanceof URL ? input.toString() : input.url;
+}

--- a/packages/playwright-toolkit/src/lib/deployedAssets.test.ts
+++ b/packages/playwright-toolkit/src/lib/deployedAssets.test.ts
@@ -147,6 +147,75 @@ describe("deployed asset verification", () => {
     expect(actual.summary.failureCount).toBe(0);
     expect(requestedUrls[0]).toContain("cbhAssetVerifier=");
   });
+
+  it("omits request headers and validator functions from reports", async () => {
+    const actual = await verifyDeployedAssets({
+      checks: [
+        {
+          headers: { authorization: "Bearer secret-token" },
+          path: "private.json",
+          url: "https://example.test/private.json",
+          validateResponse: () => ({ isValid: true }),
+        },
+      ],
+      fetchImplementation: vi.fn<typeof fetch>(async () => new Response("{}", { status: 200 })),
+    });
+
+    expect(actual.results[0]?.check).not.toHaveProperty("headers");
+    expect(actual.results[0]?.check).not.toHaveProperty("validateResponse");
+  });
+
+  it("records and retries transient validator exceptions", async () => {
+    const mockValidator = vi
+      .fn<
+        NonNullable<
+          Parameters<typeof verifyDeployedAssets>[0]["checks"][number]["validateResponse"]
+        >
+      >()
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValueOnce({ isValid: true });
+
+    const actual = await verifyDeployedAssets({
+      checks: [
+        {
+          path: "build-info.json",
+          url: "https://example.test/build-info.json",
+          validateResponse: mockValidator,
+        },
+      ],
+      fetchImplementation: vi.fn<typeof fetch>(async () => new Response("{}", { status: 200 })),
+      retry: { maxAttempts: 2, delayMs: 0 },
+    });
+
+    expect(actual.summary.failureCount).toBe(0);
+    expect(actual.results[0]?.attempts).toHaveLength(2);
+    expect(actual.results[0]?.attempts[0]?.errorMessage).toBe("fetch failed");
+  });
+
+  it.each([
+    ["text/javascript", "application/javascript"],
+    ["application/manifest+json", "application/json"],
+    ["image/vnd.microsoft.icon", "image/x-icon"],
+  ])("treats expected %s as equivalent to actual %s", async (expected, actualContentType) => {
+    const actual = await verifyDeployedAssets({
+      checks: [
+        {
+          expectedContentTypes: [expected],
+          path: "asset",
+          url: "https://example.test/asset",
+        },
+      ],
+      fetchImplementation: vi.fn<typeof fetch>(
+        async () =>
+          new Response(undefined, {
+            status: 200,
+            headers: { "content-type": actualContentType },
+          }),
+      ),
+    });
+
+    expect(actual.summary.failureCount).toBe(0);
+  });
 });
 
 function formatFetchInput(input: string | URL | Request): string {

--- a/packages/playwright-toolkit/src/lib/deployedAssets.ts
+++ b/packages/playwright-toolkit/src/lib/deployedAssets.ts
@@ -1,0 +1,488 @@
+import { performance } from "node:perf_hooks";
+
+import { isDefined, isRecord, toErrorMessage as getErrorMessage } from "@clipboard-health/util-ts";
+
+import { RetryError, runWithRetry } from "./retry";
+import { isRetryableHttpStatus } from "./setupRetry";
+
+const DEFAULT_CONCURRENCY_LIMIT = 5;
+const DEFAULT_FETCH_TIMEOUT_MS = 10_000;
+const DEFAULT_RETRY_ATTEMPTS = 3;
+const DEFAULT_RETRY_DELAY_MS = 500;
+const DEFAULT_POLL_INTERVAL_MS = 10_000;
+const CACHE_BUST_QUERY_PARAMETER = "cbhAssetVerifier";
+
+export type DeployedAssetRequestMethod = "GET" | "HEAD";
+export type DeployedAssetCacheMode = "cache-busted" | "normal";
+
+export interface DeployedAssetValidationResult {
+  isValid: boolean;
+  message?: string | undefined;
+  isTransient?: boolean | undefined;
+}
+
+export interface DeployedAssetCheck {
+  path: string;
+  url: string;
+  method?: DeployedAssetRequestMethod | undefined;
+  cacheMode?: DeployedAssetCacheMode | undefined;
+  expectedContentTypes?: readonly string[] | undefined;
+  headers?: Record<string, string> | undefined;
+  validateResponse?:
+    | ((params: {
+        response: Response;
+      }) => Promise<DeployedAssetValidationResult> | DeployedAssetValidationResult)
+    | undefined;
+}
+
+export interface DeployedAssetAttempt {
+  attemptNumber: number;
+  contentType?: string | undefined;
+  durationMs: number;
+  errorMessage?: string | undefined;
+  status?: number | undefined;
+  url: string;
+}
+
+export interface DeployedAssetResult {
+  attempts: DeployedAssetAttempt[];
+  check: DeployedAssetCheck;
+  contentType?: string | undefined;
+  errorMessage?: string | undefined;
+  isSuccess: boolean;
+  status?: number | undefined;
+}
+
+export interface DeployedAssetVerificationReport {
+  results: DeployedAssetResult[];
+  summary: {
+    failureCount: number;
+    passedCount: number;
+    totalCount: number;
+  };
+  wait?:
+    | {
+        attempts: number;
+        isStableWindowSatisfied: boolean;
+        stableWindowElapsedMs: number;
+      }
+    | undefined;
+}
+
+export interface VerifyDeployedAssetsParams {
+  checks: readonly DeployedAssetCheck[];
+  concurrencyLimit?: number | undefined;
+  fetchImplementation?: typeof fetch | undefined;
+  fetchTimeoutMs?: number | undefined;
+  nowImplementation?: (() => number) | undefined;
+  retry?:
+    | {
+        maxAttempts?: number | undefined;
+        delayMs?: number | undefined;
+      }
+    | undefined;
+  sleepImplementation?: ((params: { durationMs: number }) => Promise<void>) | undefined;
+}
+
+export interface WaitForDeployedAssetsParams extends VerifyDeployedAssetsParams {
+  timeoutMs: number;
+  pollIntervalMs?: number | undefined;
+  stableWindowMs?: number | undefined;
+}
+
+interface AssetAttemptFailureParams {
+  attempt: DeployedAssetAttempt;
+  isTransient: boolean;
+  message: string;
+}
+
+class AssetAttemptFailure extends Error {
+  public readonly attempt: DeployedAssetAttempt;
+  public readonly isTransient: boolean;
+
+  public constructor(params: AssetAttemptFailureParams) {
+    super(params.message);
+    this.name = "AssetAttemptFailure";
+    this.attempt = params.attempt;
+    this.isTransient = params.isTransient;
+  }
+}
+
+class AssetGraphNotReadyError extends Error {}
+
+/**
+ * Checks a repo-supplied deployed asset graph with bounded concurrency and
+ * classified per-asset retries. Discovery and asset classification remain in
+ * thin repo wrappers.
+ */
+export async function verifyDeployedAssets(
+  params: VerifyDeployedAssetsParams,
+): Promise<DeployedAssetVerificationReport> {
+  const concurrencyLimit = params.concurrencyLimit ?? DEFAULT_CONCURRENCY_LIMIT;
+  if (!Number.isInteger(concurrencyLimit) || concurrencyLimit < 1) {
+    throw new Error("concurrencyLimit must be a positive integer");
+  }
+
+  const results: Array<DeployedAssetResult | undefined> = Array.from({
+    length: params.checks.length,
+  });
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    for (;;) {
+      const index = nextIndex;
+      nextIndex += 1;
+
+      if (index >= params.checks.length) {
+        return;
+      }
+
+      const check = params.checks[index];
+      if (check === undefined) {
+        return;
+      }
+
+      // eslint-disable-next-line no-await-in-loop -- Each worker consumes one bounded queue item at a time.
+      results[index] = await verifyDeployedAsset({ check, options: params });
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrencyLimit, params.checks.length) }, worker),
+  );
+
+  const completedResults = results.filter(isDefined);
+  const failureCount = completedResults.filter((result) => !result.isSuccess).length;
+
+  return {
+    results: completedResults,
+    summary: {
+      failureCount,
+      passedCount: completedResults.length - failureCount,
+      totalCount: completedResults.length,
+    },
+  };
+}
+
+/**
+ * Polls the whole graph until it is healthy for an optional stable window.
+ */
+export async function waitForDeployedAssets(
+  params: WaitForDeployedAssetsParams,
+): Promise<DeployedAssetVerificationReport> {
+  const nowImplementation = params.nowImplementation ?? Date.now;
+  const stableWindowMs = params.stableWindowMs ?? 0;
+  let stableWindowStartedAtMs: number | undefined;
+  let lastReport: DeployedAssetVerificationReport | undefined;
+
+  const result = await runWithRetry({
+    operationName: "wait for deployed asset graph",
+    operation: async () => {
+      lastReport = await verifyDeployedAssets(params);
+      const nowMs = nowImplementation();
+
+      if (lastReport.summary.failureCount > 0) {
+        stableWindowStartedAtMs = undefined;
+        throw new AssetGraphNotReadyError(
+          `Deployed asset graph has ${lastReport.summary.failureCount} failure(s)`,
+        );
+      }
+
+      stableWindowStartedAtMs ??= nowMs;
+      const stableWindowElapsedMs = nowMs - stableWindowStartedAtMs;
+
+      if (stableWindowElapsedMs < stableWindowMs) {
+        throw new AssetGraphNotReadyError(
+          `Deployed asset graph is healthy for ${stableWindowElapsedMs}ms; ` +
+            `${stableWindowMs}ms required`,
+        );
+      }
+
+      return {
+        report: lastReport,
+        stableWindowElapsedMs,
+      };
+    },
+    mode: {
+      kind: "poll",
+      timeoutMs: params.timeoutMs,
+      intervalsMs: [params.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS],
+      isTransient: ({ error }) => error instanceof AssetGraphNotReadyError,
+    },
+    nowImplementation,
+    sleepImplementation: params.sleepImplementation,
+  });
+
+  return {
+    ...result.value.report,
+    wait: {
+      attempts: result.attempts,
+      isStableWindowSatisfied: true,
+      stableWindowElapsedMs: result.value.stableWindowElapsedMs,
+    },
+  };
+}
+
+async function verifyDeployedAsset(params: {
+  check: DeployedAssetCheck;
+  options: VerifyDeployedAssetsParams;
+}): Promise<DeployedAssetResult> {
+  const attempts: DeployedAssetAttempt[] = [];
+  const maxAttempts = params.options.retry?.maxAttempts ?? DEFAULT_RETRY_ATTEMPTS;
+
+  try {
+    const result = await runWithRetry<DeployedAssetAttempt>({
+      operationName: `verify deployed asset ${params.check.path}`,
+      operation: async ({ attemptNumber }) => {
+        try {
+          const attempt = await checkAssetOnce({
+            attemptNumber,
+            check: params.check,
+            fetchImplementation: params.options.fetchImplementation ?? fetch,
+            fetchTimeoutMs: params.options.fetchTimeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS,
+            nowImplementation: params.options.nowImplementation ?? (() => performance.now()),
+          });
+          attempts.push(attempt);
+          return attempt;
+        } catch (error: unknown) {
+          if (error instanceof AssetAttemptFailure) {
+            attempts.push(error.attempt);
+          }
+
+          throw error;
+        }
+      },
+      mode: {
+        kind: "classified",
+        maxAttempts,
+        delayMs: params.options.retry?.delayMs ?? DEFAULT_RETRY_DELAY_MS,
+        isTransient: ({ error }) => error instanceof AssetAttemptFailure && error.isTransient,
+      },
+      sleepImplementation: params.options.sleepImplementation,
+      nowImplementation: params.options.nowImplementation,
+    });
+    const finalAttempt = result.value;
+
+    return {
+      attempts,
+      check: params.check,
+      ...(finalAttempt.contentType === undefined ? {} : { contentType: finalAttempt.contentType }),
+      isSuccess: true,
+      ...(finalAttempt.status === undefined ? {} : { status: finalAttempt.status }),
+    };
+  } catch (error: unknown) {
+    const failure = getAssetAttemptFailure({ error });
+    const finalAttempt = attempts.at(-1);
+
+    return {
+      attempts,
+      check: params.check,
+      ...(finalAttempt?.contentType === undefined ? {} : { contentType: finalAttempt.contentType }),
+      errorMessage: failure?.message ?? getErrorMessage(error),
+      isSuccess: false,
+      ...(finalAttempt?.status === undefined ? {} : { status: finalAttempt.status }),
+    };
+  }
+}
+
+async function checkAssetOnce(params: {
+  attemptNumber: number;
+  check: DeployedAssetCheck;
+  fetchImplementation: typeof fetch;
+  fetchTimeoutMs: number;
+  nowImplementation: () => number;
+}): Promise<DeployedAssetAttempt> {
+  const requestUrl = getRequestUrl({
+    attemptNumber: params.attemptNumber,
+    check: params.check,
+  });
+  const abortController = new AbortController();
+  const timeout = setTimeout(() => {
+    abortController.abort();
+  }, params.fetchTimeoutMs);
+  const startedAtMs = params.nowImplementation();
+
+  try {
+    let response: Response;
+
+    try {
+      response = await params.fetchImplementation(requestUrl, {
+        ...getRequestInit({ check: params.check }),
+        method: params.check.method ?? "GET",
+        signal: abortController.signal,
+      });
+    } catch (error: unknown) {
+      const message = getErrorMessage(error);
+      throw new AssetAttemptFailure({
+        attempt: {
+          attemptNumber: params.attemptNumber,
+          durationMs: params.nowImplementation() - startedAtMs,
+          errorMessage: message,
+          url: requestUrl,
+        },
+        isTransient: isTransientFetchError({ error }),
+        message,
+      });
+    }
+
+    const contentType = response.headers.get("content-type") ?? undefined;
+    const attempt: DeployedAssetAttempt = {
+      attemptNumber: params.attemptNumber,
+      ...(contentType === undefined ? {} : { contentType }),
+      durationMs: params.nowImplementation() - startedAtMs,
+      status: response.status,
+      url: requestUrl,
+    };
+
+    if (!response.ok) {
+      const message = `expected HTTP 2xx but received HTTP ${response.status}`;
+      throw new AssetAttemptFailure({
+        attempt: { ...attempt, errorMessage: message },
+        isTransient: isTransientAssetStatus({ status: response.status }),
+        message,
+      });
+    }
+
+    if (
+      params.check.expectedContentTypes !== undefined &&
+      !isExpectedContentType({
+        actualContentType: contentType,
+        expectedContentTypes: params.check.expectedContentTypes,
+      })
+    ) {
+      const message =
+        `expected content-type ${params.check.expectedContentTypes.join(" or ")} ` +
+        `but received ${contentType ?? "none"}`;
+      throw new AssetAttemptFailure({
+        attempt: { ...attempt, errorMessage: message },
+        isTransient: false,
+        message,
+      });
+    }
+
+    if (params.check.validateResponse !== undefined) {
+      const validation = await params.check.validateResponse({ response });
+
+      if (!validation.isValid) {
+        const message = validation.message ?? "custom deployed asset validation failed";
+        throw new AssetAttemptFailure({
+          attempt: { ...attempt, errorMessage: message },
+          isTransient: validation.isTransient ?? false,
+          message,
+        });
+      }
+    }
+
+    return attempt;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function getRequestUrl(params: { attemptNumber: number; check: DeployedAssetCheck }): string {
+  const url = new URL(params.check.url);
+
+  if ((params.check.cacheMode ?? "normal") === "normal") {
+    return url.toString();
+  }
+
+  url.searchParams.set(CACHE_BUST_QUERY_PARAMETER, `${Date.now()}-${params.attemptNumber}`);
+
+  return url.toString();
+}
+
+function getRequestInit(params: { check: DeployedAssetCheck }): RequestInit {
+  if ((params.check.cacheMode ?? "normal") === "normal") {
+    return params.check.headers === undefined ? {} : { headers: params.check.headers };
+  }
+
+  return {
+    cache: "no-store",
+    headers: {
+      "cache-control": "no-cache",
+      pragma: "no-cache",
+      ...params.check.headers,
+    },
+  };
+}
+
+function isTransientAssetStatus(params: { status: number }): boolean {
+  return params.status === 425 || isRetryableHttpStatus({ status: params.status });
+}
+
+function isTransientFetchError(params: { error: unknown }): boolean {
+  const inspectedErrors = new Set<unknown>();
+  let error = params.error;
+
+  while (isRecord(error) && !inspectedErrors.has(error)) {
+    inspectedErrors.add(error);
+
+    if (
+      error["name"] === "AbortError" ||
+      error["code"] === "ECONNREFUSED" ||
+      error["code"] === "ECONNRESET" ||
+      error["code"] === "EAI_AGAIN" ||
+      error["code"] === "ENOTFOUND" ||
+      error["code"] === "ETIMEDOUT"
+    ) {
+      return true;
+    }
+
+    error = error["cause"];
+  }
+
+  const normalizedMessage = getErrorMessage(params.error).toLowerCase();
+  return (
+    normalizedMessage.includes("failed to fetch") ||
+    normalizedMessage.includes("fetch failed") ||
+    normalizedMessage.includes("networkerror")
+  );
+}
+
+function isExpectedContentType(params: {
+  actualContentType: string | undefined;
+  expectedContentTypes: readonly string[];
+}): boolean {
+  if (params.actualContentType === undefined) {
+    return false;
+  }
+
+  const actualContentType = normalizeContentType(params.actualContentType);
+  const expectedContentTypes = params.expectedContentTypes.flatMap(getEquivalentContentTypes);
+
+  return expectedContentTypes.includes(actualContentType);
+}
+
+function getEquivalentContentTypes(contentType: string): string[] {
+  const normalized = normalizeContentType(contentType);
+
+  if (normalized === "application/javascript") {
+    return ["application/javascript", "text/javascript"];
+  }
+
+  if (normalized === "application/json") {
+    return ["application/json", "application/manifest+json"];
+  }
+
+  if (normalized === "image/x-icon") {
+    return ["image/x-icon", "image/vnd.microsoft.icon"];
+  }
+
+  return [normalized];
+}
+
+function normalizeContentType(contentType: string): string {
+  return contentType.split(";")[0]?.trim().toLowerCase() ?? "";
+}
+
+function getAssetAttemptFailure(params: { error: unknown }): AssetAttemptFailure | undefined {
+  if (params.error instanceof AssetAttemptFailure) {
+    return params.error;
+  }
+
+  if (params.error instanceof RetryError && params.error.cause instanceof AssetAttemptFailure) {
+    return params.error.cause;
+  }
+
+  return undefined;
+}

--- a/packages/playwright-toolkit/src/lib/deployedAssets.ts
+++ b/packages/playwright-toolkit/src/lib/deployedAssets.ts
@@ -44,9 +44,11 @@ export interface DeployedAssetAttempt {
   url: string;
 }
 
+export type DeployedAssetReportCheck = Omit<DeployedAssetCheck, "headers" | "validateResponse">;
+
 export interface DeployedAssetResult {
   attempts: DeployedAssetAttempt[];
-  check: DeployedAssetCheck;
+  check: DeployedAssetReportCheck;
   contentType?: string | undefined;
   errorMessage?: string | undefined;
   isSuccess: boolean;
@@ -229,6 +231,7 @@ async function verifyDeployedAsset(params: {
 }): Promise<DeployedAssetResult> {
   const attempts: DeployedAssetAttempt[] = [];
   const maxAttempts = params.options.retry?.maxAttempts ?? DEFAULT_RETRY_ATTEMPTS;
+  const reportCheck = toDeployedAssetReportCheck(params.check);
 
   try {
     const result = await runWithRetry<DeployedAssetAttempt>({
@@ -265,7 +268,7 @@ async function verifyDeployedAsset(params: {
 
     return {
       attempts,
-      check: params.check,
+      check: reportCheck,
       ...(finalAttempt.contentType === undefined ? {} : { contentType: finalAttempt.contentType }),
       isSuccess: true,
       ...(finalAttempt.status === undefined ? {} : { status: finalAttempt.status }),
@@ -276,7 +279,7 @@ async function verifyDeployedAsset(params: {
 
     return {
       attempts,
-      check: params.check,
+      check: reportCheck,
       ...(finalAttempt?.contentType === undefined ? {} : { contentType: finalAttempt.contentType }),
       errorMessage: failure?.message ?? getErrorMessage(error),
       isSuccess: false,
@@ -361,7 +364,18 @@ async function checkAssetOnce(params: {
     }
 
     if (params.check.validateResponse !== undefined) {
-      const validation = await params.check.validateResponse({ response });
+      let validation: DeployedAssetValidationResult;
+
+      try {
+        validation = await params.check.validateResponse({ response });
+      } catch (error: unknown) {
+        const message = getErrorMessage(error);
+        throw new AssetAttemptFailure({
+          attempt: { ...attempt, errorMessage: message },
+          isTransient: isTransientFetchError({ error }),
+          message,
+        });
+      }
 
       if (!validation.isValid) {
         const message = validation.message ?? "custom deployed asset validation failed";
@@ -456,19 +470,31 @@ function isExpectedContentType(params: {
 function getEquivalentContentTypes(contentType: string): string[] {
   const normalized = normalizeContentType(contentType);
 
-  if (normalized === "application/javascript") {
+  if (normalized === "application/javascript" || normalized === "text/javascript") {
     return ["application/javascript", "text/javascript"];
   }
 
-  if (normalized === "application/json") {
+  if (normalized === "application/json" || normalized === "application/manifest+json") {
     return ["application/json", "application/manifest+json"];
   }
 
-  if (normalized === "image/x-icon") {
+  if (normalized === "image/x-icon" || normalized === "image/vnd.microsoft.icon") {
     return ["image/x-icon", "image/vnd.microsoft.icon"];
   }
 
   return [normalized];
+}
+
+function toDeployedAssetReportCheck(check: DeployedAssetCheck): DeployedAssetReportCheck {
+  return {
+    path: check.path,
+    url: check.url,
+    ...(check.method === undefined ? {} : { method: check.method }),
+    ...(check.cacheMode === undefined ? {} : { cacheMode: check.cacheMode }),
+    ...(check.expectedContentTypes === undefined
+      ? {}
+      : { expectedContentTypes: check.expectedContentTypes }),
+  };
 }
 
 function normalizeContentType(contentType: string): string {

--- a/packages/playwright-toolkit/src/lib/mailpit.test.ts
+++ b/packages/playwright-toolkit/src/lib/mailpit.test.ts
@@ -1,5 +1,7 @@
 import {
   createMailpitClient,
+  extractEmailOtpCodeFromMailpitMessage,
+  extractMagicLinkFromMailpitMessage,
   fetchEmailOtpCodeFromMailpit,
   fetchMagicLinkFromMailpit,
   type MailpitClient,
@@ -125,6 +127,62 @@ describe("Mailpit polling", () => {
     await expect(client.searchMessages({ query: "to:user@example.test" })).resolves.toEqual([
       searchSummary,
     ]);
+  });
+
+  it("does not retry malformed Mailpit response schemas", async () => {
+    let currentTimeMs = 0;
+    const mockFetch = vi.fn<typeof fetch>(
+      async () =>
+        new Response(JSON.stringify({ messages: "malformed" }), {
+          status: 200,
+        }),
+    );
+    const client = createMailpitClient({
+      baseUrl: "https://mailpit.example.test/api/v1",
+      password: "secret",
+      fetchImplementation: mockFetch,
+    });
+
+    const actualPromise = fetchMagicLinkFromMailpit({
+      client,
+      email: "user@example.test",
+      timeoutMs: 1000,
+      pollIntervalMs: 100,
+      nowImplementation: () => currentTimeMs,
+      sleepImplementation: async ({ durationMs }) => {
+        currentTimeMs += durationMs;
+      },
+    });
+
+    await expect(actualPromise).rejects.toMatchObject({
+      attempts: 1,
+      reason: "non-transient",
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("searches HTML for a magic link when the text body has no link", () => {
+    const actual = extractMagicLinkFromMailpitMessage({
+      message: createMessage({
+        id: "magic-link",
+        text: "Open the HTML version to continue.",
+        html: '<a href="https://app.test/v2/email-login-link?payload=html">Sign in</a>',
+      }),
+    });
+
+    expect(actual).toBe("https://app.test/v2/email-login-link?payload=html");
+  });
+
+  it("searches HTML for an OTP when the text body has no code", () => {
+    const actual = extractEmailOtpCodeFromMailpitMessage({
+      message: createMessage({
+        id: "otp",
+        text: "Open the HTML version to see your code.",
+        html: "<div>8102 <span>7033</span></div>",
+      }),
+    });
+
+    expect(actual).toBe("81027033");
   });
 
   it("polls again when no matching message is ready", async () => {

--- a/packages/playwright-toolkit/src/lib/mailpit.test.ts
+++ b/packages/playwright-toolkit/src/lib/mailpit.test.ts
@@ -1,0 +1,249 @@
+import {
+  createMailpitClient,
+  fetchEmailOtpCodeFromMailpit,
+  fetchMagicLinkFromMailpit,
+  type MailpitClient,
+  type MailpitMessage,
+  type MailpitMessageSummary,
+} from "../index";
+
+describe("Mailpit polling", () => {
+  it("returns the newest non-excluded magic link", async () => {
+    const messages = [
+      createSearchSummary({ id: "new", created: "2026-07-16T12:00:00.000Z" }),
+      createSearchSummary({ id: "old", created: "2026-07-16T11:00:00.000Z" }),
+    ];
+    const mockClient: MailpitClient = {
+      searchMessages: vi.fn<MailpitClient["searchMessages"]>(async () => messages),
+      getMessage: vi.fn<MailpitClient["getMessage"]>(async ({ messageId }) =>
+        createMessage({
+          id: messageId,
+          text: `https://app.test/v2/email-login-link?payload=${messageId}`,
+        }),
+      ),
+    };
+
+    const actual = await fetchMagicLinkFromMailpit({
+      client: mockClient,
+      email: "user@example.test",
+      excludeLinks: ["https://app.test/v2/email-login-link?payload=new"],
+      timeoutMs: 1000,
+    });
+
+    expect(actual).toEqual({
+      value: "https://app.test/v2/email-login-link?payload=old",
+      messageId: "old",
+    });
+  });
+
+  it("extracts an eight-digit Cognito email OTP split across HTML elements", async () => {
+    const mockClient: MailpitClient = {
+      searchMessages: vi.fn<MailpitClient["searchMessages"]>(async () => [
+        createSearchSummary({ id: "otp" }),
+      ]),
+      getMessage: vi.fn<MailpitClient["getMessage"]>(async () =>
+        createMessage({
+          id: "otp",
+          html: "<style>.x{}</style><div>8102 <span>7033</span></div>",
+        }),
+      ),
+    };
+
+    const actual = await fetchEmailOtpCodeFromMailpit({
+      client: mockClient,
+      email: "user@example.test",
+      timeoutMs: 1000,
+    });
+
+    expect(actual).toEqual({ value: "81027033", messageId: "otp" });
+  });
+
+  it("uses authenticated Mailpit HTTP search and message endpoints", async () => {
+    const mockFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            messages: [createSearchSummary({ id: "message-1" })],
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(createMessage({ id: "message-1", text: "body" })), {
+          status: 200,
+        }),
+      );
+    const client = createMailpitClient({
+      baseUrl: "https://mailpit.example.test/api/v1",
+      password: "secret",
+      fetchImplementation: mockFetch,
+    });
+
+    const searchResult = await client.searchMessages({
+      query: "to:user@example.test",
+    });
+    const messageResult = await client.getMessage({ messageId: "message-1" });
+
+    expect(searchResult).toHaveLength(1);
+    expect(messageResult.Text).toBe("body");
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      1,
+      "https://mailpit.example.test/api/v1/search?query=to%3Auser%40example.test",
+      expect.objectContaining({
+        headers: {
+          authorization: `Basic ${Buffer.from("cbh:secret").toString("base64")}`,
+        },
+      }),
+    );
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      "https://mailpit.example.test/api/v1/message/message-1",
+      expect.any(Object),
+    );
+  });
+
+  it("keeps Mailpit search summaries that omit full-message fields", async () => {
+    const searchSummary = {
+      ID: "message-1",
+      Created: "2026-07-16T12:00:00.000Z",
+      From: { Address: "noreply@example.test", Name: "Clipboard" },
+      To: [{ Address: "user@example.test", Name: "User" }],
+      Subject: "Sign in",
+    };
+    const client = createMailpitClient({
+      baseUrl: "https://mailpit.example.test/api/v1",
+      password: "secret",
+      fetchImplementation: vi.fn<typeof fetch>(
+        async () =>
+          new Response(JSON.stringify({ messages: [searchSummary] }), {
+            status: 200,
+          }),
+      ),
+    });
+
+    await expect(client.searchMessages({ query: "to:user@example.test" })).resolves.toEqual([
+      searchSummary,
+    ]);
+  });
+
+  it("polls again when no matching message is ready", async () => {
+    let currentTimeMs = 0;
+    const mockClient: MailpitClient = {
+      searchMessages: vi
+        .fn<MailpitClient["searchMessages"]>()
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([createSearchSummary({ id: "ready" })]),
+      getMessage: vi.fn<MailpitClient["getMessage"]>(async () =>
+        createMessage({
+          id: "ready",
+          text: "https://app.test/v2/email-login-link?payload=ready",
+        }),
+      ),
+    };
+
+    const actual = await fetchMagicLinkFromMailpit({
+      client: mockClient,
+      email: "user@example.test",
+      timeoutMs: 5000,
+      pollIntervalMs: 100,
+      nowImplementation: () => currentTimeMs,
+      sleepImplementation: async ({ durationMs }) => {
+        currentTimeMs += durationMs;
+      },
+    });
+
+    expect(actual.value).toContain("payload=ready");
+    expect(mockClient.searchMessages).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not refetch unchanged messages across polling attempts", async () => {
+    let currentTimeMs = 0;
+    const staleMessage = createSearchSummary({ id: "stale" });
+    const readyMessage = createSearchSummary({
+      id: "ready",
+      created: "2026-07-16T12:01:00.000Z",
+    });
+    const mockGetMessage = vi
+      .fn<MailpitClient["getMessage"]>()
+      .mockResolvedValueOnce(createMessage({ id: "stale", text: "no link yet" }))
+      .mockResolvedValueOnce(
+        createMessage({
+          id: "ready",
+          text: "https://app.test/v2/email-login-link?payload=ready",
+        }),
+      );
+    const mockClient: MailpitClient = {
+      searchMessages: vi
+        .fn<MailpitClient["searchMessages"]>()
+        .mockResolvedValueOnce([staleMessage])
+        .mockResolvedValueOnce([readyMessage, staleMessage]),
+      getMessage: mockGetMessage,
+    };
+
+    const actual = await fetchMagicLinkFromMailpit({
+      client: mockClient,
+      email: "user@example.test",
+      timeoutMs: 5000,
+      pollIntervalMs: 100,
+      nowImplementation: () => currentTimeMs,
+      sleepImplementation: async ({ durationMs }) => {
+        currentTimeMs += durationMs;
+      },
+    });
+
+    expect(actual.messageId).toBe("ready");
+    expect(mockGetMessage).toHaveBeenCalledTimes(2);
+    expect(mockGetMessage).toHaveBeenCalledWith({ messageId: "stale" });
+    expect(mockGetMessage).toHaveBeenCalledWith({ messageId: "ready" });
+  });
+
+  it("does not include the recipient email in timeout errors", async () => {
+    let currentTimeMs = 0;
+    const email = "sensitive-user@example.test";
+    const mockClient: MailpitClient = {
+      searchMessages: vi.fn<MailpitClient["searchMessages"]>(async () => []),
+      getMessage: vi.fn<MailpitClient["getMessage"]>(),
+    };
+
+    const actualPromise = fetchMagicLinkFromMailpit({
+      client: mockClient,
+      email,
+      timeoutMs: 100,
+      pollIntervalMs: 100,
+      nowImplementation: () => currentTimeMs,
+      sleepImplementation: async ({ durationMs }) => {
+        currentTimeMs += durationMs;
+      },
+    });
+
+    await expect(actualPromise).rejects.not.toThrow(email);
+  });
+});
+
+function createMessage(params: {
+  id: string;
+  date?: string;
+  html?: string;
+  text?: string;
+}): MailpitMessage {
+  return {
+    ID: params.id,
+    From: { Address: "noreply@example.test", Name: "Clipboard" },
+    To: [{ Address: "user@example.test", Name: "User" }],
+    Subject: "Sign in",
+    Date: params.date ?? "2026-07-16T12:00:00.000Z",
+    Text: params.text ?? "",
+    HTML: params.html ?? "",
+  };
+}
+
+function createSearchSummary(params: { id: string; created?: string }): MailpitMessageSummary {
+  return {
+    ID: params.id,
+    Created: params.created ?? "2026-07-16T12:00:00.000Z",
+    From: { Address: "noreply@example.test", Name: "Clipboard" },
+    To: [{ Address: "user@example.test", Name: "User" }],
+    Subject: "Sign in",
+  };
+}

--- a/packages/playwright-toolkit/src/lib/mailpit.ts
+++ b/packages/playwright-toolkit/src/lib/mailpit.ts
@@ -1,0 +1,384 @@
+import { isRecord, toErrorMessage as getErrorMessage } from "@clipboard-health/util-ts";
+
+import { runWithRetry } from "./retry";
+import { isRetryableHttpStatus } from "./setupRetry";
+
+const DEFAULT_MAILPIT_BASE_URL = "https://mailpit.tools.cbh.rocks/api/v1";
+const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_POLL_INTERVAL_MS = 1000;
+const SENT_AFTER_TOLERANCE_MS = 30_000;
+const MAX_MESSAGES_TO_FETCH = 3;
+
+export interface MailpitAddress {
+  Address: string;
+  Name: string;
+}
+
+export interface MailpitMessageHeaders {
+  ID: string;
+  From: MailpitAddress;
+  To: MailpitAddress[];
+  Subject: string;
+}
+
+export interface MailpitMessageSummary extends MailpitMessageHeaders {
+  Created: string;
+}
+
+export interface MailpitMessage extends MailpitMessageHeaders {
+  Date: string;
+  Text: string;
+  HTML: string;
+}
+
+export interface MailpitClient {
+  searchMessages(params: { query: string }): Promise<MailpitMessageSummary[]>;
+  getMessage(params: { messageId: string }): Promise<MailpitMessage>;
+}
+
+export interface CreateMailpitClientParams {
+  password: string;
+  username?: string | undefined;
+  baseUrl?: string | undefined;
+  fetchImplementation?: typeof fetch | undefined;
+  requestTimeoutMs?: number | undefined;
+}
+
+export interface FetchMailpitValueResult {
+  value: string;
+  messageId: string;
+}
+
+export interface FetchMailpitValueParams {
+  client: MailpitClient;
+  email: string;
+  extractValue: (params: { message: MailpitMessage }) => string | undefined;
+  valueLabel: string;
+  timeoutMs?: number | undefined;
+  pollIntervalMs?: number | undefined;
+  sentAfter?: Date | undefined;
+  excludedValues?: readonly string[] | undefined;
+  sleepImplementation?: ((params: { durationMs: number }) => Promise<void>) | undefined;
+  nowImplementation?: (() => number) | undefined;
+}
+
+type MailpitPollParams = Omit<
+  FetchMailpitValueParams,
+  "excludedValues" | "extractValue" | "valueLabel"
+>;
+
+export type FetchMagicLinkFromMailpitParams = MailpitPollParams & {
+  excludeLinks?: readonly string[] | undefined;
+};
+
+export type FetchEmailOtpCodeFromMailpitParams = MailpitPollParams & {
+  excludeCodes?: readonly string[] | undefined;
+};
+
+interface MailpitRequestErrorParams {
+  message: string;
+  status?: number | undefined;
+  cause?: unknown;
+}
+
+export class MailpitRequestError extends Error {
+  public override readonly cause: unknown;
+  public readonly status: number | undefined;
+
+  public constructor(params: MailpitRequestErrorParams) {
+    super(params.message, { cause: params.cause });
+    this.name = "MailpitRequestError";
+    this.cause = params.cause;
+    this.status = params.status;
+  }
+}
+
+class MailpitValueNotFoundError extends Error {}
+
+export function createMailpitClient(params: CreateMailpitClientParams): MailpitClient {
+  if (params.password.length === 0) {
+    throw new Error("Mailpit password must not be empty");
+  }
+
+  const fetchImplementation = params.fetchImplementation ?? fetch;
+  const baseUrl = params.baseUrl ?? DEFAULT_MAILPIT_BASE_URL;
+  const authorization = `Basic ${Buffer.from(
+    `${params.username ?? "cbh"}:${params.password}`,
+  ).toString("base64")}`;
+
+  return {
+    async searchMessages({ query }) {
+      const response = await requestMailpitJson({
+        fetchImplementation,
+        requestTimeoutMs: params.requestTimeoutMs,
+        url: addSearchQuery({ baseUrl, query }),
+        authorization,
+      });
+
+      if (!isRecord(response) || !Array.isArray(response["messages"])) {
+        throw new MailpitRequestError({
+          message: "Mailpit search response is malformed",
+        });
+      }
+
+      return response["messages"].filter(isMailpitMessageSummary);
+    },
+    async getMessage({ messageId }) {
+      const response = await requestMailpitJson({
+        fetchImplementation,
+        requestTimeoutMs: params.requestTimeoutMs,
+        url: new URL(
+          `message/${encodeURIComponent(messageId)}`,
+          ensureTrailingSlash(baseUrl),
+        ).toString(),
+        authorization,
+      });
+
+      if (!isMailpitMessage(response)) {
+        throw new MailpitRequestError({
+          message: "Mailpit message response is malformed",
+        });
+      }
+
+      return response;
+    },
+  };
+}
+
+export async function fetchMailpitValue(
+  params: FetchMailpitValueParams,
+): Promise<FetchMailpitValueResult> {
+  const excludedValues = new Set(params.excludedValues ?? []);
+  const valuesByMessageId = new Map<string, string | undefined>();
+  const result = await runWithRetry({
+    operationName: `wait for Mailpit ${params.valueLabel}`,
+    operation: async () => {
+      const messages = await params.client.searchMessages({
+        query: `to:${params.email}`,
+      });
+      const candidates = messages
+        .filter((message) => isMessageSentAfter({ message, sentAfter: params.sentAfter }))
+        .toSorted(compareMailpitMessagesNewestFirst)
+        .slice(0, MAX_MESSAGES_TO_FETCH);
+
+      for (const message of candidates) {
+        if (valuesByMessageId.has(message.ID)) {
+          const cachedValue = valuesByMessageId.get(message.ID);
+
+          if (cachedValue !== undefined && !excludedValues.has(cachedValue)) {
+            return { value: cachedValue, messageId: message.ID };
+          }
+
+          continue;
+        }
+
+        try {
+          // eslint-disable-next-line no-await-in-loop -- Candidates are checked newest-first.
+          const fullMessage = await params.client.getMessage({
+            messageId: message.ID,
+          });
+          const value = params.extractValue({ message: fullMessage });
+          valuesByMessageId.set(message.ID, value);
+
+          if (value !== undefined && !excludedValues.has(value)) {
+            return { value, messageId: message.ID };
+          }
+        } catch (error: unknown) {
+          if (!isTransientMailpitError({ error })) {
+            throw error;
+          }
+        }
+      }
+
+      throw new MailpitValueNotFoundError(
+        `No matching Mailpit ${params.valueLabel} is available yet`,
+      );
+    },
+    mode: {
+      kind: "poll",
+      timeoutMs: params.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      intervalsMs: [params.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS],
+      isTransient: ({ error }) =>
+        error instanceof MailpitValueNotFoundError || isTransientMailpitError({ error }),
+    },
+    sleepImplementation: params.sleepImplementation,
+    nowImplementation: params.nowImplementation,
+  });
+
+  return result.value;
+}
+
+export async function fetchMagicLinkFromMailpit(
+  params: FetchMagicLinkFromMailpitParams,
+): Promise<FetchMailpitValueResult> {
+  return await fetchMailpitValue({
+    ...params,
+    excludedValues: params.excludeLinks,
+    extractValue: extractMagicLinkFromMailpitMessage,
+    valueLabel: "Cognito magic link",
+  });
+}
+
+export async function fetchEmailOtpCodeFromMailpit(
+  params: FetchEmailOtpCodeFromMailpitParams,
+): Promise<FetchMailpitValueResult> {
+  return await fetchMailpitValue({
+    ...params,
+    excludedValues: params.excludeCodes,
+    extractValue: extractEmailOtpCodeFromMailpitMessage,
+    valueLabel: "Cognito email OTP",
+  });
+}
+
+export function extractMagicLinkFromMailpitMessage(params: {
+  message: MailpitMessage;
+}): string | undefined {
+  const content = params.message.Text || params.message.HTML;
+  const matches = /https?:\/\/[^\s]+\/v2\/email-login-link\?[^\s<"')]*/i.exec(content);
+
+  return matches?.[0];
+}
+
+export function extractEmailOtpCodeFromMailpitMessage(params: {
+  message: MailpitMessage;
+}): string | undefined {
+  const source =
+    params.message.Text.trim().length > 0
+      ? params.message.Text
+      : params.message.HTML.replaceAll(/<(style|script)[^>]*>[\s\S]*?<\/\1>/gi, "").replaceAll(
+          /<[^>]+>/g,
+          " ",
+        );
+  const eightDigits = /(?<!\d)\d{8}(?!\d)/.exec(source);
+
+  if (eightDigits !== null) {
+    return eightDigits[0];
+  }
+
+  const twoGroups = /(?<!\d)(\d{4})\s*(\d{4})(?!\d)/.exec(source);
+
+  return twoGroups === null ? undefined : `${twoGroups[1]}${twoGroups[2]}`;
+}
+
+export function isTransientMailpitError(params: { error: unknown }): boolean {
+  if (!(params.error instanceof MailpitRequestError)) {
+    return false;
+  }
+
+  const { status } = params.error;
+  return status === undefined || status === 404 || isRetryableHttpStatus({ status });
+}
+
+async function requestMailpitJson(params: {
+  fetchImplementation: typeof fetch;
+  requestTimeoutMs?: number | undefined;
+  url: string;
+  authorization: string;
+}): Promise<unknown> {
+  const abortController = new AbortController();
+  const timeout = setTimeout(() => {
+    abortController.abort();
+  }, params.requestTimeoutMs ?? 10_000);
+
+  try {
+    let response: Response;
+
+    try {
+      response = await params.fetchImplementation(params.url, {
+        headers: { authorization: params.authorization },
+        signal: abortController.signal,
+      });
+    } catch (error: unknown) {
+      throw new MailpitRequestError({
+        message: `Mailpit request failed: ${getErrorMessage(error)}`,
+        cause: error,
+      });
+    }
+
+    if (!response.ok) {
+      throw new MailpitRequestError({
+        message: `Mailpit request failed with HTTP ${response.status}`,
+        status: response.status,
+      });
+    }
+
+    return await response.json();
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function addSearchQuery(params: { baseUrl: string; query: string }): string {
+  const url = new URL("search", ensureTrailingSlash(params.baseUrl));
+  url.searchParams.set("query", params.query);
+
+  return url.toString();
+}
+
+function ensureTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url : `${url}/`;
+}
+
+function isMessageSentAfter(params: {
+  message: MailpitMessageSummary;
+  sentAfter: Date | undefined;
+}): boolean {
+  if (params.sentAfter === undefined) {
+    return true;
+  }
+
+  const messageTimestamp = Date.parse(params.message.Created);
+  if (!Number.isFinite(messageTimestamp)) {
+    return true;
+  }
+
+  return messageTimestamp >= params.sentAfter.getTime() - SENT_AFTER_TOLERANCE_MS;
+}
+
+function compareMailpitMessagesNewestFirst(
+  first: MailpitMessageSummary,
+  second: MailpitMessageSummary,
+): number {
+  const firstTimestamp = Date.parse(first.Created);
+  const secondTimestamp = Date.parse(second.Created);
+
+  if (!Number.isFinite(firstTimestamp)) {
+    return Number.isFinite(secondTimestamp) ? 1 : 0;
+  }
+
+  if (!Number.isFinite(secondTimestamp)) {
+    return -1;
+  }
+
+  return secondTimestamp - firstTimestamp;
+}
+
+function isMailpitMessage(value: unknown): value is MailpitMessage {
+  return (
+    isRecord(value) &&
+    hasMailpitMessageHeaders(value) &&
+    typeof value["Date"] === "string" &&
+    typeof value["Text"] === "string" &&
+    typeof value["HTML"] === "string"
+  );
+}
+
+function isMailpitMessageSummary(value: unknown): value is MailpitMessageSummary {
+  return isRecord(value) && hasMailpitMessageHeaders(value) && typeof value["Created"] === "string";
+}
+
+function hasMailpitMessageHeaders(value: Record<string, unknown>): boolean {
+  return (
+    typeof value["ID"] === "string" &&
+    typeof value["Subject"] === "string" &&
+    isMailpitAddress(value["From"]) &&
+    Array.isArray(value["To"]) &&
+    value["To"].every(isMailpitAddress)
+  );
+}
+
+function isMailpitAddress(value: unknown): value is MailpitAddress {
+  return (
+    isRecord(value) && typeof value["Address"] === "string" && typeof value["Name"] === "string"
+  );
+}

--- a/packages/playwright-toolkit/src/lib/mailpit.ts
+++ b/packages/playwright-toolkit/src/lib/mailpit.ts
@@ -79,16 +79,19 @@ interface MailpitRequestErrorParams {
   message: string;
   status?: number | undefined;
   cause?: unknown;
+  isTransient?: boolean | undefined;
 }
 
 export class MailpitRequestError extends Error {
   public override readonly cause: unknown;
+  public readonly isTransient: boolean;
   public readonly status: number | undefined;
 
   public constructor(params: MailpitRequestErrorParams) {
     super(params.message, { cause: params.cause });
     this.name = "MailpitRequestError";
     this.cause = params.cause;
+    this.isTransient = params.isTransient ?? false;
     this.status = params.status;
   }
 }
@@ -233,22 +236,34 @@ export async function fetchEmailOtpCodeFromMailpit(
 export function extractMagicLinkFromMailpitMessage(params: {
   message: MailpitMessage;
 }): string | undefined {
-  const content = params.message.Text || params.message.HTML;
-  const matches = /https?:\/\/[^\s]+\/v2\/email-login-link\?[^\s<"')]*/i.exec(content);
+  for (const content of [params.message.Text, params.message.HTML]) {
+    const match = /https?:\/\/[^\s]+\/v2\/email-login-link\?[^\s<"')]*/i.exec(content);
 
-  return matches?.[0];
+    if (match !== null) {
+      return match[0];
+    }
+  }
+
+  return undefined;
 }
 
 export function extractEmailOtpCodeFromMailpitMessage(params: {
   message: MailpitMessage;
 }): string | undefined {
-  const source =
-    params.message.Text.trim().length > 0
-      ? params.message.Text
-      : params.message.HTML.replaceAll(/<(style|script)[^>]*>[\s\S]*?<\/\1>/gi, "").replaceAll(
-          /<[^>]+>/g,
-          " ",
-        );
+  const textCode = extractEmailOtpCodeFromContent(params.message.Text);
+  if (textCode !== undefined) {
+    return textCode;
+  }
+
+  const htmlText = params.message.HTML.replaceAll(
+    /<(style|script)[^>]*>[\s\S]*?<\/\1>/gi,
+    "",
+  ).replaceAll(/<[^>]+>/g, " ");
+
+  return extractEmailOtpCodeFromContent(htmlText);
+}
+
+function extractEmailOtpCodeFromContent(source: string): string | undefined {
   const eightDigits = /(?<!\d)\d{8}(?!\d)/.exec(source);
 
   if (eightDigits !== null) {
@@ -266,7 +281,7 @@ export function isTransientMailpitError(params: { error: unknown }): boolean {
   }
 
   const { status } = params.error;
-  return status === undefined || status === 404 || isRetryableHttpStatus({ status });
+  return params.error.isTransient || status === 404 || isRetryableHttpStatus({ status });
 }
 
 async function requestMailpitJson(params: {
@@ -292,6 +307,7 @@ async function requestMailpitJson(params: {
       throw new MailpitRequestError({
         message: `Mailpit request failed: ${getErrorMessage(error)}`,
         cause: error,
+        isTransient: true,
       });
     }
 

--- a/packages/playwright-toolkit/src/lib/retry.test.ts
+++ b/packages/playwright-toolkit/src/lib/retry.test.ts
@@ -138,10 +138,23 @@ describe("runWithRetry", () => {
       message: "intervalsMs must be finite and non-negative",
     },
     {
+      mode: { kind: "poll" as const, timeoutMs: 100, intervalsMs: [-1] },
+      message: "intervalsMs must be finite and non-negative",
+    },
+    {
       mode: {
         kind: "classified" as const,
         maxAttempts: 2,
         delayMs: Number.POSITIVE_INFINITY,
+        isTransient: () => true,
+      },
+      message: "delayMs must be finite and non-negative",
+    },
+    {
+      mode: {
+        kind: "classified" as const,
+        maxAttempts: 2,
+        delayMs: -1,
         isTransient: () => true,
       },
       message: "delayMs must be finite and non-negative",

--- a/packages/playwright-toolkit/src/lib/retry.test.ts
+++ b/packages/playwright-toolkit/src/lib/retry.test.ts
@@ -127,4 +127,109 @@ describe("runWithRetry", () => {
       vi.useRealTimers();
     }
   });
+
+  it.each([
+    {
+      mode: { kind: "poll" as const, timeoutMs: 100, intervalsMs: [] },
+      message: "intervalsMs must not be empty",
+    },
+    {
+      mode: { kind: "poll" as const, timeoutMs: 100, intervalsMs: [Number.NaN] },
+      message: "intervalsMs must be finite and non-negative",
+    },
+    {
+      mode: {
+        kind: "classified" as const,
+        maxAttempts: 2,
+        delayMs: Number.POSITIVE_INFINITY,
+        isTransient: () => true,
+      },
+      message: "delayMs must be finite and non-negative",
+    },
+  ])("rejects invalid retry schedules: $message", async ({ mode, message }) => {
+    await expect(
+      runWithRetry({
+        operationName: "invalid retry",
+        operation: async () => await Promise.reject(new Error("not ready")),
+        mode,
+      }),
+    ).rejects.toThrow(message);
+  });
+
+  it("rejects invalid delays returned by classified retry functions", async () => {
+    await expect(
+      runWithRetry({
+        operationName: "invalid retry delay",
+        operation: async () => await Promise.reject(new Error("not ready")),
+        mode: {
+          kind: "classified",
+          maxAttempts: 2,
+          delayMs: () => Number.NaN,
+          isTransient: () => true,
+        },
+      }),
+    ).rejects.toThrow("Retry delay must be finite and non-negative");
+  });
+
+  it("keeps a pending failure hook inside the poll deadline", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const pendingPromise = new Promise<void>(() => {
+        // Intentionally pending to exercise the hard poll deadline.
+      });
+      const actualPromise = runWithRetry({
+        operationName: "wait for pending failure hook",
+        operation: async () => await Promise.reject(new Error("not ready")),
+        mode: {
+          kind: "poll",
+          timeoutMs: 100,
+        },
+        onFailedAttempt: async () => {
+          await pendingPromise;
+        },
+      });
+
+      await Promise.all([
+        expect(actualPromise).rejects.toMatchObject({
+          reason: "timeout",
+          attempts: 1,
+        }),
+        vi.advanceTimersByTimeAsync(100),
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a pending sleep inside the poll deadline", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const pendingPromise = new Promise<void>(() => {
+        // Intentionally pending to exercise the hard poll deadline.
+      });
+      const actualPromise = runWithRetry({
+        operationName: "wait for pending sleep",
+        operation: async () => await Promise.reject(new Error("not ready")),
+        mode: {
+          kind: "poll",
+          timeoutMs: 100,
+        },
+        sleepImplementation: async () => {
+          await pendingPromise;
+        },
+      });
+
+      await Promise.all([
+        expect(actualPromise).rejects.toMatchObject({
+          reason: "timeout",
+          attempts: 1,
+        }),
+        vi.advanceTimersByTimeAsync(100),
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/playwright-toolkit/src/lib/retry.test.ts
+++ b/packages/playwright-toolkit/src/lib/retry.test.ts
@@ -1,0 +1,130 @@
+import { type RetryAttemptContext, type RetryError, runWithRetry } from "../index";
+
+describe("runWithRetry", () => {
+  it("retries only errors approved by the classified transient predicate", async () => {
+    const input = new Error("service unavailable");
+    const mockOperation = vi
+      .fn<(context: RetryAttemptContext) => Promise<string>>()
+      .mockRejectedValueOnce(input)
+      .mockResolvedValueOnce("ready");
+    const sleepDurations: number[] = [];
+
+    const actual = await runWithRetry({
+      operationName: "load readiness",
+      operation: mockOperation,
+      mode: {
+        kind: "classified",
+        maxAttempts: 3,
+        delayMs: 25,
+        isTransient: ({ error }) => error === input,
+      },
+      sleepImplementation: async ({ durationMs }) => {
+        sleepDurations.push(durationMs);
+      },
+    });
+
+    expect(actual).toEqual({ value: "ready", attempts: 2 });
+    expect(sleepDurations).toEqual([25]);
+  });
+
+  it("bails immediately with rich context for non-transient failures", async () => {
+    const input = new Error("invalid request");
+
+    const actualPromise = runWithRetry({
+      operationName: "create worker",
+      operation: async () => await Promise.reject(input),
+      mode: {
+        kind: "classified",
+        maxAttempts: 5,
+        isTransient: () => false,
+      },
+    });
+
+    await expect(actualPromise).rejects.toMatchObject({
+      name: "RetryError",
+      operationName: "create worker",
+      attempts: 1,
+      reason: "non-transient",
+      cause: input,
+    });
+  });
+
+  it("polls until pass within a timeout budget", async () => {
+    let currentTimeMs = 0;
+    const mockOperation = vi
+      .fn<(context: RetryAttemptContext) => Promise<string>>()
+      .mockRejectedValueOnce(new Error("not ready"))
+      .mockRejectedValueOnce(new Error("still not ready"))
+      .mockResolvedValueOnce("ready");
+
+    const actual = await runWithRetry({
+      operationName: "wait for mail",
+      operation: mockOperation,
+      mode: {
+        kind: "poll",
+        timeoutMs: 1000,
+        intervalsMs: [100, 200],
+      },
+      nowImplementation: () => currentTimeMs,
+      sleepImplementation: async ({ durationMs }) => {
+        currentTimeMs += durationMs;
+      },
+    });
+
+    expect(actual).toEqual({ value: "ready", attempts: 3 });
+  });
+
+  it("reports poll timeout exhaustion with the last error", async () => {
+    let currentTimeMs = 0;
+    const input = new Error("not ready");
+
+    const actualPromise = runWithRetry({
+      operationName: "wait for deployment",
+      operation: async () => await Promise.reject(input),
+      mode: {
+        kind: "poll",
+        timeoutMs: 250,
+        intervalsMs: [100],
+      },
+      nowImplementation: () => currentTimeMs,
+      sleepImplementation: async ({ durationMs }) => {
+        currentTimeMs += durationMs;
+      },
+    });
+
+    await expect(actualPromise).rejects.toEqual(
+      expect.objectContaining<Partial<RetryError>>({
+        reason: "timeout",
+        attempts: 3,
+        cause: input,
+      }),
+    );
+  });
+
+  it("enforces the poll timeout when an attempt does not settle", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const actualPromise = runWithRetry({
+        operationName: "wait for hung probe",
+        operation: async () =>
+          await new Promise<string>(() => {
+            // Intentionally pending to exercise the hard poll deadline.
+          }),
+        mode: {
+          kind: "poll",
+          timeoutMs: 100,
+        },
+      });
+      await Promise.all([
+        expect(actualPromise).rejects.toMatchObject({
+          reason: "timeout",
+          attempts: 1,
+        }),
+        vi.advanceTimersByTimeAsync(100),
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/playwright-toolkit/src/lib/retry.ts
+++ b/packages/playwright-toolkit/src/lib/retry.ts
@@ -141,8 +141,32 @@ export async function runWithRetry<T>(params: RunWithRetryParams<T>): Promise<Re
         error,
         signal: abortController.signal,
       };
-      // eslint-disable-next-line no-await-in-loop -- Attempt reporting is intentionally sequential.
-      await params.onFailedAttempt?.(failureContext);
+
+      try {
+        // eslint-disable-next-line no-await-in-loop -- Attempt reporting is intentionally sequential.
+        await runWithinRetryBudget({
+          abortController,
+          elapsedMs: failureContext.elapsedMs,
+          mode: params.mode,
+          promise: Promise.resolve(params.onFailedAttempt?.(failureContext)),
+        });
+      } catch (hookError: unknown) {
+        if (hookError instanceof PollAttemptTimeoutError) {
+          throw createPollTimeoutError({
+            attempts: attemptNumber,
+            cause: error,
+            elapsedMs: getElapsedMs({ nowImplementation, startedAtMs }),
+            operationName: params.operationName,
+          });
+        }
+
+        throw hookError;
+      }
+
+      failureContext.elapsedMs = getElapsedMs({
+        nowImplementation,
+        startedAtMs,
+      });
 
       const terminalReason = getTerminalReason({
         context: failureContext,
@@ -162,8 +186,27 @@ export async function runWithRetry<T>(params: RunWithRetryParams<T>): Promise<Re
         context: failureContext,
         mode: params.mode,
       });
-      // eslint-disable-next-line no-await-in-loop -- Retry attempts are intentionally sequential.
-      await sleepImplementation({ durationMs });
+
+      try {
+        // eslint-disable-next-line no-await-in-loop -- Retry attempts are intentionally sequential.
+        await runWithinRetryBudget({
+          abortController,
+          elapsedMs: failureContext.elapsedMs,
+          mode: params.mode,
+          promise: sleepImplementation({ durationMs }),
+        });
+      } catch (sleepError: unknown) {
+        if (sleepError instanceof PollAttemptTimeoutError) {
+          throw createPollTimeoutError({
+            attempts: attemptNumber,
+            cause: error,
+            elapsedMs: getElapsedMs({ nowImplementation, startedAtMs }),
+            operationName: params.operationName,
+          });
+        }
+
+        throw sleepError;
+      }
     }
   }
 }
@@ -174,8 +217,8 @@ function validateRetryMode(mode: RetryMode): void {
       throw new Error("Classified retry maxAttempts must be a positive integer");
     }
 
-    if (typeof mode.delayMs === "number" && mode.delayMs < 0) {
-      throw new Error("Classified retry delayMs must be non-negative");
+    if (typeof mode.delayMs === "number" && (!Number.isFinite(mode.delayMs) || mode.delayMs < 0)) {
+      throw new Error("Classified retry delayMs must be finite and non-negative");
     }
 
     return;
@@ -185,8 +228,14 @@ function validateRetryMode(mode: RetryMode): void {
     throw new Error("Poll retry timeoutMs must be positive");
   }
 
-  if (mode.intervalsMs?.some((intervalMs) => intervalMs < 0) === true) {
-    throw new Error("Poll retry intervalsMs must be non-negative");
+  if (mode.intervalsMs?.length === 0) {
+    throw new Error("Poll retry intervalsMs must not be empty");
+  }
+
+  if (
+    mode.intervalsMs?.some((intervalMs) => !Number.isFinite(intervalMs) || intervalMs < 0) === true
+  ) {
+    throw new Error("Poll retry intervalsMs must be finite and non-negative");
   }
 }
 
@@ -223,16 +272,30 @@ async function runAttempt<T>(params: {
 }): Promise<T> {
   const operationPromise = params.operation(params.context);
 
+  return await runWithinRetryBudget({
+    abortController: params.abortController,
+    elapsedMs: params.context.elapsedMs,
+    mode: params.mode,
+    promise: operationPromise,
+  });
+}
+
+async function runWithinRetryBudget<T>(params: {
+  abortController: AbortController;
+  elapsedMs: number;
+  mode: RetryMode;
+  promise: Promise<T>;
+}): Promise<T> {
   if (params.mode.kind === "classified") {
-    return await operationPromise;
+    return await params.promise;
   }
 
-  const remainingTimeoutMs = Math.max(params.mode.timeoutMs - params.context.elapsedMs, 0);
+  const remainingTimeoutMs = Math.max(params.mode.timeoutMs - params.elapsedMs, 0);
   let timeout: ReturnType<typeof setTimeout> | undefined;
 
   try {
     return await Promise.race([
-      operationPromise,
+      params.promise,
       new Promise<T>((_resolve, reject) => {
         timeout = setTimeout(() => {
           params.abortController.abort();
@@ -248,18 +311,27 @@ async function runAttempt<T>(params: {
 }
 
 function getRetryDelayMs(params: { context: RetryFailureContext; mode: RetryMode }): number {
+  let durationMs: number;
+
   if (params.mode.kind === "classified") {
-    return typeof params.mode.delayMs === "function"
-      ? params.mode.delayMs(params.context)
-      : (params.mode.delayMs ?? 0);
+    durationMs =
+      typeof params.mode.delayMs === "function"
+        ? params.mode.delayMs(params.context)
+        : (params.mode.delayMs ?? 0);
+  } else {
+    const intervalsMs = params.mode.intervalsMs ?? [100, 250, 500, 1000];
+    const intervalIndex = Math.min(params.context.attemptNumber - 1, intervalsMs.length - 1);
+    const configuredDelayMs = intervalsMs[intervalIndex] ?? 0;
+    const remainingMs = Math.max(params.mode.timeoutMs - params.context.elapsedMs, 0);
+
+    durationMs = Math.min(configuredDelayMs, remainingMs);
   }
 
-  const intervalsMs = params.mode.intervalsMs ?? [100, 250, 500, 1000];
-  const intervalIndex = Math.min(params.context.attemptNumber - 1, intervalsMs.length - 1);
-  const configuredDelayMs = intervalsMs[intervalIndex] ?? 0;
-  const remainingMs = Math.max(params.mode.timeoutMs - params.context.elapsedMs, 0);
+  if (!Number.isFinite(durationMs) || durationMs < 0) {
+    throw new Error("Retry delay must be finite and non-negative");
+  }
 
-  return Math.min(configuredDelayMs, remainingMs);
+  return durationMs;
 }
 
 function getElapsedMs(params: { nowImplementation: () => number; startedAtMs: number }): number {
@@ -279,4 +351,16 @@ function formatRetryErrorMessage(params: RetryErrorParams): string {
     `(${params.elapsedMs}ms, reason: ${params.reason}). ` +
     `Last error: ${getErrorMessage(params.cause)}`
   );
+}
+
+function createPollTimeoutError(params: {
+  attempts: number;
+  cause: unknown;
+  elapsedMs: number;
+  operationName: string;
+}): RetryError {
+  return new RetryError({
+    ...params,
+    reason: "timeout",
+  });
 }

--- a/packages/playwright-toolkit/src/lib/retry.ts
+++ b/packages/playwright-toolkit/src/lib/retry.ts
@@ -1,0 +1,282 @@
+import { toErrorMessage as getErrorMessage } from "@clipboard-health/util-ts";
+
+export type RetryFailureReason = "attempts-exhausted" | "non-transient" | "timeout";
+
+export interface RetryAttemptContext {
+  attemptNumber: number;
+  elapsedMs: number;
+  signal: AbortSignal;
+}
+
+export interface RetryFailureContext extends RetryAttemptContext {
+  error: unknown;
+}
+
+export interface ClassifiedRetryMode {
+  kind: "classified";
+  maxAttempts: number;
+  delayMs?: number | ((context: RetryFailureContext) => number) | undefined;
+  isTransient: (context: RetryFailureContext) => boolean;
+}
+
+export interface PollRetryMode {
+  kind: "poll";
+  timeoutMs: number;
+  intervalsMs?: readonly number[] | undefined;
+  isTransient?: ((context: RetryFailureContext) => boolean) | undefined;
+}
+
+export type RetryMode = ClassifiedRetryMode | PollRetryMode;
+
+export interface RetrySuccess<T> {
+  value: T;
+  attempts: number;
+}
+
+export interface RunWithRetryParams<T> {
+  operationName: string;
+  operation: (context: RetryAttemptContext) => Promise<T>;
+  mode: RetryMode;
+  nowImplementation?: (() => number) | undefined;
+  sleepImplementation?: ((params: { durationMs: number }) => Promise<void>) | undefined;
+  onFailedAttempt?: ((context: RetryFailureContext) => void | Promise<void>) | undefined;
+}
+
+interface RetryErrorParams {
+  operationName: string;
+  attempts: number;
+  elapsedMs: number;
+  reason: RetryFailureReason;
+  cause: unknown;
+}
+
+class PollAttemptTimeoutError extends Error {
+  public constructor() {
+    super("Poll attempt exceeded the remaining timeout budget");
+    this.name = "PollAttemptTimeoutError";
+  }
+}
+
+/**
+ * Rich terminal error for both retry modes.
+ *
+ * `reason` distinguishes deterministic bail-out, attempt exhaustion, and poll
+ * timeout while `cause` retains the last operation error.
+ */
+export class RetryError extends Error {
+  public readonly attempts: number;
+  public override readonly cause: unknown;
+  public readonly elapsedMs: number;
+  public readonly operationName: string;
+  public readonly reason: RetryFailureReason;
+
+  public constructor(params: RetryErrorParams) {
+    super(formatRetryErrorMessage(params), { cause: params.cause });
+    this.name = "RetryError";
+    this.attempts = params.attempts;
+    this.cause = params.cause;
+    this.elapsedMs = params.elapsedMs;
+    this.operationName = params.operationName;
+    this.reason = params.reason;
+  }
+}
+
+/**
+ * Runs one bounded retry policy.
+ *
+ * Classified mode is for operations where the caller can positively identify
+ * transient failures. Poll mode is for idempotent readiness probes where every
+ * failure means "not ready yet" until the timeout expires.
+ */
+export async function runWithRetry<T>(params: RunWithRetryParams<T>): Promise<RetrySuccess<T>> {
+  validateRetryMode(params.mode);
+
+  const nowImplementation = params.nowImplementation ?? Date.now;
+  const sleepImplementation = params.sleepImplementation ?? sleep;
+  const startedAtMs = nowImplementation();
+  let attemptNumber = 0;
+  let lastError: unknown;
+
+  for (;;) {
+    const elapsedBeforeAttemptMs = getElapsedMs({
+      nowImplementation,
+      startedAtMs,
+    });
+
+    if (
+      params.mode.kind === "poll" &&
+      attemptNumber > 0 &&
+      elapsedBeforeAttemptMs >= params.mode.timeoutMs
+    ) {
+      throw new RetryError({
+        operationName: params.operationName,
+        attempts: attemptNumber,
+        elapsedMs: elapsedBeforeAttemptMs,
+        reason: "timeout",
+        cause: lastError,
+      });
+    }
+
+    attemptNumber += 1;
+    const abortController = new AbortController();
+
+    try {
+      // eslint-disable-next-line no-await-in-loop -- Retry attempts are intentionally sequential.
+      const value = await runAttempt({
+        context: {
+          attemptNumber,
+          elapsedMs: elapsedBeforeAttemptMs,
+          signal: abortController.signal,
+        },
+        mode: params.mode,
+        operation: params.operation,
+        abortController,
+      });
+      return { value, attempts: attemptNumber };
+    } catch (error: unknown) {
+      lastError = error;
+      const failureContext = {
+        attemptNumber,
+        elapsedMs: getElapsedMs({ nowImplementation, startedAtMs }),
+        error,
+        signal: abortController.signal,
+      };
+      // eslint-disable-next-line no-await-in-loop -- Attempt reporting is intentionally sequential.
+      await params.onFailedAttempt?.(failureContext);
+
+      const terminalReason = getTerminalReason({
+        context: failureContext,
+        mode: params.mode,
+      });
+      if (terminalReason !== undefined) {
+        throw new RetryError({
+          operationName: params.operationName,
+          attempts: attemptNumber,
+          elapsedMs: failureContext.elapsedMs,
+          reason: terminalReason,
+          cause: error,
+        });
+      }
+
+      const durationMs = getRetryDelayMs({
+        context: failureContext,
+        mode: params.mode,
+      });
+      // eslint-disable-next-line no-await-in-loop -- Retry attempts are intentionally sequential.
+      await sleepImplementation({ durationMs });
+    }
+  }
+}
+
+function validateRetryMode(mode: RetryMode): void {
+  if (mode.kind === "classified") {
+    if (!Number.isInteger(mode.maxAttempts) || mode.maxAttempts < 1) {
+      throw new Error("Classified retry maxAttempts must be a positive integer");
+    }
+
+    if (typeof mode.delayMs === "number" && mode.delayMs < 0) {
+      throw new Error("Classified retry delayMs must be non-negative");
+    }
+
+    return;
+  }
+
+  if (!Number.isFinite(mode.timeoutMs) || mode.timeoutMs <= 0) {
+    throw new Error("Poll retry timeoutMs must be positive");
+  }
+
+  if (mode.intervalsMs?.some((intervalMs) => intervalMs < 0) === true) {
+    throw new Error("Poll retry intervalsMs must be non-negative");
+  }
+}
+
+function getTerminalReason(params: {
+  context: RetryFailureContext;
+  mode: RetryMode;
+}): RetryFailureReason | undefined {
+  if (params.mode.kind === "classified") {
+    if (!params.mode.isTransient(params.context)) {
+      return "non-transient";
+    }
+
+    return params.context.attemptNumber >= params.mode.maxAttempts
+      ? "attempts-exhausted"
+      : undefined;
+  }
+
+  if (params.context.error instanceof PollAttemptTimeoutError) {
+    return "timeout";
+  }
+
+  if (params.mode.isTransient?.(params.context) === false) {
+    return "non-transient";
+  }
+
+  return params.context.elapsedMs >= params.mode.timeoutMs ? "timeout" : undefined;
+}
+
+async function runAttempt<T>(params: {
+  abortController: AbortController;
+  context: RetryAttemptContext;
+  mode: RetryMode;
+  operation: (context: RetryAttemptContext) => Promise<T>;
+}): Promise<T> {
+  const operationPromise = params.operation(params.context);
+
+  if (params.mode.kind === "classified") {
+    return await operationPromise;
+  }
+
+  const remainingTimeoutMs = Math.max(params.mode.timeoutMs - params.context.elapsedMs, 0);
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    return await Promise.race([
+      operationPromise,
+      new Promise<T>((_resolve, reject) => {
+        timeout = setTimeout(() => {
+          params.abortController.abort();
+          reject(new PollAttemptTimeoutError());
+        }, remainingTimeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function getRetryDelayMs(params: { context: RetryFailureContext; mode: RetryMode }): number {
+  if (params.mode.kind === "classified") {
+    return typeof params.mode.delayMs === "function"
+      ? params.mode.delayMs(params.context)
+      : (params.mode.delayMs ?? 0);
+  }
+
+  const intervalsMs = params.mode.intervalsMs ?? [100, 250, 500, 1000];
+  const intervalIndex = Math.min(params.context.attemptNumber - 1, intervalsMs.length - 1);
+  const configuredDelayMs = intervalsMs[intervalIndex] ?? 0;
+  const remainingMs = Math.max(params.mode.timeoutMs - params.context.elapsedMs, 0);
+
+  return Math.min(configuredDelayMs, remainingMs);
+}
+
+function getElapsedMs(params: { nowImplementation: () => number; startedAtMs: number }): number {
+  return Math.max(params.nowImplementation() - params.startedAtMs, 0);
+}
+
+async function sleep(params: { durationMs: number }): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, params.durationMs);
+  });
+}
+
+function formatRetryErrorMessage(params: RetryErrorParams): string {
+  return (
+    `${params.operationName} failed after ${params.attempts} ` +
+    `${params.attempts === 1 ? "attempt" : "attempts"} ` +
+    `(${params.elapsedMs}ms, reason: ${params.reason}). ` +
+    `Last error: ${getErrorMessage(params.cause)}`
+  );
+}

--- a/packages/playwright-toolkit/src/lib/setupRetry.test.ts
+++ b/packages/playwright-toolkit/src/lib/setupRetry.test.ts
@@ -1,0 +1,49 @@
+import { classifySetupRetry, isRetryableHttpStatus } from "../index";
+
+describe("setup retry classification", () => {
+  it.each([408, 429, 500, 503])("classifies HTTP %s as transient", (status) => {
+    expect(isRetryableHttpStatus({ status })).toBe(true);
+  });
+
+  it.each([400, 401, 403, 404, 422, 600])("classifies HTTP %s as deterministic", (status) => {
+    expect(isRetryableHttpStatus({ status })).toBe(false);
+  });
+
+  it("regenerates identity for collision failures", () => {
+    const input = new Error("phone already in use");
+
+    expect(
+      classifySetupRetry({
+        error: input,
+        isIdentityCollision: ({ error }) => error === input,
+      }),
+    ).toEqual({
+      classification: "identity-collision",
+      retryDecision: "regenerate-identity",
+    });
+  });
+
+  it("retries the same identity only for transient failures", () => {
+    const input = {
+      message: "service unavailable",
+      response: { status: 503 },
+    };
+
+    expect(classifySetupRetry({ error: input })).toEqual({
+      classification: "transient",
+      retryDecision: "retry-same-identity",
+    });
+  });
+
+  it("does not retry deterministic setup failures", () => {
+    const input = {
+      message: "invalid qualification",
+      response: { status: 422 },
+    };
+
+    expect(classifySetupRetry({ error: input })).toEqual({
+      classification: "deterministic",
+      retryDecision: "do-not-retry",
+    });
+  });
+});

--- a/packages/playwright-toolkit/src/lib/setupRetry.ts
+++ b/packages/playwright-toolkit/src/lib/setupRetry.ts
@@ -1,0 +1,81 @@
+import { isRecord } from "@clipboard-health/util-ts";
+
+export type SetupRetryClassification = "deterministic" | "identity-collision" | "transient";
+export type SetupRetryDecision = "do-not-retry" | "regenerate-identity" | "retry-same-identity";
+
+export interface SetupRetryResult {
+  classification: SetupRetryClassification;
+  retryDecision: SetupRetryDecision;
+}
+
+export interface SetupErrorContext {
+  error: unknown;
+  status: number | undefined;
+}
+
+export interface ClassifySetupRetryParams {
+  error: unknown;
+  isIdentityCollision?: (context: SetupErrorContext) => boolean;
+  isTransientError?: (context: SetupErrorContext) => boolean;
+}
+
+/**
+ * Classifies setup failures without conflating identity collisions and
+ * transient infrastructure errors.
+ *
+ * Collision retries must regenerate a fresh identity. Transient retries must
+ * repeat the same identity so they do not change the scenario under test.
+ */
+export function classifySetupRetry(params: ClassifySetupRetryParams): SetupRetryResult {
+  const context = {
+    error: params.error,
+    status: getHttpErrorStatus({ error: params.error }),
+  };
+
+  if (params.isIdentityCollision?.(context) === true) {
+    return {
+      classification: "identity-collision",
+      retryDecision: "regenerate-identity",
+    };
+  }
+
+  if (
+    isRetryableHttpStatus({ status: context.status }) ||
+    params.isTransientError?.(context) === true
+  ) {
+    return {
+      classification: "transient",
+      retryDecision: "retry-same-identity",
+    };
+  }
+
+  return {
+    classification: "deterministic",
+    retryDecision: "do-not-retry",
+  };
+}
+
+export function isRetryableHttpStatus(params: { status: number | undefined }): boolean {
+  return (
+    params.status === 408 ||
+    params.status === 429 ||
+    (typeof params.status === "number" && params.status >= 500 && params.status <= 599)
+  );
+}
+
+export function getHttpErrorStatus(params: { error: unknown }): number | undefined {
+  if (!isRecord(params.error)) {
+    return undefined;
+  }
+
+  if (typeof params.error["status"] === "number") {
+    return params.error["status"];
+  }
+
+  const response = params.error["response"];
+  if (isRecord(response) && typeof response["status"] === "number") {
+    return response["status"];
+  }
+
+  return undefined;
+}

--- a/packages/playwright-toolkit/src/lib/traceparent.test.ts
+++ b/packages/playwright-toolkit/src/lib/traceparent.test.ts
@@ -1,0 +1,82 @@
+import { createTraceparent, createTraceparentFixtures, installTraceparentForTest } from "../index";
+
+describe("traceparent", () => {
+  it("creates a valid non-zero W3C traceparent", () => {
+    const mockRandomBytes = vi
+      .fn<(byteCount: number) => Uint8Array>()
+      .mockReturnValueOnce(Buffer.from("11111111111111111111111111111111", "hex"))
+      .mockReturnValueOnce(Buffer.from("2222222222222222", "hex"));
+
+    const actual = createTraceparent({
+      randomBytesImplementation: mockRandomBytes,
+    });
+
+    expect(actual).toBe("00-11111111111111111111111111111111-2222222222222222-01");
+  });
+
+  it("installs the per-test header and annotation", async () => {
+    const mockSetExtraHttpHeaders = vi
+      .fn<(headers: Record<string, string>) => Promise<void>>()
+      .mockResolvedValue();
+    const annotations: Array<{ type: string; description?: string }> = [];
+
+    const actual = await installTraceparentForTest({
+      context: {
+        setExtraHTTPHeaders: mockSetExtraHttpHeaders,
+      },
+      testInfo: { annotations },
+      traceparent: "00-11111111111111111111111111111111-2222222222222222-01",
+    });
+
+    expect(actual).toEqual({
+      traceparent: "00-11111111111111111111111111111111-2222222222222222-01",
+    });
+    expect(mockSetExtraHttpHeaders).toHaveBeenCalledWith({
+      traceparent: actual.traceparent,
+    });
+    expect(annotations).toEqual([{ type: "traceparent", description: actual.traceparent }]);
+  });
+
+  it("preserves project HTTP headers in the automatic Playwright fixture", async () => {
+    const mockSetExtraHttpHeaders = vi
+      .fn<(headers: Record<string, string>) => Promise<void>>()
+      .mockResolvedValue();
+    const mockUse = vi.fn<(traceparent: string) => Promise<void>>().mockResolvedValue();
+    const actual = createTraceparentFixtures({
+      randomBytesImplementation: vi
+        .fn<(byteCount: number) => Uint8Array>()
+        .mockReturnValueOnce(Buffer.from("11111111111111111111111111111111", "hex"))
+        .mockReturnValueOnce(Buffer.from("2222222222222222", "hex")),
+    });
+    const [fixture] = actual.traceparent as unknown as [
+      (
+        fixtureArguments: {
+          context: { setExtraHTTPHeaders: typeof mockSetExtraHttpHeaders };
+          extraHTTPHeaders: Record<string, string>;
+        },
+        use: typeof mockUse,
+        testInfo: {
+          annotations: Array<{ type: string; description?: string }>;
+        },
+      ) => Promise<void>,
+      { auto: true },
+    ];
+
+    await fixture(
+      {
+        context: { setExtraHTTPHeaders: mockSetExtraHttpHeaders },
+        extraHTTPHeaders: { "x-suite-header": "configured" },
+      },
+      mockUse,
+      { annotations: [] },
+    );
+
+    expect(actual).toMatchObject({
+      traceparent: [expect.any(Function), { auto: true }],
+    });
+    expect(mockSetExtraHttpHeaders).toHaveBeenCalledWith({
+      "x-suite-header": "configured",
+      traceparent: "00-11111111111111111111111111111111-2222222222222222-01",
+    });
+  });
+});

--- a/packages/playwright-toolkit/src/lib/traceparent.ts
+++ b/packages/playwright-toolkit/src/lib/traceparent.ts
@@ -1,0 +1,115 @@
+import { randomBytes } from "node:crypto";
+
+import type {
+  Fixtures,
+  PlaywrightTestArgs,
+  PlaywrightTestOptions,
+  PlaywrightWorkerArgs,
+  PlaywrightWorkerOptions,
+} from "@playwright/test";
+
+const INVALID_TRACE_ID = "00000000000000000000000000000000";
+const INVALID_PARENT_ID = "0000000000000000";
+
+export interface TraceparentFixtures {
+  traceparent: string;
+}
+
+export interface TraceparentContextLike {
+  setExtraHTTPHeaders(headers: Record<string, string>): Promise<void>;
+}
+
+export interface TraceparentTestInfoLike {
+  annotations: Array<{ type: string; description?: string }>;
+}
+
+export interface CreateTraceparentParams {
+  randomBytesImplementation?: (byteCount: number) => Uint8Array;
+}
+
+export interface InstallTraceparentForTestParams {
+  context: TraceparentContextLike;
+  testInfo: TraceparentTestInfoLike;
+  traceparent?: string;
+  existingHeaders?: Record<string, string> | undefined;
+}
+
+/**
+ * Creates an auto fixture that installs one W3C traceparent per Playwright
+ * test and records it as a test annotation for reporter/APM correlation.
+ */
+export function createTraceparentFixtures(
+  params: CreateTraceparentParams = {},
+): Fixtures<
+  TraceparentFixtures,
+  Record<never, never>,
+  PlaywrightTestArgs & PlaywrightTestOptions,
+  PlaywrightWorkerArgs & PlaywrightWorkerOptions
+> {
+  return {
+    traceparent: [
+      async ({ context, extraHTTPHeaders }, use, testInfo) => {
+        const result = await installTraceparentForTest({
+          context,
+          existingHeaders: extraHTTPHeaders,
+          testInfo,
+          traceparent: createTraceparent(params),
+        });
+
+        await use(result.traceparent);
+      },
+      { auto: true },
+    ],
+  };
+}
+
+export function createTraceparent(params: CreateTraceparentParams = {}): string {
+  const randomBytesImplementation = params.randomBytesImplementation ?? randomBytes;
+  const traceId = createNonZeroHex({
+    byteCount: 16,
+    invalidValue: INVALID_TRACE_ID,
+    randomBytesImplementation,
+  });
+  const parentId = createNonZeroHex({
+    byteCount: 8,
+    invalidValue: INVALID_PARENT_ID,
+    randomBytesImplementation,
+  });
+
+  return `00-${traceId}-${parentId}-01`;
+}
+
+export async function installTraceparentForTest(
+  params: InstallTraceparentForTestParams,
+): Promise<{ traceparent: string }> {
+  const traceparent = params.traceparent ?? createTraceparent();
+
+  await params.context.setExtraHTTPHeaders({
+    ...params.existingHeaders,
+    traceparent,
+  });
+  params.testInfo.annotations.push({
+    type: "traceparent",
+    description: traceparent,
+  });
+
+  return { traceparent };
+}
+
+function createNonZeroHex(params: {
+  byteCount: number;
+  invalidValue: string;
+  randomBytesImplementation: (byteCount: number) => Uint8Array;
+}): string {
+  for (;;) {
+    const value = Buffer.from(params.randomBytesImplementation(params.byteCount)).toString("hex");
+
+    if (value.length !== params.byteCount * 2) {
+      throw new Error(`Random byte source returned ${value.length / 2} bytes`);
+    }
+
+    if (value !== params.invalidValue) {
+      return value;
+    }
+  }
+}

--- a/packages/playwright-toolkit/tsconfig.json
+++ b/packages/playwright-toolkit/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "outDir": "../../dist/out-tsc",
+    "composite": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lint.json"
+    },
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/playwright-toolkit/tsconfig.lib.json
+++ b/packages/playwright-toolkit/tsconfig.lib.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "types": ["node"],
+    "composite": true,
+    "moduleResolution": "bundler",
+    "outDir": "../../dist/packages/playwright-toolkit",
+    "rootDir": ".",
+    "tsBuildInfoFile": "../../.nx/tsbuildinfo/packages/playwright-toolkit/tsconfig.lib.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["vitest.config.ts", "src/**/*.test.ts"],
+  "references": [
+    {
+      "path": "../util-ts/tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/playwright-toolkit/tsconfig.lint.json
+++ b/packages/playwright-toolkit/tsconfig.lint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.lint.json",
+  "compilerOptions": {
+    "lib": ["ES2024", "DOM", "DOM.Iterable"]
+  },
+  "include": ["."]
+}

--- a/packages/playwright-toolkit/tsconfig.spec.json
+++ b/packages/playwright-toolkit/tsconfig.spec.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["vitest/globals", "node"]
+  },
+  "include": ["vitest.config.ts", "src/**/*.test.ts", "src/**/*.d.ts"]
+}

--- a/packages/playwright-toolkit/typedoc.json
+++ b/packages/playwright-toolkit/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/playwright-toolkit/vitest.config.ts
+++ b/packages/playwright-toolkit/vitest.config.ts
@@ -1,0 +1,12 @@
+import { definePackageVitestConfig } from "../../vitest.preset";
+
+export default definePackageVitestConfig({
+  coverageThresholds: {
+    branches: 65,
+    functions: 85,
+    lines: 75,
+    statements: 75,
+  },
+  name: "playwright-toolkit",
+  reportsDirectory: "../../coverage/packages/playwright-toolkit",
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -30,6 +30,7 @@
       "@clipboard-health/playwright-reporter-llm": [
         "./packages/playwright-reporter-llm/src/index.ts"
       ],
+      "@clipboard-health/playwright-toolkit": ["./packages/playwright-toolkit/src/index.ts"],
       "@clipboard-health/rules-engine": ["./packages/rules-engine/src/index.ts"],
       "@clipboard-health/testing-core": ["./packages/testing-core/src/index.ts"],
       "@clipboard-health/util-ts": ["./packages/util-ts/src/index.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -64,6 +64,9 @@
     },
     {
       "path": "./packages/clearance"
+    },
+    {
+      "path": "./packages/playwright-toolkit"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- add the publishable `@clipboard-health/playwright-toolkit` package with per-test traceparent correlation, classified retries and bounded polling, cross-process admin-token caching, deployed-asset verification, Mailpit polling, Cognito diagnostics, and setup retry classification
- port package-boundary tests for every extracted capability and document direct migration mappings for consuming repositories
- preserve configured Playwright headers, enforce hard poll deadlines, use Mailpit summary timestamps correctly, redact recipient PII from retry errors, and keep retry classification transient-only

## Validation

- `npm exec nx -- test playwright-toolkit --configuration ci --verbose`
- `npm exec nx -- build playwright-toolkit --skip-nx-cache --verbose`
- `node --run verify`
- `npm pack --dry-run --json dist/packages/playwright-toolkit`

## Notes

- No consuming repositories are changed in this ticket.
- No new external dependency was introduced; the package reuses `@clipboard-health/util-ts` from this monorepo.

Closes staff-1814

Agent session: `codex resume 019f6b81-15ad-7af3-a13d-4dea207f6e05`

<sub>🤖 <code>cb-ship:created v1 core@3.18.0</code></sub>