### PR TITLE
fix: explain ai-rules test exclusion

### DIFF
--- a/packages/ai-rules/scripts/build.ts
+++ b/packages/ai-rules/scripts/build.ts
@@ -75,6 +75,7 @@ async function build(): Promise<void> {
 }
 
 function isTestFile(source: string): boolean {
+  // Consumers install the bundle without test dependencies, so omit test files from publication.
   return /\.(?<type>spec|test)\.ts$/.test(source);
 }
 


### PR DESCRIPTION
## Summary

Document why the ai-rules build excludes test files from the published skills bundle: consumers install it without test-only dependencies.

## Validation

- `node --run verify`
- `npm exec nx -- test ai-rules --skip-nx-cache`
- `npm exec nx -- run-many --targets=build,lint,test --projects=ai-rules` (lint and test passed; Nx build hit a local tsx IPC permission restriction)
- `node --import tsx packages/ai-rules/scripts/build.ts` (package build fallback passed)

## Notes

Agent session: `codex resume 019f6d96-7ebf-73d1-be4f-71a446cfac1d`

<sub>🤖 <code>cb-ship:created v1 core@3.20.0</code></sub>