### PR TITLE
fix: prioritize PR link in ship output

### DIFF
--- a/plugins/core/skills/cb-ship/SKILL.md
+++ b/plugins/core/skills/cb-ship/SKILL.md
@@ -28,9 +28,23 @@ Resolve bundled "./references" paths relative to SKILL.md.
 7. Output:
 
    ```plaintext
+   - PR: [Complete url] (e.g., `https://github.com/clipboardhealth/core-utils/pull/123`)
+
+   [One concise sentence describing what was implemented and shipped.]
+
+   [Optional bullets for the most important user-facing outcomes. Omit when the sentence is sufficient.]
+
+   Additional information:
+
    - Directory: [Absolute path]
    - Branch: [Branch name]
+   - Validation: [Checks run and their results]
    - Review: [N findings — M applied, K dismissed with a one-line reason each] (omit if step 4 skipped or found nothing)
    - Session: [Resume command from 6a] (omit if none)
-   - PR: [Complete url] (e.g., `https://github.com/clipboardhealth/core-utils/pull/123`)
+   - Existing changes: [Uncommitted changes that remain outside the shipped scope] (omit if none)
    ```
+
+   Keep the PR as the first bullet and visually separate it from everything
+   else with a blank line. Use the middle section only for meaningful behavior
+   or outcome details. Put lower-priority handoff metadata and caveats under
+   `Additional information`.

--- a/plugins/core/skills/cb-ship/SKILL.md
+++ b/plugins/core/skills/cb-ship/SKILL.md
@@ -38,7 +38,6 @@ Resolve bundled "./references" paths relative to SKILL.md.
 
    - Directory: [Absolute path]
    - Branch: [Branch name]
-   - Validation: [Checks run and their results]
    - Review: [N findings — M applied, K dismissed with a one-line reason each] (omit if step 4 skipped or found nothing)
    - Session: [Resume command from 6a] (omit if none)
    - Existing changes: [Uncommitted changes that remain outside the shipped scope] (omit if none)


### PR DESCRIPTION
## Summary

Make `cb-ship` handoffs lead with the complete PR URL, separated from the shipped summary by a blank line.

Move directory, branch, review, session, and unrelated-worktree caveats into an `Additional information` section so they do not compete with the PR link or user-facing outcomes.

## Validation

- `node --run markdown:lint -- plugins/core/skills/cb-ship/SKILL.md`
- `node --run verify` passed 9 of 10 checks; the environment blocked the `tsx` CLI Unix socket used by `embed:check`
- Equivalent embed check passed via `node --import tsx packages/embedex/src/bin/cli.ts --sourcesGlob 'packages/*/examples/**/*.{md,ts}' --check`
- Equivalent `sync-ai-rules` build and sync steps passed through the Node `tsx` loader
- `git diff --check`

## Notes

The generic skill validator rejects the existing `argument-hint` frontmatter key. This change does not alter that pre-existing metadata.

<sub>🤖 <code>cb-ship:created v1 core@3.19.0</code></sub>
