### PR TITLE
feat: add shared Playwright flake linter (STAFF-1815)

### DIFF
--- a/.knip.jsonc
+++ b/.knip.jsonc
@@ -68,5 +68,8 @@
     "packages/playwright-reporter-llm": {
       "entry": ["src/index.ts", "test/e2e/playwright.config.ts"],
     },
+    "packages/playwright-flake-linter": {
+      "entry": ["src/bin/cli.ts", "src/index.ts"],
+    },
   },
 }

--- a/.rules/common/coreLibraries.md
+++ b/.rules/common/coreLibraries.md
@@ -35,6 +35,7 @@ When a bug traces into a `@clipboard-health/*` library, read the source code in 
 - **nx-plugin**: An Nx plugin with generators to manage libraries and applications.
 - **oxlint-config**: Shared Oxlint configuration for Clipboard Health repositories.
 - **phone-number**: Phone number utility functions.
+- **playwright-flake-linter**: Shared configurable checks for Playwright flake anti-patterns.
 - **playwright-reporter-llm**: Playwright reporter that outputs structured JSON for LLM agents. Minimal console output, flat schema, easy to filter to failures.
 - **rules-engine**: A pure functional rules engine to keep logic-dense code simple, reliable, understandable, and explainable.
 - **testing-core**: TypeScript-friendly testing utilities.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 - [nx-plugin](./packages/nx-plugin/README.md): An Nx plugin with generators to manage libraries and applications.
 - [oxlint-config](./packages/oxlint-config/README.md): Shared Oxlint configuration for Clipboard Health repositories.
 - [phone-number](./packages/phone-number/README.md): Phone number utility functions.
+- [playwright-flake-linter](./packages/playwright-flake-linter/README.md): Shared configurable checks for Playwright flake anti-patterns.
 - [playwright-reporter-llm](./packages/playwright-reporter-llm/README.md): Playwright reporter that outputs structured JSON for LLM agents. Minimal console output, flat schema, easy to filter to failures.
 - [rules-engine](./packages/rules-engine/README.md): A pure functional rules engine to keep logic-dense code simple, reliable, understandable, and explainable.
 - [testing-core](./packages/testing-core/README.md): TypeScript-friendly testing utilities.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2982,6 +2982,10 @@
       "resolved": "packages/phone-number",
       "link": true
     },
+    "node_modules/@clipboard-health/playwright-flake-linter": {
+      "resolved": "packages/playwright-flake-linter",
+      "link": true
+    },
     "node_modules/@clipboard-health/playwright-reporter-llm": {
       "resolved": "packages/playwright-reporter-llm",
       "link": true
@@ -35001,6 +35005,19 @@
       },
       "peerDependencies": {
         "libphonenumber-js": "^1.12"
+      }
+    },
+    "packages/playwright-flake-linter": {
+      "name": "@clipboard-health/playwright-flake-linter",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "13.0.6",
+        "tslib": "2.8.1",
+        "typescript": "5.9.3"
+      },
+      "bin": {
+        "playwright-flake-lint": "src/bin/cli.js"
       }
     },
     "packages/playwright-reporter-llm": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "architecture:check": "depcruise packages/*/src",
     "cpd": "jscpd .",
     "docs": "rm -rf docs && typedoc",
-    "embed": "tsx packages/embedex/src/bin/cli.ts --sourcesGlob 'packages/*/examples/**/*.{md,ts}'",
+    "embed": "node --import tsx packages/embedex/src/bin/cli.ts --sourcesGlob 'packages/*/examples/**/*.{md,ts}'",
     "embed:check": "node --run embed -- --check",
     "eval": "promptfoo eval --config evals/promptfooconfig.ts",
     "eval:skill": "tsx scripts/runSkillEval.mts",

--- a/packages/ai-rules/rules/common/coreLibraries.md
+++ b/packages/ai-rules/rules/common/coreLibraries.md
@@ -35,6 +35,7 @@ When a bug traces into a `@clipboard-health/*` library, read the source code in 
 - **nx-plugin**: An Nx plugin with generators to manage libraries and applications.
 - **oxlint-config**: Shared Oxlint configuration for Clipboard Health repositories.
 - **phone-number**: Phone number utility functions.
+- **playwright-flake-linter**: Shared configurable checks for Playwright flake anti-patterns.
 - **playwright-reporter-llm**: Playwright reporter that outputs structured JSON for LLM agents. Minimal console output, flat schema, easy to filter to failures.
 - **rules-engine**: A pure functional rules engine to keep logic-dense code simple, reliable, understandable, and explainable.
 - **testing-core**: TypeScript-friendly testing utilities.

--- a/packages/playwright-flake-linter/.eslintrc.json
+++ b/packages/playwright-flake-linter/.eslintrc.json
@@ -1,0 +1,22 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*", "**/*.json", "!**/package.json", "test/fixtures/**"],
+  "parserOptions": {
+    "project": "packages/playwright-flake-linter/tsconfig.lint.json"
+  },
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {
+        "security/detect-non-literal-fs-filename": "off",
+        "security/detect-non-literal-regexp": "off",
+        "unicorn/filename-case": ["error", { "case": "camelCase" }]
+      }
+    }
+  ],
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  }
+}

--- a/packages/playwright-flake-linter/README.md
+++ b/packages/playwright-flake-linter/README.md
@@ -1,0 +1,146 @@
+# @clipboard-health/playwright-flake-linter
+
+Shared, configurable TypeScript AST checks for Playwright flake anti-patterns.
+The rule implementation lives in this package; consuming repositories provide
+only their paths, helper names, mechanism names, and justified exceptions.
+
+## Install
+
+```bash
+npm install --save-dev @clipboard-health/playwright-flake-linter
+```
+
+TypeScript is a runtime dependency because the checker uses the compiler API;
+`glob` provides the repository-standard source discovery used by `embedex`.
+Both are actively maintained, commercially compatible (Apache-2.0 and ISC),
+already standardized in this monorepo, and the CLI is not included in
+application bundles.
+
+## Configure
+
+Create `playwright-flake-lint.config.mjs` at the repository root:
+
+```javascript
+export default {
+  scanRoots: ["playwright"],
+  hardenedIdentityHelperNames: ["generateRandomUserEmail"],
+  identityHelperMinimumLengths: {
+    generateRandomAlphaNumericString: 24,
+    generateRandomString: 26,
+  },
+  retryHelperNames: ["retry"],
+  specificRequestMatcherNames: ["isMatchingRequest"],
+  transientClassifierNamePatterns: ["^isRetryable", "retryClassification"],
+  undiscriminatingRetryHelperNames: ["retryUntilPassOrTimeout", "toPass"],
+  sharedReadinessMechanisms: [
+    {
+      name: "Home Health response readiness",
+      filePathPattern: "playwright/e2e/homeHealth/.*\\.spec\\.ts$",
+      directCallNames: ["waitForResponse"],
+      sharedHelperNames: ["waitForHomeHealthResponse"],
+    },
+  ],
+};
+```
+
+The mobile repository can use its own genuine names without changing a rule:
+
+```javascript
+export default {
+  scanRoots: ["playwright"],
+  identityHelperMinimumLengths: {
+    mobileRandomSuffix: 32,
+  },
+  retryHelperNames: ["retryMobileAction"],
+  specificRequestMatcherNames: ["matchesMobileRequest"],
+  transientClassifierNamePatterns: ["^isTransientMobile"],
+  sharedReadinessMechanisms: [
+    {
+      name: "BottomSheet readiness",
+      filePathPattern: "playwright/e2e/sheets/.*\\.spec\\.ts$",
+      directCallNames: ["waitForResponse"],
+      sharedHelperNames: ["waitForBottomSheet"],
+    },
+  ],
+};
+```
+
+All pattern fields are JavaScript regular-expression source strings. Optional
+configuration:
+
+| Field                              | Purpose                                                             |
+| ---------------------------------- | ------------------------------------------------------------------- |
+| `allowlist`                        | Reason-required repository exceptions by rule and file pattern      |
+| `hardenedIdentityHelperNames`      | Identity helpers that are safe without a length argument            |
+| `identityHelperMinimumLengths`     | Repository random-helper names and their safe minimum lengths       |
+| `identityNamePattern`              | Names treated as parallel-worker-sensitive identities               |
+| `responseWaitCallNames`            | Repository response-wait utility names                              |
+| `retryHelperNames`                 | Retry utilities whose callbacks must classify transient failures    |
+| `sharedReadinessMechanisms`        | File/mechanism registry mapping direct gates to shared helpers      |
+| `specificRequestMatcherNames`      | Delegated helpers that fully discriminate a response request        |
+| `specFilePattern`                  | Files where fixed-sleep checks apply                                |
+| `transientClassifierNamePatterns`  | Classifier names accepted inside retry callbacks                    |
+| `undiscriminatingRetryHelperNames` | Utilities that inherently retry any failure and are always rejected |
+
+`sharedReadinessMechanisms[].name` is the diagnostic label, so repositories can
+use their native terminology such as `Dialog` or `BottomSheet`.
+
+## Wire into CI
+
+Add the executable to the repository's existing verification chain:
+
+```json
+{
+  "scripts": {
+    "architecture:check": "existing-checks && playwright-flake-lint"
+  }
+}
+```
+
+Use a non-default config location with
+`playwright-flake-lint --config path/to/config.mjs`.
+
+## Rules
+
+| Rule ID                | Anti-pattern                                                     | Required alternative                                                 |
+| ---------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `fixed-sleep`          | `waitForTimeout` or `setTimeout` delays in specs                 | Rubric B2: use a deterministic readiness signal                      |
+| `response-wait`        | Status/`.ok()` response predicates without specific request data | Rubric B2: match method, URL, and a discriminating request predicate |
+| `retry-classification` | Retry utilities invoked without transient-only classification    | Rubric B1: classify transient failures and fail fast otherwise       |
+| `test-data-identity`   | Low-entropy identities or bypasses of hardened random helpers    | Rubric A2: use configured hardened or UUID-backed identities         |
+| `shared-readiness`     | Per-spec readiness gates where a shared mechanism helper exists  | Rubric A1: use or extend the configured shared helper                |
+
+## Allowlisting
+
+Prefer fixing a violation. A justified inline exception must immediately
+precede the violating statement and include a reason:
+
+```typescript
+// flake-lint-allow fixed-sleep -- The timer fixture verifies elapsed product time.
+await page.waitForTimeout(100);
+```
+
+A repository-level exception also requires a reason:
+
+```javascript
+export default {
+  scanRoots: ["playwright"],
+  allowlist: [
+    {
+      ruleId: "fixed-sleep",
+      filePathPattern: "playwright/e2e/legacy/timer\\.spec\\.ts$",
+      reason: "The timer fixture verifies elapsed product time.",
+    },
+  ],
+};
+```
+
+Comments or config entries without a non-empty reason do not suppress a
+violation.
+
+## Future shared rules
+
+The existing per-repository Dialog/query-list checks are a candidate for this
+package. Their component-name difference (`Dialog` in admin and `BottomSheet`
+in mobile) belongs in repository config when that rule is migrated; this
+package does not change those checks yet.

--- a/packages/playwright-flake-linter/package.json
+++ b/packages/playwright-flake-linter/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@clipboard-health/playwright-flake-linter",
+  "version": "0.0.0",
+  "description": "Shared configurable checks for Playwright flake anti-patterns.",
+  "keywords": [
+    "flaky-tests",
+    "lint",
+    "playwright",
+    "testing"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ClipboardHealth/core-utils.git",
+    "directory": "packages/playwright-flake-linter"
+  },
+  "bin": {
+    "playwright-flake-lint": "./src/bin/cli.js"
+  },
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "typings": "./src/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "glob": "13.0.6",
+    "tslib": "2.8.1",
+    "typescript": "5.9.3"
+  }
+}

--- a/packages/playwright-flake-linter/project.json
+++ b/packages/playwright-flake-linter/project.json
@@ -1,0 +1,37 @@
+{
+  "name": "playwright-flake-linter",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "packages/playwright-flake-linter/src",
+  "tags": [],
+  "targets": {
+    "build": {
+      "dependsOn": ["prepare-build-package", "^build"],
+      "inputs": ["packageBuild", "^production"],
+      "outputs": ["{workspaceRoot}/dist/packages/playwright-flake-linter"],
+      "options": {
+        "forwardAllArgs": false
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "options": {
+        "lintFilePatterns": ["packages/playwright-flake-linter/**/*.[jt]s?(x)"],
+        "maxWarnings": 0
+      },
+      "outputs": ["{options.outputFile}"]
+    },
+    "test": {
+      "executor": "@nx/vitest:test",
+      "options": {
+        "configFile": "packages/playwright-flake-linter/vitest.config.ts"
+      }
+    },
+    "prepare-build-package": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "env -u NO_COLOR node --import tsx scripts/prepareTsgoPackage.mts packages/playwright-flake-linter"
+      }
+    }
+  }
+}

