### PR TITLE
fix: clarify sync error context

### DIFF
--- a/packages/ai-rules/scripts/toErrorMessage.ts
+++ b/packages/ai-rules/scripts/toErrorMessage.ts
@@ -1,4 +1,4 @@
-// Prefer stack over message for Error instances to preserve debugging context!
+// Error.stack includes the message plus call-site context, which makes sync failures actionable.
 export function toErrorMessage(error: unknown): string {
   return error instanceof Error ? (error.stack ?? error.message) : String(error);
 }


### PR DESCRIPTION
## Summary

Clarify why ai-rules sync errors prefer `Error.stack`: it retains the message and call-site context needed to diagnose failures.

The comment-only TypeScript change keeps runtime behavior unchanged while the `fix:` commit exercises the ai-rules patch-release flow.

## Validation

- `npm exec nx run ai-rules:lint`
- `npm exec nx run ai-rules:test`
- `node --import tsx packages/ai-rules/scripts/build.ts`
- `node --run verify`

## Notes

The direct Nx build command cannot open the `tsx` CLI Unix socket in the local tool environment. Running the same build script through Node's `tsx` loader passed.

<sub>🤖 <code>cb-ship:created v1 core@3.20.0</code></sub>