--- a/packages/playwright-flake-linter/src/bin/cli.ts
+++ b/packages/playwright-flake-linter/src/bin/cli.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+import { runCli } from "./runCli";
+
+async function main(): Promise<void> {
+  try {
+    const exitCode = await runCli({
+      arguments_: process.argv.slice(2),
+      cwd: process.cwd(),
+      writeError: (output) => {
+        process.stderr.write(output);
+      },
+    });
+    process.exitCode = exitCode;
+  } catch (error: unknown) {
+    process.stderr.write(`${getErrorMessage(error)}\n`);
+    process.exitCode = 1;
+  }
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+// eslint-disable-next-line unicorn/prefer-top-level-await -- the published CLI is CommonJS
+void main();

--- a/packages/playwright-flake-linter/src/bin/runCli.ts
+++ b/packages/playwright-flake-linter/src/bin/runCli.ts
@@ -1,0 +1,40 @@
+import path from "node:path";
+
+import { lintPlaywrightProject, loadPlaywrightFlakeLinterConfig } from "../lib/projectLinter";
+
+const DEFAULT_CONFIG_FILE_NAME = "playwright-flake-lint.config.mjs";
+
+interface RunCliParams {
+  arguments_: readonly string[];
+  cwd: string;
+  writeError: (output: string) => void;
+}
+
+export async function runCli({ arguments_, cwd, writeError }: RunCliParams): Promise<number> {
+  const configFilePath = path.resolve(cwd, getConfigFilePath(arguments_));
+  const config = await loadPlaywrightFlakeLinterConfig({ configFilePath });
+  const violations = await lintPlaywrightProject({ config, cwd });
+
+  for (const violation of violations) {
+    writeError(
+      `${violation.filePath}:${violation.line}:${violation.column} ` +
+        `[${violation.ruleId}] ${violation.message}. ` +
+        `For a justified exception, add // flake-lint-allow ` +
+        `${violation.ruleId} -- <reason>.\n`,
+    );
+  }
+
+  return violations.length === 0 ? 0 : 1;
+}
+
+function getConfigFilePath(arguments_: readonly string[]): string {
+  if (arguments_.length === 0) {
+    return DEFAULT_CONFIG_FILE_NAME;
+  }
+
+  if (arguments_.length === 2 && arguments_[0] === "--config" && arguments_[1] !== undefined) {
+    return arguments_[1];
+  }
+
+  throw new Error("Usage: playwright-flake-lint [--config <config-file-path>]");
+}

--- a/packages/playwright-flake-linter/src/index.ts
+++ b/packages/playwright-flake-linter/src/index.ts
@@ -1,0 +1,13 @@
+export type {
+  PlaywrightFlakeLinterAllowlistEntry,
+  PlaywrightFlakeLinterConfig,
+  PlaywrightFlakePatternViolation,
+  PlaywrightFlakeRuleId,
+  SharedReadinessMechanism,
+} from "./lib/playwrightFlakeLinter";
+export {
+  definePlaywrightFlakeLinterConfig,
+  findPlaywrightFlakePatternViolations,
+  PLAYWRIGHT_FLAKE_RULE_IDS,
+} from "./lib/playwrightFlakeLinter";
+export { lintPlaywrightProject, loadPlaywrightFlakeLinterConfig } from "./lib/projectLinter";

--- a/packages/playwright-flake-linter/src/lib/internal/violations.test.ts
+++ b/packages/playwright-flake-linter/src/lib/internal/violations.test.ts
@@ -1,0 +1,29 @@
+import { compareViolations } from "./violations";
+
+describe("compareViolations", () => {
+  it("uses locale-independent code-unit ordering", () => {
+    const input = [
+      {
+        column: 1,
+        filePath: "playwright/ä.spec.ts",
+        line: 1,
+        message: "first",
+        ruleId: "fixed-sleep" as const,
+      },
+      {
+        column: 1,
+        filePath: "playwright/z.spec.ts",
+        line: 1,
+        message: "second",
+        ruleId: "fixed-sleep" as const,
+      },
+    ];
+
+    const actual = input.toSorted(compareViolations);
+
+    expect(actual.map(({ filePath }) => filePath)).toEqual([
+      "playwright/z.spec.ts",
+      "playwright/ä.spec.ts",
+    ]);
+  });
+});

--- a/packages/playwright-flake-linter/src/lib/internal/violations.ts
+++ b/packages/playwright-flake-linter/src/lib/internal/violations.ts
@@ -5,9 +5,22 @@ export function compareViolations(
   second: PlaywrightFlakePatternViolation,
 ): number {
   return (
-    first.filePath.localeCompare(second.filePath) ||
+    compareStrings({ first: first.filePath, second: second.filePath }) ||
     first.line - second.line ||
     first.column - second.column ||
-    first.ruleId.localeCompare(second.ruleId)
+    compareStrings({ first: first.ruleId, second: second.ruleId })
   );
+}
+
+interface CompareStringsParams {
+  first: string;
+  second: string;
+}
+
+function compareStrings({ first, second }: CompareStringsParams): number {
+  if (first === second) {
+    return 0;
+  }
+
+  return first < second ? -1 : 1;
 }

--- a/packages/playwright-flake-linter/src/lib/internal/violations.ts
+++ b/packages/playwright-flake-linter/src/lib/internal/violations.ts
@@ -1,0 +1,13 @@
+import type { PlaywrightFlakePatternViolation } from "../playwrightFlakeLinter";
+
+export function compareViolations(
+  first: PlaywrightFlakePatternViolation,
+  second: PlaywrightFlakePatternViolation,
+): number {
+  return (
+    first.filePath.localeCompare(second.filePath) ||
+    first.line - second.line ||
+    first.column - second.column ||
+    first.ruleId.localeCompare(second.ruleId)
+  );
+}

--- a/packages/playwright-flake-linter/src/lib/playwrightFlakeLinter.test.ts
+++ b/packages/playwright-flake-linter/src/lib/playwrightFlakeLinter.test.ts
@@ -1,0 +1,438 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { PlaywrightFlakeRuleId } from "./playwrightFlakeLinter";
+import {
+  definePlaywrightFlakeLinterConfig,
+  findPlaywrightFlakePatternViolations,
+} from "./playwrightFlakeLinter";
+
+const FIXTURES_ROOT = path.resolve(import.meta.dirname, "../../test/fixtures/playwright");
+const RULE_FIXTURES = [
+  ["fixed-sleep", "fixed-sleep"],
+  ["response-wait", "response-wait"],
+  ["retry-classification", "retry-classification"],
+  ["test-data-identity", "test-data-identity"],
+  ["shared-readiness", "shared-readiness"],
+] satisfies ReadonlyArray<readonly [string, PlaywrightFlakeRuleId]>;
+const FIXTURE_NAMES = RULE_FIXTURES.map(([fixtureName]) => fixtureName);
+const config = definePlaywrightFlakeLinterConfig({
+  hardenedIdentityHelperNames: ["generateRandomUserEmail"],
+  identityHelperMinimumLengths: {
+    generateRandomAlphaNumericString: 24,
+    generateRandomString: 26,
+  },
+  retryHelperNames: ["retry"],
+  scanRoots: ["playwright"],
+  sharedReadinessMechanisms: [
+    {
+      directCallNames: ["waitForResponse"],
+      filePathPattern: String.raw`playwright/e2e/homeHealth/.*\.spec\.ts$`,
+      name: "Home Health response readiness",
+      sharedHelperNames: ["waitForHomeHealthResponse"],
+    },
+  ],
+  transientClassifierNamePatterns: ["^isRetryable", "retryClassification"],
+  undiscriminatingRetryHelperNames: ["retryUntilPassOrTimeout", "toPass"],
+});
+
+describe("findPlaywrightFlakePatternViolations", () => {
+  it.each(RULE_FIXTURES)(
+    "reports the %s fixture with the rubric and preferred alternative",
+    async (fixtureName, expectedRuleId) => {
+      const actual = await lintFixture({
+        fixtureName,
+        variant: "violation",
+      });
+
+      expect(actual).toHaveLength(1);
+      expect(actual[0]).toMatchObject({ ruleId: expectedRuleId });
+      expect(actual[0]?.message).toMatch(/rubric [A-Z]\d/);
+      expect(actual[0]?.message).toMatch(/Use|Replace|Retry|Match/);
+    },
+  );
+
+  it.each(FIXTURE_NAMES)("accepts the compliant %s fixture", async (fixtureName) => {
+    const actual = await lintFixture({
+      fixtureName,
+      variant: "compliant",
+    });
+
+    expect(actual).toEqual([]);
+  });
+
+  it.each(FIXTURE_NAMES)(
+    "accepts the reason-bearing inline allowlist for %s",
+    async (fixtureName) => {
+      const actual = await lintFixture({
+        fixtureName,
+        variant: "allowlisted",
+      });
+
+      expect(actual).toEqual([]);
+    },
+  );
+
+  it("uses repository-specific helper and shared-mechanism configuration", () => {
+    const customConfig = definePlaywrightFlakeLinterConfig({
+      identityHelperMinimumLengths: {
+        mobileRandomSuffix: 32,
+      },
+      retryHelperNames: ["retryMobileAction"],
+      scanRoots: ["e2e"],
+      sharedReadinessMechanisms: [
+        {
+          directCallNames: ["waitForResponse"],
+          filePathPattern: String.raw`e2e/sheets/.*\.spec\.tsx$`,
+          name: "BottomSheet readiness",
+          sharedHelperNames: ["waitForBottomSheet"],
+        },
+      ],
+      transientClassifierNamePatterns: ["^isTransientMobile"],
+    });
+    const source = `
+      const workerName = mobileRandomSuffix(8);
+      await retryMobileAction(async () => createWorker());
+      await page.waitForResponse((response) => response.ok());
+    `;
+
+    const actual = findPlaywrightFlakePatternViolations({
+      config: customConfig,
+      filePath: "e2e/sheets/worker.spec.tsx",
+      source,
+    });
+
+    expect(actual.map(({ ruleId }) => ruleId)).toEqual([
+      "test-data-identity",
+      "retry-classification",
+      "response-wait",
+      "shared-readiness",
+    ]);
+    expect(actual.at(-1)?.message).toContain("waitForBottomSheet");
+  });
+
+  it("supports a readiness mechanism with a repository-specific direct call", () => {
+    const customConfig = definePlaywrightFlakeLinterConfig({
+      scanRoots: ["e2e"],
+      sharedReadinessMechanisms: [
+        {
+          directCallNames: ["waitForBottomSheetResponse"],
+          filePathPattern: String.raw`e2e/sheets/.*\.spec\.tsx$`,
+          name: "BottomSheet readiness",
+          sharedHelperNames: ["waitForBottomSheet"],
+        },
+      ],
+    });
+
+    const actual = findPlaywrightFlakePatternViolations({
+      config: customConfig,
+      filePath: "e2e/sheets/worker.spec.tsx",
+      source: "await page.waitForBottomSheetResponse(isReady);",
+    });
+
+    expect(actual.map(({ ruleId }) => ruleId)).toEqual(["shared-readiness"]);
+  });
+
+  it("flags timestamp identities that bypass configured hardened helpers", () => {
+    const interpolation = `${String.fromCodePoint(36)}{Date.now()}`;
+
+    const actual = findPlaywrightFlakePatternViolations({
+      config,
+      filePath: "playwright/e2e/example.spec.ts",
+      source: `const workerEmail = \`worker-${interpolation}@example.com\`;`,
+    });
+
+    expect(actual.map(({ ruleId }) => ruleId)).toEqual(["test-data-identity"]);
+  });
+
+  it("supports a reason-bearing repository allowlist", () => {
+    const allowlistedConfig = definePlaywrightFlakeLinterConfig({
+      ...config,
+      allowlist: [
+        {
+          filePathPattern: String.raw`legacy/.*\.spec\.ts$`,
+          reason: "The timer fixture verifies elapsed product time.",
+          ruleId: "fixed-sleep",
+        },
+      ],
+    });
+
+    const actual = findPlaywrightFlakePatternViolations({
+      config: allowlistedConfig,
+      filePath: "playwright/e2e/legacy/timer.spec.ts",
+      source: "await page.waitForTimeout(100);",
+    });
+
+    expect(actual).toEqual([]);
+  });
+
+  it("rejects inline allowlists without a reason", () => {
+    const actual = findPlaywrightFlakePatternViolations({
+      config,
+      filePath: "playwright/e2e/example.spec.ts",
+      source: `
+        // flake-lint-allow fixed-sleep
+        await page.waitForTimeout(100);
+      `,
+    });
+
+    expect(actual.map(({ ruleId }) => ruleId)).toEqual(["fixed-sleep"]);
+  });
+
+  it("rejects repository allowlists without a reason", () => {
+    expect(() =>
+      definePlaywrightFlakeLinterConfig({
+        ...config,
+        allowlist: [
+          {
+            filePathPattern: "legacy",
+            reason: " ",
+            ruleId: "fixed-sleep",
+          },
+        ],
+      }),
+    ).toThrow("allowlist reason");
+  });
+
+  it("flags bare and qualified setTimeout sleeps in specs", () => {
+    const actual = findPlaywrightFlakePatternViolations({
+      config,
+      filePath: "playwright/e2e/example.spec.ts",
+      source: `
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        await new Promise((resolve) => globalThis.setTimeout(resolve, 100));
+      `,
+    });
+
+    expect(actual.map(({ ruleId }) => ruleId)).toEqual(["fixed-sleep", "fixed-sleep"]);
+  });
+
+  it("follows named predicate result dependencies", () => {
+    const actual = findPlaywrightFlakePatternViolations({
+      config,
+      filePath: "playwright/e2e/example.spec.ts",
+      source: `
+        const isReady = (response) => {
+          const methodMatches = response.request().method() === "POST";
+          const url = new URL(response.url());
+          const identityMatches = url.searchParams.get("workerId") === workerId;
+          return methodMatches && identityMatches && response.ok();
+        };
+        await page.waitForResponse(isReady);
+      `,
+    });
+
+    expect(actual).toEqual([]);
+  });
+
+  it("allows a delegated specific-request matcher", () => {
+    const actual = findPlaywrightFlakePatternViolations({
+      config,
+      filePath: "playwright/e2e/example.spec.ts",
+      source: `
+        function isReady(response) {
+          return isMatchingRequest(response.request()) && response.ok();
+        }
+        await page.waitForResponse(isReady);
+      `,
+    });
+
+    expect(actual).toEqual([]);
+  });
+
+  it("uses repository-specific delegated request matcher names", () => {
+    const customConfig = definePlaywrightFlakeLinterConfig({
+      scanRoots: ["playwright"],
+      specificRequestMatcherNames: ["matchesMobileRequest"],
+    });
+    const actual = findPlaywrightFlakePatternViolations({
+      config: customConfig,
+      filePath: "playwright/e2e/example.spec.ts",
+      source: `
+        await page.waitForResponse(
+          (response) => matchesMobileRequest(response.request()) && response.ok()
+        );
+      `,
+    });
+
+    expect(actual).toEqual([]);
+  });
+
+  it("does not count unused request inspection as discrimination", () => {
+    const actual = findPlaywrightFlakePatternViolations({
+      config,
+      filePath: "playwright/e2e/example.spec.ts",
+      source: `
+        await page.waitForResponse((response) => {
+          response.request().method();
+          response.url();
+          response.request().postDataJSON();
+          return response.ok();
+        });
+      `,
+    });
+
+    expect(actual.map(({ ruleId }) => ruleId)).toEqual(["response-wait"]);
+  });
+
+  it("accepts a dynamic URL segment as a discriminating request property", () => {
+    const actual = findPlaywrightFlakePatternViolations({
+      config,
+      filePath: "playwright/e2e/example.spec.ts",
+      source: `
+        await page.waitForResponse(
+          (response) =>
+            response.request().method() === "GET" &&
+            response.url().endsWith(\`/workers/\${workerId}\`) &&
+            response.ok()
+        );
+      `,
+    });
+
+    expect(actual).toEqual([]);
+  });
+
+  it("flags unresolved retry callbacks and always-undiscriminating methods", () => {
+    const actual = findPlaywrightFlakePatternViolations({
+      config,
+      filePath: "playwright/helpers/retry.ts",
+      source: `
+        await retry(createWorker);
+        await expect(async () => createWorker()).toPass();
+      `,
+    });
+
+    expect(actual.map(({ ruleId }) => ruleId)).toEqual([
+      "retry-classification",
+      "retry-classification",
+    ]);
+  });
+
+  it("accepts configured transient classifier identifiers", () => {
+    const actual = findPlaywrightFlakePatternViolations({
+      config,
+      filePath: "playwright/helpers/retry.ts",
+      source: `
+        await retry(async (bail) => {
+          const retryClassification = classifyError();
+          if (retryClassification === "permanent") {
+            return bail();
+          }
+          throw new Error("transient");
+        });
+      `,
+    });
+
+    expect(actual).toEqual([]);
+  });
+
+  it("flags non-literal random lengths and Math.random identities", () => {
+    const actual = findPlaywrightFlakePatternViolations({
+      config,
+      filePath: "playwright/e2e/example.spec.ts",
+      source: `
+        const workerName = generateRandomString(randomLength);
+        const workerEmail = Math.random();
+      `,
+    });
+
+    expect(actual.map(({ ruleId }) => ruleId)).toEqual([
+      "test-data-identity",
+      "test-data-identity",
+    ]);
+  });
+
+  it("allows timestamp calculations outside identity contexts", () => {
+    const actual = findPlaywrightFlakePatternViolations({
+      config,
+      filePath: "playwright/e2e/example.spec.ts",
+      source: "const expiresAt = Date.now() + 60_000;",
+    });
+
+    expect(actual).toEqual([]);
+  });
+
+  it("does not let an enclosing allowlist suppress nested statements", () => {
+    const actual = findPlaywrightFlakePatternViolations({
+      config,
+      filePath: "playwright/e2e/example.spec.ts",
+      source: `
+        // flake-lint-allow fixed-sleep -- This applies only to the test declaration.
+        test("loads", async ({ page }) => {
+          await page.waitForTimeout(100);
+        });
+      `,
+    });
+
+    expect(actual.map(({ ruleId }) => ruleId)).toEqual(["fixed-sleep"]);
+  });
+
+  it("rejects empty scan roots and invalid configured patterns", () => {
+    expect(() =>
+      definePlaywrightFlakeLinterConfig({
+        scanRoots: [],
+      }),
+    ).toThrow("scan root");
+    expect(() =>
+      definePlaywrightFlakeLinterConfig({
+        scanRoots: ["playwright"],
+        specFilePattern: "[",
+      }),
+    ).toThrow("Invalid spec file pattern");
+  });
+
+  it("rejects unusable identity and shared-readiness configuration", () => {
+    expect(() =>
+      definePlaywrightFlakeLinterConfig({
+        identityHelperMinimumLengths: {
+          randomSuffix: 0,
+        },
+        scanRoots: ["playwright"],
+      }),
+    ).toThrow("positive integer");
+    expect(() =>
+      definePlaywrightFlakeLinterConfig({
+        scanRoots: ["playwright"],
+        sharedReadinessMechanisms: [
+          {
+            directCallNames: ["waitForResponse"],
+            filePathPattern: "playwright",
+            name: "response readiness",
+            sharedHelperNames: [],
+          },
+        ],
+      }),
+    ).toThrow("shared helper");
+  });
+});
+
+interface LintFixtureParams {
+  fixtureName: string;
+  variant: "allowlisted" | "compliant" | "violation";
+}
+
+async function lintFixture({
+  fixtureName,
+  variant,
+}: LintFixtureParams): Promise<ReturnType<typeof findPlaywrightFlakePatternViolations>> {
+  const filePath = getFixtureFilePath({ fixtureName, variant });
+  const source = await readFile(path.join(FIXTURES_ROOT, filePath), "utf8");
+
+  return findPlaywrightFlakePatternViolations({
+    config,
+    filePath: `playwright/${filePath.slice(0, -".txt".length)}`,
+    source,
+  });
+}
+
+function getFixtureFilePath({ fixtureName, variant }: LintFixtureParams): string {
+  if (fixtureName === "shared-readiness") {
+    return `e2e/homeHealth/${fixtureName}.${variant}.spec.ts.txt`;
+  }
+
+  if (fixtureName === "retry-classification") {
+    return `helpers/${fixtureName}.${variant}.ts.txt`;
+  }
+
+  return `e2e/${fixtureName}.${variant}.spec.ts.txt`;
+}

--- a/packages/playwright-flake-linter/src/lib/playwrightFlakeLinter.test.ts
+++ b/packages/playwright-flake-linter/src/lib/playwrightFlakeLinter.test.ts
@@ -275,6 +275,21 @@ describe("findPlaywrightFlakePatternViolations", () => {
     expect(actual.map(({ ruleId }) => ruleId)).toEqual(["response-wait"]);
   });
 
+  it("does not count an unused delegated matcher as discrimination", () => {
+    const actual = findPlaywrightFlakePatternViolations({
+      config,
+      filePath: "playwright/e2e/example.spec.ts",
+      source: `
+        await page.waitForResponse((response) => {
+          isMatchingRequest(response.request());
+          return response.ok();
+        });
+      `,
+    });
+
+    expect(actual.map(({ ruleId }) => ruleId)).toEqual(["response-wait"]);
+  });
+
   it("accepts a dynamic URL segment as a discriminating request property", () => {
     const actual = findPlaywrightFlakePatternViolations({
       config,
@@ -324,6 +339,22 @@ describe("findPlaywrightFlakePatternViolations", () => {
     });
 
     expect(actual).toEqual([]);
+  });
+
+  it("does not count a dead classifier reference as retry classification", () => {
+    const actual = findPlaywrightFlakePatternViolations({
+      config,
+      filePath: "playwright/helpers/retry.ts",
+      source: `
+        await retry(async () => {
+          const retryClassification = classifyError();
+          console.info(retryClassification);
+          await createWorker();
+        });
+      `,
+    });
+
+    expect(actual.map(({ ruleId }) => ruleId)).toEqual(["retry-classification"]);
   });
 
   it("flags non-literal random lengths and Math.random identities", () => {

--- a/packages/playwright-flake-linter/src/lib/playwrightFlakeLinter.ts
+++ b/packages/playwright-flake-linter/src/lib/playwrightFlakeLinter.ts
@@ -351,7 +351,7 @@ function hasUndiscriminatingResponsePredicate({
   let checksUrl = false;
   let checksDiscriminatingRequestProperty = false;
 
-  function visitFullPredicate(node: ts.Node): void {
+  function visitResultDependency(node: ts.Node): void {
     if (ts.isCallExpression(node)) {
       checksStatus ||= isDirectResponseCall({
         callExpression: node,
@@ -361,13 +361,6 @@ function hasUndiscriminatingResponsePredicate({
       delegatesSpecificRequestMatching ||=
         ts.isIdentifier(node.expression) &&
         specificRequestMatcherNames.includes(node.expression.text);
-    }
-
-    ts.forEachChild(node, visitFullPredicate);
-  }
-
-  function visitResultDependency(node: ts.Node): void {
-    if (ts.isCallExpression(node)) {
       checksUrl ||= isDirectResponseCall({
         callExpression: node,
         methodNames: ["url"],
@@ -392,8 +385,6 @@ function hasUndiscriminatingResponsePredicate({
 
     ts.forEachChild(node, visitResultDependency);
   }
-
-  visitFullPredicate(predicate);
 
   for (const resultNode of getPredicateResultDependencies(predicate)) {
     visitResultDependency(resultNode);
@@ -697,18 +688,102 @@ function isUndiscriminatingRetryCall({
   const classifierPatterns = (
     config.transientClassifierNamePatterns ?? DEFAULT_TRANSIENT_CLASSIFIER_NAME_PATTERNS
   ).map((pattern) => new RegExp(pattern));
-  let usesTransientClassifier = false;
+
+  return !usesTransientClassifierToGovernRetry({
+    callback,
+    classifierPatterns,
+  });
+}
+
+interface UsesTransientClassifierToGovernRetryParams {
+  callback: ts.FunctionLikeDeclaration;
+  classifierPatterns: readonly RegExp[];
+}
+
+function usesTransientClassifierToGovernRetry({
+  callback,
+  classifierPatterns,
+}: UsesTransientClassifierToGovernRetryParams): boolean {
+  if (callback.body === undefined || !ts.isBlock(callback.body)) {
+    return false;
+  }
+
+  const bailParameter = callback.parameters[0]?.name;
+
+  if (bailParameter === undefined || !ts.isIdentifier(bailParameter)) {
+    return false;
+  }
+
+  const bailParameterName = bailParameter.text;
+  const dependencies: ts.Node[] = [];
+  const initializerByName = new Map<string, ts.Expression>();
+  const callbackBody = callback.body;
 
   function visit(node: ts.Node): void {
-    if (ts.isIdentifier(node) && classifierPatterns.some((pattern) => pattern.test(node.text))) {
-      usesTransientClassifier = true;
+    if (node !== callback && ts.isFunctionLike(node)) {
+      return;
+    }
+
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer !== undefined
+    ) {
+      initializerByName.set(node.name.text, node.initializer);
+    }
+
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === bailParameterName
+    ) {
+      addGoverningConditions({
+        boundary: callbackBody,
+        dependencies,
+        node,
+      });
     }
 
     ts.forEachChild(node, visit);
   }
 
-  visit(callback);
-  return !usesTransientClassifier;
+  visit(callbackBody);
+
+  for (const dependency of dependencies) {
+    addReferencedInitializers({
+      dependencies,
+      initializerByName,
+      node: dependency,
+    });
+  }
+
+  return dependencies.some((dependency) =>
+    containsClassifierReference({
+      classifierPatterns,
+      node: dependency,
+    }),
+  );
+}
+
+interface ContainsClassifierReferenceParams {
+  classifierPatterns: readonly RegExp[];
+  node: ts.Node;
+}
+
+function containsClassifierReference({
+  classifierPatterns,
+  node,
+}: ContainsClassifierReferenceParams): boolean {
+  if (ts.isIdentifier(node) && classifierPatterns.some((pattern) => pattern.test(node.text))) {
+    return true;
+  }
+
+  return node.getChildren().some((childNode) =>
+    containsClassifierReference({
+      classifierPatterns,
+      node: childNode,
+    }),
+  );
 }
 
 interface IsLowEntropyTestDataIdentityCallParams {

--- a/packages/playwright-flake-linter/src/lib/playwrightFlakeLinter.ts
+++ b/packages/playwright-flake-linter/src/lib/playwrightFlakeLinter.ts
@@ -1,0 +1,1009 @@
+import path from "node:path";
+
+import ts from "typescript";
+
+import { compareViolations } from "./internal/violations";
+
+export const PLAYWRIGHT_FLAKE_RULE_IDS = [
+  "fixed-sleep",
+  "response-wait",
+  "retry-classification",
+  "test-data-identity",
+  "shared-readiness",
+] as const;
+const PLAYWRIGHT_FLAKE_RULE_ID_SET: ReadonlySet<string> = new Set(PLAYWRIGHT_FLAKE_RULE_IDS);
+
+export type PlaywrightFlakeRuleId = (typeof PLAYWRIGHT_FLAKE_RULE_IDS)[number];
+
+export interface PlaywrightFlakeLinterAllowlistEntry {
+  filePathPattern: string;
+  reason: string;
+  ruleId: PlaywrightFlakeRuleId;
+}
+
+export interface SharedReadinessMechanism {
+  directCallNames: readonly string[];
+  filePathPattern: string;
+  name: string;
+  sharedHelperNames: readonly string[];
+}
+
+export interface PlaywrightFlakeLinterConfig {
+  allowlist?: readonly PlaywrightFlakeLinterAllowlistEntry[];
+  hardenedIdentityHelperNames?: readonly string[];
+  identityHelperMinimumLengths?: Readonly<Record<string, number>>;
+  identityNamePattern?: string;
+  responseWaitCallNames?: readonly string[];
+  retryHelperNames?: readonly string[];
+  scanRoots: readonly string[];
+  sharedReadinessMechanisms?: readonly SharedReadinessMechanism[];
+  specificRequestMatcherNames?: readonly string[];
+  specFilePattern?: string;
+  transientClassifierNamePatterns?: readonly string[];
+  undiscriminatingRetryHelperNames?: readonly string[];
+}
+
+export interface PlaywrightFlakePatternViolation {
+  column: number;
+  filePath: string;
+  line: number;
+  message: string;
+  ruleId: PlaywrightFlakeRuleId;
+}
+
+const ALLOWLIST_PREFIX = "flake-lint-allow";
+const DEFAULT_IDENTITY_NAME_PATTERN =
+  "(address|email|identifier|license|message|name|phone|street|suffix|title|id$)";
+const DEFAULT_RESPONSE_WAIT_CALL_NAMES = ["waitForResponse"];
+const DEFAULT_SPECIFIC_REQUEST_MATCHER_NAMES = ["isMatchingRequest"];
+const DEFAULT_SPEC_FILE_PATTERN = String.raw`\.spec\.[cm]?[jt]sx?$`;
+const DEFAULT_TRANSIENT_CLASSIFIER_NAME_PATTERNS = ["^isRetryable", "retryClassification"];
+const RULE_MESSAGES: Readonly<Record<Exclude<PlaywrightFlakeRuleId, "shared-readiness">, string>> =
+  {
+    "fixed-sleep":
+      "Fixed sleep anti-pattern (rubric B2). Replace waitForTimeout/setTimeout delays with a deterministic readiness signal",
+    "response-wait":
+      "Undiscriminating response-wait anti-pattern (rubric B2). Match the request method, URL, and a discriminating request predicate",
+    "retry-classification":
+      "Undiscriminating retry anti-pattern (rubric B1). Retry only failures classified as transient and fail fast for genuine failures",
+    "test-data-identity":
+      "Low-entropy parallel-worker identity collision anti-pattern (rubric A2). Use a configured hardened random helper or UUID-backed identity",
+  };
+
+interface FindPlaywrightFlakePatternViolationsParams {
+  config: PlaywrightFlakeLinterConfig;
+  filePath: string;
+  source: string;
+}
+
+interface AddViolationParams {
+  message: string;
+  node: ts.Node;
+  ruleId: PlaywrightFlakeRuleId;
+}
+
+interface ParsePlaywrightFlakeLinterConfigParams {
+  sourceDescription: string;
+  value: unknown;
+}
+
+export function definePlaywrightFlakeLinterConfig(
+  config: PlaywrightFlakeLinterConfig,
+): PlaywrightFlakeLinterConfig {
+  validateConfig(config);
+
+  return config;
+}
+
+export function parsePlaywrightFlakeLinterConfig({
+  sourceDescription,
+  value,
+}: ParsePlaywrightFlakeLinterConfigParams): PlaywrightFlakeLinterConfig {
+  if (!isPlaywrightFlakeLinterConfig(value)) {
+    throw new Error(`Invalid Playwright flake linter config at ${sourceDescription}.`);
+  }
+
+  return definePlaywrightFlakeLinterConfig(value);
+}
+
+export function findPlaywrightFlakePatternViolations({
+  config,
+  filePath,
+  source,
+}: FindPlaywrightFlakePatternViolationsParams): PlaywrightFlakePatternViolation[] {
+  validateConfig(config);
+
+  const normalizedFilePath = normalizeFilePath(filePath);
+  const sourceFile = ts.createSourceFile(
+    normalizedFilePath,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    getScriptKind(normalizedFilePath),
+  );
+  const violations: PlaywrightFlakePatternViolation[] = [];
+  const isSpecFile = new RegExp(config.specFilePattern ?? DEFAULT_SPEC_FILE_PATTERN).test(
+    normalizedFilePath,
+  );
+  const sharedReadinessMechanisms = getMatchingSharedReadinessMechanisms({
+    config,
+    filePath: normalizedFilePath,
+  });
+
+  function addViolation({ message, node, ruleId }: AddViolationParams): void {
+    if (
+      hasInlineAllowlistComment({
+        node,
+        ruleId,
+        source,
+        sourceFile,
+      }) ||
+      isAllowlistedByConfig({
+        config,
+        filePath: normalizedFilePath,
+        ruleId,
+      })
+    ) {
+      return;
+    }
+
+    const position = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+    violations.push({
+      column: position.character + 1,
+      filePath: normalizedFilePath,
+      line: position.line + 1,
+      message,
+      ruleId,
+    });
+  }
+
+  function visit(node: ts.Node): void {
+    if (ts.isCallExpression(node)) {
+      if (isSpecFile && isFixedSleepCall(node)) {
+        addViolation({
+          message: RULE_MESSAGES["fixed-sleep"],
+          node,
+          ruleId: "fixed-sleep",
+        });
+      }
+
+      if (
+        isConfiguredCall({
+          callExpression: node,
+          names: getResponseWaitCallNames(config),
+        }) &&
+        hasUndiscriminatingResponsePredicate({
+          callExpression: node,
+          specificRequestMatcherNames:
+            config.specificRequestMatcherNames ?? DEFAULT_SPECIFIC_REQUEST_MATCHER_NAMES,
+        })
+      ) {
+        addViolation({
+          message: RULE_MESSAGES["response-wait"],
+          node,
+          ruleId: "response-wait",
+        });
+      }
+
+      for (const mechanism of sharedReadinessMechanisms) {
+        if (!mechanism.directCallNames.includes(getCallName(node) ?? "")) {
+          continue;
+        }
+
+        addViolation({
+          message: getSharedReadinessMessage(mechanism),
+          node,
+          ruleId: "shared-readiness",
+        });
+      }
+
+      if (isUndiscriminatingRetryCall({ callExpression: node, config })) {
+        addViolation({
+          message: RULE_MESSAGES["retry-classification"],
+          node,
+          ruleId: "retry-classification",
+        });
+      }
+
+      if (isLowEntropyTestDataIdentityCall({ callExpression: node, config })) {
+        addViolation({
+          message: RULE_MESSAGES["test-data-identity"],
+          node,
+          ruleId: "test-data-identity",
+        });
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return violations.toSorted(compareViolations);
+}
+
+function validateConfig(config: PlaywrightFlakeLinterConfig): void {
+  if (
+    config.scanRoots.length === 0 ||
+    config.scanRoots.some((scanRoot) => scanRoot.trim().length === 0)
+  ) {
+    throw new Error("Playwright flake linter config requires at least one scan root.");
+  }
+
+  for (const allowlistEntry of config.allowlist ?? []) {
+    if (allowlistEntry.reason.trim().length === 0) {
+      throw new Error("Every Playwright flake linter allowlist reason must be non-empty.");
+    }
+
+    validatePattern({
+      label: "allowlist file path",
+      pattern: allowlistEntry.filePathPattern,
+    });
+  }
+
+  validateOptionalPattern({
+    label: "spec file",
+    pattern: config.specFilePattern,
+  });
+  validateOptionalPattern({
+    label: "identity name",
+    pattern: config.identityNamePattern,
+  });
+
+  for (const pattern of config.transientClassifierNamePatterns ?? []) {
+    validatePattern({ label: "transient classifier name", pattern });
+  }
+
+  for (const [helperName, minimumLength] of Object.entries(
+    config.identityHelperMinimumLengths ?? {},
+  )) {
+    if (helperName.trim().length === 0 || !Number.isInteger(minimumLength) || minimumLength <= 0) {
+      throw new Error(
+        "Identity helper minimum lengths require a non-empty helper name and positive integer.",
+      );
+    }
+  }
+
+  for (const mechanism of config.sharedReadinessMechanisms ?? []) {
+    if (
+      mechanism.name.trim().length === 0 ||
+      mechanism.directCallNames.length === 0 ||
+      mechanism.sharedHelperNames.length === 0
+    ) {
+      throw new Error(
+        "Shared readiness mechanisms require a name, direct call, and shared helper.",
+      );
+    }
+
+    validatePattern({
+      label: `${mechanism.name} file path`,
+      pattern: mechanism.filePathPattern,
+    });
+  }
+}
+
+interface ValidateOptionalPatternParams {
+  label: string;
+  pattern: string | undefined;
+}
+
+function validateOptionalPattern({ label, pattern }: ValidateOptionalPatternParams): void {
+  if (pattern !== undefined) {
+    validatePattern({ label, pattern });
+  }
+}
+
+interface ValidatePatternParams {
+  label: string;
+  pattern: string;
+}
+
+function validatePattern({ label, pattern }: ValidatePatternParams): void {
+  try {
+    new RegExp(pattern).test("");
+  } catch {
+    throw new Error(`Invalid ${label} pattern: ${pattern}`);
+  }
+}
+
+function isFixedSleepCall(callExpression: ts.CallExpression): boolean {
+  const { expression } = callExpression;
+  const isQualifiedSetTimeout =
+    ts.isPropertyAccessExpression(expression) &&
+    expression.name.text === "setTimeout" &&
+    ts.isIdentifier(expression.expression) &&
+    ["globalThis", "self", "window"].includes(expression.expression.text);
+
+  return (
+    (ts.isPropertyAccessExpression(expression) && expression.name.text === "waitForTimeout") ||
+    isQualifiedSetTimeout ||
+    (ts.isIdentifier(expression) && expression.text === "setTimeout")
+  );
+}
+
+interface HasUndiscriminatingResponsePredicateParams {
+  callExpression: ts.CallExpression;
+  specificRequestMatcherNames: readonly string[];
+}
+
+function hasUndiscriminatingResponsePredicate({
+  callExpression,
+  specificRequestMatcherNames,
+}: HasUndiscriminatingResponsePredicateParams): boolean {
+  const predicate = resolveFunctionLike({
+    expression: callExpression.arguments[0],
+    referenceNode: callExpression,
+  });
+
+  if (predicate === undefined) {
+    return false;
+  }
+
+  const responseParameter = predicate.parameters[0]?.name;
+
+  if (responseParameter === undefined || !ts.isIdentifier(responseParameter)) {
+    return false;
+  }
+
+  const responseName = responseParameter.text;
+  let checksStatus = false;
+  let delegatesSpecificRequestMatching = false;
+  let checksMethod = false;
+  let checksUrl = false;
+  let checksDiscriminatingRequestProperty = false;
+
+  function visitFullPredicate(node: ts.Node): void {
+    if (ts.isCallExpression(node)) {
+      checksStatus ||= isDirectResponseCall({
+        callExpression: node,
+        methodNames: ["ok", "status"],
+        responseName,
+      });
+      delegatesSpecificRequestMatching ||=
+        ts.isIdentifier(node.expression) &&
+        specificRequestMatcherNames.includes(node.expression.text);
+    }
+
+    ts.forEachChild(node, visitFullPredicate);
+  }
+
+  function visitResultDependency(node: ts.Node): void {
+    if (ts.isCallExpression(node)) {
+      checksUrl ||= isDirectResponseCall({
+        callExpression: node,
+        methodNames: ["url"],
+        responseName,
+      });
+      checksMethod ||= isResponseRequestCall({
+        callExpression: node,
+        methodNames: ["method"],
+        responseName,
+      });
+      checksDiscriminatingRequestProperty ||=
+        isResponseRequestCall({
+          callExpression: node,
+          methodNames: ["headerValue", "postData", "postDataJSON", "resourceType"],
+          responseName,
+        }) || isDynamicResponseUrlMatch({ callExpression: node, responseName });
+    }
+
+    if (ts.isPropertyAccessExpression(node) && node.name.text === "searchParams") {
+      checksDiscriminatingRequestProperty = true;
+    }
+
+    ts.forEachChild(node, visitResultDependency);
+  }
+
+  visitFullPredicate(predicate);
+
+  for (const resultNode of getPredicateResultDependencies(predicate)) {
+    visitResultDependency(resultNode);
+  }
+
+  if (!checksStatus) {
+    return false;
+  }
+
+  return (
+    !delegatesSpecificRequestMatching &&
+    (!checksMethod || !checksUrl || !checksDiscriminatingRequestProperty)
+  );
+}
+
+interface ResponseCallParams {
+  callExpression: ts.CallExpression;
+  methodNames: readonly string[];
+  responseName: string;
+}
+
+function isDirectResponseCall({
+  callExpression,
+  methodNames,
+  responseName,
+}: ResponseCallParams): boolean {
+  const { expression } = callExpression;
+
+  return (
+    ts.isPropertyAccessExpression(expression) &&
+    methodNames.includes(expression.name.text) &&
+    ts.isIdentifier(expression.expression) &&
+    expression.expression.text === responseName
+  );
+}
+
+function isResponseRequestCall({
+  callExpression,
+  methodNames,
+  responseName,
+}: ResponseCallParams): boolean {
+  const { expression } = callExpression;
+
+  if (
+    !ts.isPropertyAccessExpression(expression) ||
+    !methodNames.includes(expression.name.text) ||
+    !ts.isCallExpression(expression.expression)
+  ) {
+    return false;
+  }
+
+  return isDirectResponseCall({
+    callExpression: expression.expression,
+    methodNames: ["request"],
+    responseName,
+  });
+}
+
+interface IsDynamicResponseUrlMatchParams {
+  callExpression: ts.CallExpression;
+  responseName: string;
+}
+
+function isDynamicResponseUrlMatch({
+  callExpression,
+  responseName,
+}: IsDynamicResponseUrlMatchParams): boolean {
+  const { expression } = callExpression;
+
+  return (
+    ts.isPropertyAccessExpression(expression) &&
+    ["endsWith", "includes", "startsWith"].includes(expression.name.text) &&
+    ts.isCallExpression(expression.expression) &&
+    isDirectResponseCall({
+      callExpression: expression.expression,
+      methodNames: ["url"],
+      responseName,
+    }) &&
+    callExpression.arguments.some(ts.isTemplateExpression)
+  );
+}
+
+function getPredicateResultDependencies(predicate: ts.FunctionLikeDeclaration): ts.Node[] {
+  if (predicate.body === undefined) {
+    return [];
+  }
+
+  const predicateBody = predicate.body;
+
+  if (!ts.isBlock(predicateBody)) {
+    return [predicateBody];
+  }
+
+  const dependencies: ts.Node[] = [];
+  const initializerByName = new Map<string, ts.Expression>();
+
+  function visit(node: ts.Node): void {
+    if (node !== predicate && ts.isFunctionLike(node)) {
+      return;
+    }
+
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer !== undefined
+    ) {
+      initializerByName.set(node.name.text, node.initializer);
+    }
+
+    if (ts.isReturnStatement(node) && node.expression !== undefined) {
+      dependencies.push(node.expression);
+      addGoverningConditions({
+        boundary: predicateBody,
+        dependencies,
+        node,
+      });
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(predicateBody);
+
+  let dependencyIndex = 0;
+
+  while (dependencyIndex < dependencies.length) {
+    const dependency = dependencies[dependencyIndex];
+    dependencyIndex += 1;
+
+    if (dependency === undefined) {
+      continue;
+    }
+
+    addReferencedInitializers({
+      dependencies,
+      initializerByName,
+      node: dependency,
+    });
+  }
+
+  return dependencies;
+}
+
+interface AddReferencedInitializersParams {
+  dependencies: ts.Node[];
+  initializerByName: ReadonlyMap<string, ts.Expression>;
+  node: ts.Node;
+}
+
+function addReferencedInitializers({
+  dependencies,
+  initializerByName,
+  node,
+}: AddReferencedInitializersParams): void {
+  if (ts.isIdentifier(node)) {
+    const initializer = initializerByName.get(node.text);
+
+    if (initializer !== undefined && !dependencies.includes(initializer)) {
+      dependencies.push(initializer);
+    }
+  }
+
+  ts.forEachChild(node, (childNode) => {
+    addReferencedInitializers({
+      dependencies,
+      initializerByName,
+      node: childNode,
+    });
+  });
+}
+
+interface AddGoverningConditionsParams {
+  boundary: ts.Node;
+  dependencies: ts.Node[];
+  node: ts.Node;
+}
+
+function addGoverningConditions({
+  boundary,
+  dependencies,
+  node,
+}: AddGoverningConditionsParams): void {
+  let ancestor = node.parent;
+
+  while (ancestor !== undefined && ancestor !== boundary) {
+    if (ts.isIfStatement(ancestor)) {
+      dependencies.push(ancestor.expression);
+    }
+
+    ancestor = ancestor.parent;
+  }
+}
+
+interface ResolveFunctionLikeParams {
+  expression: ts.Expression | undefined;
+  referenceNode: ts.Node;
+}
+
+function resolveFunctionLike({
+  expression,
+  referenceNode,
+}: ResolveFunctionLikeParams): ts.FunctionLikeDeclaration | undefined {
+  if (expression === undefined) {
+    return undefined;
+  }
+
+  if (ts.isArrowFunction(expression) || ts.isFunctionExpression(expression)) {
+    return expression;
+  }
+
+  if (!ts.isIdentifier(expression)) {
+    return undefined;
+  }
+
+  let scope: ts.Node | undefined = referenceNode.parent;
+
+  while (scope !== undefined) {
+    if (ts.isBlock(scope) || ts.isSourceFile(scope)) {
+      const declaration = findFunctionLikeInStatements({
+        functionName: expression.text,
+        statements: scope.statements,
+      });
+
+      if (declaration !== undefined) {
+        return declaration;
+      }
+    }
+
+    scope = scope.parent;
+  }
+
+  return undefined;
+}
+
+interface FindFunctionLikeInStatementsParams {
+  functionName: string;
+  statements: ts.NodeArray<ts.Statement>;
+}
+
+function findFunctionLikeInStatements({
+  functionName,
+  statements,
+}: FindFunctionLikeInStatementsParams): ts.FunctionLikeDeclaration | undefined {
+  for (const statement of statements) {
+    if (ts.isFunctionDeclaration(statement) && statement.name?.text === functionName) {
+      return statement;
+    }
+
+    if (!ts.isVariableStatement(statement)) {
+      continue;
+    }
+
+    for (const declaration of statement.declarationList.declarations) {
+      if (
+        ts.isIdentifier(declaration.name) &&
+        declaration.name.text === functionName &&
+        declaration.initializer !== undefined &&
+        (ts.isArrowFunction(declaration.initializer) ||
+          ts.isFunctionExpression(declaration.initializer))
+      ) {
+        return declaration.initializer;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+interface IsUndiscriminatingRetryCallParams {
+  callExpression: ts.CallExpression;
+  config: PlaywrightFlakeLinterConfig;
+}
+
+function isUndiscriminatingRetryCall({
+  callExpression,
+  config,
+}: IsUndiscriminatingRetryCallParams): boolean {
+  const callName = getCallName(callExpression);
+
+  if (callName === undefined) {
+    return false;
+  }
+
+  if ((config.undiscriminatingRetryHelperNames ?? []).includes(callName)) {
+    return true;
+  }
+
+  if (!(config.retryHelperNames ?? []).includes(callName)) {
+    return false;
+  }
+
+  const callback = resolveFunctionLike({
+    expression: callExpression.arguments[0],
+    referenceNode: callExpression,
+  });
+
+  if (callback === undefined) {
+    return true;
+  }
+
+  const classifierPatterns = (
+    config.transientClassifierNamePatterns ?? DEFAULT_TRANSIENT_CLASSIFIER_NAME_PATTERNS
+  ).map((pattern) => new RegExp(pattern));
+  let usesTransientClassifier = false;
+
+  function visit(node: ts.Node): void {
+    if (ts.isIdentifier(node) && classifierPatterns.some((pattern) => pattern.test(node.text))) {
+      usesTransientClassifier = true;
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(callback);
+  return !usesTransientClassifier;
+}
+
+interface IsLowEntropyTestDataIdentityCallParams {
+  callExpression: ts.CallExpression;
+  config: PlaywrightFlakeLinterConfig;
+}
+
+function isLowEntropyTestDataIdentityCall({
+  callExpression,
+  config,
+}: IsLowEntropyTestDataIdentityCallParams): boolean {
+  const identityOwnerName = findIdentityContextName(callExpression);
+
+  if (
+    identityOwnerName === undefined ||
+    !new RegExp(config.identityNamePattern ?? DEFAULT_IDENTITY_NAME_PATTERN, "i").test(
+      identityOwnerName,
+    )
+  ) {
+    return false;
+  }
+
+  const callName = getCallName(callExpression);
+
+  if (callName !== undefined && (config.hardenedIdentityHelperNames ?? []).includes(callName)) {
+    return false;
+  }
+
+  if (isLowEntropyBuiltInIdentitySource(callExpression)) {
+    return true;
+  }
+
+  if (callName === undefined || !(callName in (config.identityHelperMinimumLengths ?? {}))) {
+    return false;
+  }
+
+  const [lengthArgument] = callExpression.arguments;
+
+  if (lengthArgument === undefined || !ts.isNumericLiteral(lengthArgument)) {
+    return true;
+  }
+
+  const minimumLength = config.identityHelperMinimumLengths?.[callName];
+
+  return minimumLength !== undefined && Number(lengthArgument.text) < minimumLength;
+}
+
+function isLowEntropyBuiltInIdentitySource(callExpression: ts.CallExpression): boolean {
+  const { expression } = callExpression;
+
+  return (
+    ts.isPropertyAccessExpression(expression) &&
+    ((expression.expression.getText() === "Date" && expression.name.text === "now") ||
+      (expression.expression.getText() === "Math" && expression.name.text === "random"))
+  );
+}
+
+function findIdentityContextName(node: ts.Node): string | undefined {
+  let ancestor = node.parent;
+
+  while (ancestor !== undefined) {
+    if (ts.isVariableDeclaration(ancestor) && ts.isIdentifier(ancestor.name)) {
+      return ancestor.name.text;
+    }
+
+    if (ts.isPropertyAssignment(ancestor)) {
+      return ancestor.name.getText();
+    }
+
+    if (
+      ts.isCallExpression(ancestor) &&
+      ts.isPropertyAccessExpression(ancestor.expression) &&
+      ancestor.expression.name.text === "fill"
+    ) {
+      return collectStringLiteralText(ancestor);
+    }
+
+    if (ts.isStatement(ancestor)) {
+      return undefined;
+    }
+
+    ancestor = ancestor.parent;
+  }
+
+  return undefined;
+}
+
+function collectStringLiteralText(node: ts.Node): string {
+  const stringValues: string[] = [];
+
+  function visit(descendant: ts.Node): void {
+    if (ts.isStringLiteralLike(descendant)) {
+      stringValues.push(descendant.text);
+    }
+
+    ts.forEachChild(descendant, visit);
+  }
+
+  visit(node);
+  return stringValues.join(" ");
+}
+
+interface HasInlineAllowlistCommentParams {
+  node: ts.Node;
+  ruleId: PlaywrightFlakeRuleId;
+  source: string;
+  sourceFile: ts.SourceFile;
+}
+
+function hasInlineAllowlistComment({
+  node,
+  ruleId,
+  source,
+  sourceFile,
+}: HasInlineAllowlistCommentParams): boolean {
+  const allowlistPattern = new RegExp(
+    `${ALLOWLIST_PREFIX}\\s+${escapeRegExp(ruleId)}\\s+--\\s+\\S`,
+  );
+  let currentNode: ts.Node | undefined = node;
+
+  while (currentNode !== undefined && currentNode !== sourceFile) {
+    const leadingCommentRanges =
+      ts.getLeadingCommentRanges(source, currentNode.getFullStart()) ?? [];
+
+    if (
+      leadingCommentRanges.some((range) =>
+        allowlistPattern.test(source.slice(range.pos, range.end)),
+      )
+    ) {
+      return true;
+    }
+
+    if (ts.isStatement(currentNode)) {
+      return false;
+    }
+
+    currentNode = currentNode.parent;
+  }
+
+  return false;
+}
+
+interface IsAllowlistedByConfigParams {
+  config: PlaywrightFlakeLinterConfig;
+  filePath: string;
+  ruleId: PlaywrightFlakeRuleId;
+}
+
+function isAllowlistedByConfig({ config, filePath, ruleId }: IsAllowlistedByConfigParams): boolean {
+  return (config.allowlist ?? []).some(
+    (entry) => entry.ruleId === ruleId && new RegExp(entry.filePathPattern).test(filePath),
+  );
+}
+
+interface GetMatchingSharedReadinessMechanismsParams {
+  config: PlaywrightFlakeLinterConfig;
+  filePath: string;
+}
+
+function getMatchingSharedReadinessMechanisms({
+  config,
+  filePath,
+}: GetMatchingSharedReadinessMechanismsParams): readonly SharedReadinessMechanism[] {
+  return (config.sharedReadinessMechanisms ?? []).filter((mechanism) =>
+    new RegExp(mechanism.filePathPattern).test(filePath),
+  );
+}
+
+function getSharedReadinessMessage(mechanism: SharedReadinessMechanism): string {
+  return (
+    `Per-spec ${mechanism.name} gate anti-pattern (rubric A1 shared-helper rule). ` +
+    `Use or extend ${mechanism.sharedHelperNames.join(" or ")}`
+  );
+}
+
+function getResponseWaitCallNames(config: PlaywrightFlakeLinterConfig): readonly string[] {
+  return config.responseWaitCallNames ?? DEFAULT_RESPONSE_WAIT_CALL_NAMES;
+}
+
+interface IsConfiguredCallParams {
+  callExpression: ts.CallExpression;
+  names: readonly string[];
+}
+
+function isConfiguredCall({ callExpression, names }: IsConfiguredCallParams): boolean {
+  const callName = getCallName(callExpression);
+
+  return callName !== undefined && names.includes(callName);
+}
+
+function getCallName(callExpression: ts.CallExpression): string | undefined {
+  const { expression } = callExpression;
+
+  if (ts.isIdentifier(expression)) {
+    return expression.text;
+  }
+
+  if (ts.isPropertyAccessExpression(expression)) {
+    return expression.name.text;
+  }
+
+  return undefined;
+}
+
+function getScriptKind(filePath: string): ts.ScriptKind {
+  return filePath.endsWith("x") ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
+}
+
+function normalizeFilePath(filePath: string): string {
+  return filePath.replaceAll(path.sep, "/");
+}
+
+function isPlaywrightFlakeLinterConfig(value: unknown): value is PlaywrightFlakeLinterConfig {
+  if (!isRecord(value) || !isStringArray(value["scanRoots"])) {
+    return false;
+  }
+
+  return (
+    isOptionalString(value["specFilePattern"]) &&
+    isOptionalString(value["identityNamePattern"]) &&
+    isOptionalStringArray(value["hardenedIdentityHelperNames"]) &&
+    isOptionalStringArray(value["responseWaitCallNames"]) &&
+    isOptionalStringArray(value["retryHelperNames"]) &&
+    isOptionalStringArray(value["specificRequestMatcherNames"]) &&
+    isOptionalStringArray(value["transientClassifierNamePatterns"]) &&
+    isOptionalStringArray(value["undiscriminatingRetryHelperNames"]) &&
+    isOptionalNumberRecord(value["identityHelperMinimumLengths"]) &&
+    isOptionalAllowlist(value["allowlist"]) &&
+    isOptionalSharedReadinessMechanisms(value["sharedReadinessMechanisms"])
+  );
+}
+
+function isOptionalAllowlist(
+  value: unknown,
+): value is readonly PlaywrightFlakeLinterAllowlistEntry[] | undefined {
+  return (
+    value === undefined ||
+    (Array.isArray(value) &&
+      value.every(
+        (entry: unknown) =>
+          isRecord(entry) &&
+          typeof entry["filePathPattern"] === "string" &&
+          typeof entry["reason"] === "string" &&
+          isPlaywrightFlakeRuleId(entry["ruleId"]),
+      ))
+  );
+}
+
+function isOptionalSharedReadinessMechanisms(
+  value: unknown,
+): value is readonly SharedReadinessMechanism[] | undefined {
+  return (
+    value === undefined ||
+    (Array.isArray(value) &&
+      value.every(
+        (mechanism: unknown) =>
+          isRecord(mechanism) &&
+          isStringArray(mechanism["directCallNames"]) &&
+          typeof mechanism["filePathPattern"] === "string" &&
+          typeof mechanism["name"] === "string" &&
+          isStringArray(mechanism["sharedHelperNames"]),
+      ))
+  );
+}
+
+function isPlaywrightFlakeRuleId(value: unknown): value is PlaywrightFlakeRuleId {
+  return typeof value === "string" && PLAYWRIGHT_FLAKE_RULE_ID_SET.has(value);
+}
+
+function isOptionalNumberRecord(
+  value: unknown,
+): value is Readonly<Record<string, number>> | undefined {
+  return (
+    value === undefined ||
+    (isRecord(value) &&
+      Object.values(value).every((entry) => typeof entry === "number" && Number.isFinite(entry)))
+  );
+}
+
+function isOptionalString(value: unknown): value is string | undefined {
+  return value === undefined || typeof value === "string";
+}
+
+function isOptionalStringArray(value: unknown): value is readonly string[] | undefined {
+  return value === undefined || isStringArray(value);
+}
+
+function isStringArray(value: unknown): value is readonly string[] {
+  return Array.isArray(value) && value.every((entry: unknown) => typeof entry === "string");
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+}

--- a/packages/playwright-flake-linter/src/lib/projectLinter.test.ts
+++ b/packages/playwright-flake-linter/src/lib/projectLinter.test.ts
@@ -1,0 +1,192 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { runCli } from "../bin/runCli";
+import type { PlaywrightFlakeLinterConfig } from "./playwrightFlakeLinter";
+import { lintPlaywrightProject, loadPlaywrightFlakeLinterConfig } from "./projectLinter";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map(async (directoryPath) => {
+      await rm(directoryPath, { force: true, recursive: true });
+    }),
+  );
+});
+
+describe("lintPlaywrightProject", () => {
+  it("recursively scans configured roots and returns sorted violations", async () => {
+    const cwd = await createTemporaryDirectory();
+    const config = getConfig();
+    await writeFixture({
+      cwd,
+      filePath: "playwright/z-last.spec.ts",
+      source: "await page.waitForTimeout(200);",
+    });
+    await writeFixture({
+      cwd,
+      filePath: "playwright/nested/a-first.spec.ts",
+      source: "await page.waitForResponse((response) => response.ok());",
+    });
+    await writeFixture({
+      cwd,
+      filePath: "outside/ignored.spec.ts",
+      source: "await page.waitForTimeout(100);",
+    });
+
+    const actual = await lintPlaywrightProject({ config, cwd });
+
+    expect(actual.map(({ filePath, ruleId }) => `${filePath}:${ruleId}`)).toEqual([
+      "playwright/nested/a-first.spec.ts:response-wait",
+      "playwright/z-last.spec.ts:fixed-sleep",
+    ]);
+  });
+
+  it("supports a configured source file and ignores non-TypeScript files", async () => {
+    const cwd = await createTemporaryDirectory();
+    await writeFixture({
+      cwd,
+      filePath: "single.spec.tsx",
+      source: "await page.waitForTimeout(100);",
+    });
+    await writeFixture({
+      cwd,
+      filePath: "ignored.txt",
+      source: "await page.waitForTimeout(100);",
+    });
+
+    const actual = await lintPlaywrightProject({
+      config: { scanRoots: ["single.spec.tsx"] },
+      cwd,
+    });
+
+    expect(actual.map(({ ruleId }) => ruleId)).toEqual(["fixed-sleep"]);
+  });
+});
+
+describe("loadPlaywrightFlakeLinterConfig", () => {
+  it("loads a default-exported repository config fixture", async () => {
+    const cwd = await createTemporaryDirectory();
+    const configFilePath = path.join(cwd, "mobile.config.mjs");
+    await writeFile(
+      configFilePath,
+      `export default ${JSON.stringify({
+        scanRoots: ["playwright"],
+        sharedReadinessMechanisms: [
+          {
+            directCallNames: ["waitForResponse"],
+            filePathPattern: String.raw`playwright/e2e/sheets/.*\.spec\.ts$`,
+            name: "BottomSheet readiness",
+            sharedHelperNames: ["waitForBottomSheet"],
+          },
+        ],
+      })};`,
+      "utf8",
+    );
+
+    const actual = await loadPlaywrightFlakeLinterConfig({ configFilePath });
+
+    expect(actual.scanRoots).toEqual(["playwright"]);
+    expect(actual.sharedReadinessMechanisms?.[0]?.name).toBe("BottomSheet readiness");
+  });
+
+  it("rejects an invalid config module", async () => {
+    const cwd = await createTemporaryDirectory();
+    const configFilePath = path.join(cwd, "invalid.mjs");
+    await writeFile(configFilePath, "export default {};", "utf8");
+
+    await expect(loadPlaywrightFlakeLinterConfig({ configFilePath })).rejects.toThrow(
+      "Invalid Playwright flake linter config",
+    );
+  });
+});
+
+describe("runCli", () => {
+  it("prints actionable diagnostics and returns failure for violations", async () => {
+    const cwd = await createTemporaryDirectory();
+    const configFilePath = path.join(cwd, "playwright-flake-lint.config.mjs");
+    await writeFile(configFilePath, `export default ${JSON.stringify(getConfig())};`, "utf8");
+    await writeFixture({
+      cwd,
+      filePath: "playwright/example.spec.ts",
+      source: "await page.waitForTimeout(100);",
+    });
+    const output: string[] = [];
+
+    const actual = await runCli({
+      arguments_: [],
+      cwd,
+      writeError: (value) => {
+        output.push(value);
+      },
+    });
+
+    expect(actual).toBe(1);
+    expect(output.join("")).toContain("playwright/example.spec.ts:1:7 [fixed-sleep]");
+    expect(output.join("")).toContain("flake-lint-allow fixed-sleep -- <reason>");
+  });
+
+  it("accepts an explicit config path and returns success without violations", async () => {
+    const cwd = await createTemporaryDirectory();
+    await writeFile(
+      path.join(cwd, "custom.mjs"),
+      `export default ${JSON.stringify(getConfig())};`,
+      "utf8",
+    );
+    await writeFixture({
+      cwd,
+      filePath: "playwright/example.spec.ts",
+      source: 'await expect(page.getByRole("heading")).toBeVisible();',
+    });
+    const output: string[] = [];
+
+    const actual = await runCli({
+      arguments_: ["--config", "custom.mjs"],
+      cwd,
+      writeError: (value) => {
+        output.push(value);
+      },
+    });
+
+    expect(actual).toBe(0);
+    expect(output).toEqual([]);
+  });
+
+  it("rejects unsupported arguments", async () => {
+    await expect(
+      runCli({
+        arguments_: ["--unknown"],
+        cwd: process.cwd(),
+        writeError: (value) => {
+          process.stderr.write(value);
+        },
+      }),
+    ).rejects.toThrow("Usage:");
+  });
+});
+
+function getConfig(): PlaywrightFlakeLinterConfig {
+  return {
+    scanRoots: ["playwright"],
+  };
+}
+
+async function createTemporaryDirectory(): Promise<string> {
+  const directoryPath = await mkdtemp(path.join(os.tmpdir(), "playwright-flake-linter-"));
+  temporaryDirectories.push(directoryPath);
+  return directoryPath;
+}
+
+interface WriteFixtureParams {
+  cwd: string;
+  filePath: string;
+  source: string;
+}
+
+async function writeFixture({ cwd, filePath, source }: WriteFixtureParams): Promise<void> {
+  const absoluteFilePath = path.join(cwd, filePath);
+  await mkdir(path.dirname(absoluteFilePath), { recursive: true });
+  await writeFile(absoluteFilePath, source, "utf8");
+}

--- a/packages/playwright-flake-linter/src/lib/projectLinter.ts
+++ b/packages/playwright-flake-linter/src/lib/projectLinter.ts
@@ -1,0 +1,96 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { glob } from "glob";
+
+import { compareViolations } from "./internal/violations";
+import type {
+  PlaywrightFlakeLinterConfig,
+  PlaywrightFlakePatternViolation,
+} from "./playwrightFlakeLinter";
+import {
+  findPlaywrightFlakePatternViolations,
+  parsePlaywrightFlakeLinterConfig,
+} from "./playwrightFlakeLinter";
+
+const SOURCE_FILE_PATTERN = "*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}";
+
+interface LintPlaywrightProjectParams {
+  config: PlaywrightFlakeLinterConfig;
+  cwd: string;
+}
+
+interface LoadPlaywrightFlakeLinterConfigParams {
+  configFilePath: string;
+}
+
+export async function lintPlaywrightProject({
+  config,
+  cwd,
+}: LintPlaywrightProjectParams): Promise<PlaywrightFlakePatternViolation[]> {
+  const filePaths = await findSourceFiles({ config, cwd });
+  const nestedViolations = await Promise.all(
+    filePaths.map(async (filePath) =>
+      findPlaywrightFlakePatternViolations({
+        config,
+        filePath: path.relative(cwd, filePath),
+        source: await readFile(filePath, "utf8"),
+      }),
+    ),
+  );
+
+  return nestedViolations.flat().toSorted(compareViolations);
+}
+
+export async function loadPlaywrightFlakeLinterConfig({
+  configFilePath,
+}: LoadPlaywrightFlakeLinterConfigParams): Promise<PlaywrightFlakeLinterConfig> {
+  const importedModule: unknown = await import(
+    `${pathToFileURL(path.resolve(configFilePath)).href}?loaded=${Date.now()}`
+  );
+
+  return parsePlaywrightFlakeLinterConfig({
+    sourceDescription: configFilePath,
+    value: getDefaultExport(importedModule),
+  });
+}
+
+interface FindSourceFilesParams {
+  config: PlaywrightFlakeLinterConfig;
+  cwd: string;
+}
+
+async function findSourceFiles({ config, cwd }: FindSourceFilesParams): Promise<string[]> {
+  const patterns = config.scanRoots.flatMap((scanRoot) => [
+    normalizeGlobPath(scanRoot),
+    path.posix.join(normalizeGlobPath(scanRoot), "**", SOURCE_FILE_PATTERN),
+  ]);
+  const filePaths = await glob(patterns, {
+    absolute: true,
+    cwd,
+    nodir: true,
+  });
+
+  return filePaths.filter(isSourceFile);
+}
+
+function normalizeGlobPath(filePath: string): string {
+  return filePath.replaceAll(path.sep, "/");
+}
+
+function isSourceFile(filePath: string): boolean {
+  return /\.[cm]?[jt]sx?$/.test(filePath);
+}
+
+function getDefaultExport(importedModule: unknown): unknown {
+  if (
+    typeof importedModule !== "object" ||
+    importedModule === null ||
+    Array.isArray(importedModule)
+  ) {
+    return undefined;
+  }
+
+  return Reflect.get(importedModule, "default");
+}

--- a/packages/playwright-flake-linter/test/fixtures/playwright/e2e/fixed-sleep.allowlisted.spec.ts.txt
+++ b/packages/playwright-flake-linter/test/fixtures/playwright/e2e/fixed-sleep.allowlisted.spec.ts.txt
@@ -1,0 +1,2 @@
+// flake-lint-allow fixed-sleep -- This fixture verifies elapsed product time.
+await page.waitForTimeout(2_000);

--- a/packages/playwright-flake-linter/test/fixtures/playwright/e2e/fixed-sleep.compliant.spec.ts.txt
+++ b/packages/playwright-flake-linter/test/fixtures/playwright/e2e/fixed-sleep.compliant.spec.ts.txt
@@ -1,0 +1,1 @@
+await expect(page.getByRole("heading")).toBeVisible();

--- a/packages/playwright-flake-linter/test/fixtures/playwright/e2e/fixed-sleep.violation.spec.ts.txt
+++ b/packages/playwright-flake-linter/test/fixtures/playwright/e2e/fixed-sleep.violation.spec.ts.txt
@@ -1,0 +1,1 @@
+await page.waitForTimeout(2_000);

--- a/packages/playwright-flake-linter/test/fixtures/playwright/e2e/homeHealth/shared-readiness.allowlisted.spec.ts.txt
+++ b/packages/playwright-flake-linter/test/fixtures/playwright/e2e/homeHealth/shared-readiness.allowlisted.spec.ts.txt
@@ -1,0 +1,2 @@
+// flake-lint-allow shared-readiness -- This response belongs to the auth service.
+await page.waitForResponse((response) => response.url().includes("/auth"));

--- a/packages/playwright-flake-linter/test/fixtures/playwright/e2e/homeHealth/shared-readiness.compliant.spec.ts.txt
+++ b/packages/playwright-flake-linter/test/fixtures/playwright/e2e/homeHealth/shared-readiness.compliant.spec.ts.txt
@@ -1,0 +1,4 @@
+await waitForHomeHealthResponse({
+  page,
+  isMatchingRequest,
+});

--- a/packages/playwright-flake-linter/test/fixtures/playwright/e2e/homeHealth/shared-readiness.violation.spec.ts.txt
+++ b/packages/playwright-flake-linter/test/fixtures/playwright/e2e/homeHealth/shared-readiness.violation.spec.ts.txt
@@ -1,0 +1,3 @@
+await page.waitForResponse(
+  (response) => response.request().method() === "PATCH" && response.url().includes("/visits/123"),
+);

--- a/packages/playwright-flake-linter/test/fixtures/playwright/e2e/response-wait.allowlisted.spec.ts.txt
+++ b/packages/playwright-flake-linter/test/fixtures/playwright/e2e/response-wait.allowlisted.spec.ts.txt
@@ -1,0 +1,2 @@
+// flake-lint-allow response-wait -- The isolated fixture emits exactly one response.
+await page.waitForResponse((response) => response.status() === 204);

--- a/packages/playwright-flake-linter/test/fixtures/playwright/e2e/response-wait.compliant.spec.ts.txt
+++ b/packages/playwright-flake-linter/test/fixtures/playwright/e2e/response-wait.compliant.spec.ts.txt
@@ -1,0 +1,7 @@
+await page.waitForResponse(
+  (response) =>
+    response.request().method() === "POST" &&
+    response.url().includes("/visits/123") &&
+    response.request().postDataJSON().data.type === "visit" &&
+    response.ok(),
+);

--- a/packages/playwright-flake-linter/test/fixtures/playwright/e2e/response-wait.violation.spec.ts.txt
+++ b/packages/playwright-flake-linter/test/fixtures/playwright/e2e/response-wait.violation.spec.ts.txt
@@ -1,0 +1,1 @@
+await page.waitForResponse((response) => response.ok());

--- a/packages/playwright-flake-linter/test/fixtures/playwright/e2e/test-data-identity.allowlisted.spec.ts.txt
+++ b/packages/playwright-flake-linter/test/fixtures/playwright/e2e/test-data-identity.allowlisted.spec.ts.txt
@@ -1,0 +1,2 @@
+// flake-lint-allow test-data-identity -- The vendor field is limited to eight characters.
+const workerName = generateRandomString(8);

--- a/packages/playwright-flake-linter/test/fixtures/playwright/e2e/test-data-identity.compliant.spec.ts.txt
+++ b/packages/playwright-flake-linter/test/fixtures/playwright/e2e/test-data-identity.compliant.spec.ts.txt
@@ -1,0 +1,1 @@
+const workerEmail = generateRandomUserEmail();

--- a/packages/playwright-flake-linter/test/fixtures/playwright/e2e/test-data-identity.violation.spec.ts.txt
+++ b/packages/playwright-flake-linter/test/fixtures/playwright/e2e/test-data-identity.violation.spec.ts.txt
@@ -1,0 +1,1 @@
+const workerEmail = `worker-${generateRandomAlphaNumericString(8)}@example.com`;

--- a/packages/playwright-flake-linter/test/fixtures/playwright/helpers/retry-classification.allowlisted.ts.txt
+++ b/packages/playwright-flake-linter/test/fixtures/playwright/helpers/retry-classification.allowlisted.ts.txt
@@ -1,0 +1,2 @@
+// flake-lint-allow retry-classification -- The callback only asserts an idempotent mock.
+await retryUntilPassOrTimeout(async () => expectMockCall());

--- a/packages/playwright-flake-linter/test/fixtures/playwright/helpers/retry-classification.compliant.ts.txt
+++ b/packages/playwright-flake-linter/test/fixtures/playwright/helpers/retry-classification.compliant.ts.txt
@@ -1,0 +1,11 @@
+await retry(async (bail) => {
+  try {
+    await createWorker();
+  } catch (error) {
+    if (!isRetryableReadinessError(error)) {
+      return bail(error);
+    }
+
+    throw error;
+  }
+});

--- a/packages/playwright-flake-linter/test/fixtures/playwright/helpers/retry-classification.violation.ts.txt
+++ b/packages/playwright-flake-linter/test/fixtures/playwright/helpers/retry-classification.violation.ts.txt
@@ -1,0 +1,1 @@
+await retry(async () => createWorker());

--- a/packages/playwright-flake-linter/tsconfig.json
+++ b/packages/playwright-flake-linter/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "composite": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lint.json"
+    },
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/playwright-flake-linter/tsconfig.lib.json
+++ b/packages/playwright-flake-linter/tsconfig.lib.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "types": ["node"],
+    "composite": true,
+    "moduleResolution": "bundler",
+    "outDir": "../../dist/packages/playwright-flake-linter",
+    "rootDir": ".",
+    "tsBuildInfoFile": "../../.nx/tsbuildinfo/packages/playwright-flake-linter/tsconfig.lib.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["vitest.config.ts", "src/**/*.test.ts"]
+}

--- a/packages/playwright-flake-linter/tsconfig.lint.json
+++ b/packages/playwright-flake-linter/tsconfig.lint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.lint.json",
+  "compilerOptions": {
+    "rootDir": "../.."
+  },
+  "include": ["src/**/*.ts", "vitest.config.ts"]
+}

--- a/packages/playwright-flake-linter/tsconfig.spec.json
+++ b/packages/playwright-flake-linter/tsconfig.spec.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["vitest/globals", "node"]
+  },
+  "include": ["vitest.config.ts", "src/**/*.test.ts", "src/**/*.d.ts"]
+}

--- a/packages/playwright-flake-linter/vitest.config.ts
+++ b/packages/playwright-flake-linter/vitest.config.ts
@@ -1,0 +1,13 @@
+import { definePackageVitestConfig } from "../../vitest.preset";
+
+export default definePackageVitestConfig({
+  coverageThresholds: {
+    branches: 85,
+    functions: 95,
+    lines: 90,
+    statements: 90,
+  },
+  coverageExclude: ["src/bin/cli.ts"],
+  name: "playwright-flake-linter",
+  reportsDirectory: "../../coverage/packages/playwright-flake-linter",
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -64,6 +64,9 @@
     },
     {
       "path": "./packages/clearance"
+    },
+    {
+      "path": "./packages/playwright-flake-linter"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Publish `@clipboard-health/playwright-flake-linter`, a single configurable TypeScript AST checker for the shared flake rubric instead of maintaining frontend-repository copies.

The CLI enforces fixed-sleep B2 violations, underspecified response waits, unclassified B1 retries, low-entropy parallel-worker identities, and per-spec A1 readiness gates. Repository config owns genuine differences such as random/retry/helper names, delegated request matchers, readiness mechanisms, Dialog/BottomSheet terminology, and reason-required file allowlists. Inline exceptions also require an attached reason.

Positive, compliant, and allowlisted fixtures cover every rule. The README includes admin and mobile config examples plus the single verification-chain line needed for adoption.

## Validation

- `node --run verify`
- `NX_ISOLATE_PLUGINS=false npm exec -- nx test playwright-flake-linter --configuration=ci`
  - 91.19% statements, 89.93% branches, 95.45% functions, 91.1% lines
- `NX_ISOLATE_PLUGINS=false npm exec -- nx build playwright-flake-linter`
- `npm pack --dry-run --json ./dist/packages/playwright-flake-linter`
- Installed the built package under `/tmp` and executed its generated `playwright-flake-lint` bin

## Notes

- Runtime dependencies: TypeScript 5.9.3 (Apache-2.0) for compiler-API parsing and glob 13.0.6 (ISC) for the repository-standard file discovery already used by `embedex`. Both are actively maintained, already present in this monorepo, and used only by the CI CLI, so they add no frontend bundle weight.
- The existing per-repository Dialog/query-list checks from STAFF-1796/1797 are a candidate to migrate into this package later. This change documents the config seam but intentionally does not absorb those rules.
- The root embed command now invokes the existing `tsx` loader through Node, avoiding the CLI IPC socket while preserving the same checker behavior.

Closes staff-1815

<sub>🤖 <code>cb-ship:created v1 core@3.18.1</code></sub>
