### PR TITLE
fix: refine flaky-fix gate guidance (STAFF-1865)

### DIFF
--- a/plugins/core/skills/flaky-critic/references/rubric.md
+++ b/plugins/core/skills/flaky-critic/references/rubric.md
@@ -90,7 +90,7 @@ Proposing a code fix from a diagnosis that stops at the failure symptom — "the
 
 1. **Terminated:** the chain ends at a cause. A status code, timeout, or throttle is a link, never a terminus.
 2. **Explicitly broken:** the chain names the link where evidence ran out and the observability that would extend it; confidence is capped at 2/5 and B6 applies — the deliverable is the instrumentation, not a code fix.
-3. **Harness-contract terminus:** for a C1/C2 test-harness change, the chain may terminate at a specific violated harness contract in named code when artifacts prove the user action or downstream request never began, and the fix is bounded, idempotent, and diagnostic. If a product, service, or identity-provider cause may still exist, cap confidence at 3/5 and require owning-surface observability or a linked handoff. A generic timeout, detach, 401, or retry success without the named contract and evidence remains a symptom, not a terminus.
+3. **Harness-contract terminus (amendment, 2026-07-17):** for a C1/C2 test-harness change, the chain may terminate at a specific violated harness contract in named code when artifacts prove the user action or downstream request never began, and the fix is bounded, idempotent, and diagnostic. If a product, service, or identity-provider cause may still exist, cap confidence at 3/5 and require owning-surface observability or a linked handoff. A generic timeout, detach, 401, or retry success without the named contract and evidence remains a symptom, not a terminus.
 
 **Confidence ceiling:** 5/5 additionally requires reproduction by inducing the blamed cause — fault injection in the harness (delay or fail the specific response, disable the seed step) or a focused lower-level test that deterministically reproduces the race. Without reproduction, the ceiling is 4/5. One inferred _intermediate_ link with an evidenced terminus is still a terminated chain (≤4/5); an unevidenced terminus is a broken chain (cap 2/5).
 
@@ -229,6 +229,8 @@ The STAFF-1818 blind-backtest proposals were reviewed per the standing per-PR am
 1. **Deterministic-boundary reproduction — approved:** exact evaluation of a named pure expression at captured inputs is deterministic reproduction when the plan shows before/after values.
 2. **Harness-contract terminus — approved with live monitoring:** the exception is limited by the artifact, confidence, and observability guardrails in B8. The 14-day monitor specifically watches for generic detach, timeout, 401, or retry-success symptoms being laundered as a harness contract.
 3. **Mechanism-aware Prior-attempts counting — rejected:** agent-claimed novelty does not reduce the failed-fix count. The ≥2 route remains family-level, and the dossier-backed deep dive adjudicates mechanism identity first.
+
+**Live follow-up (Rocky, 2026-07-17):** the backtest's case 1865 analog and the live false-positive rejection on STAFF-1865 established the harness-contract terminus amendment. No additional Proposal 1 change was approved because the live run produced no applicable case; that follow-up is deferred pending live evidence. Proposal 3 remains rejected because the dossier-backed deep dive, not agent self-certification, adjudicates mechanism novelty.
 
 ## 8. Appendix: corpus stats
 

--- a/plugins/core/skills/flaky-debug/references/fix.md
+++ b/plugins/core/skills/flaky-debug/references/fix.md
@@ -10,7 +10,9 @@ Before editing, verify the plan is still current:
 
 - The failing commit's code path still exists on current `main`, or the plan has been adjusted for the current code.
 - The proposed fix targets the diagnosed failure surface, not only the final assertion.
-- Any retry/wait change is safe and idempotent; it must not repeat one-time credentials, duplicate writes, destructive actions, or rate-limited setup calls.
+- Any retry/wait change is safe and idempotent; it must not repeat one-time credentials, duplicate writes, or destructive actions.
+- The retry predicate names the exact transient failure signatures it matches: opaque 5xx yes; 4xx validation no; 429 only with a cap.
+- A retry against a rate-limited or quota-limited dependency such as Cognito, a 429-emitting API, token minting, one-time credential provisioning, or seed creation states its concurrency cap or call-volume bound. Without one, return to the plan and choose A7-style serialization or caching to de-stress the dependency. An uncapped retry is retry amplification and will be rejected under B1; a cap does not make a non-idempotent operation safe.
 
 ## Validate the Sibling Frontend Check
 

--- a/plugins/core/skills/flaky-debug/references/fix.md
+++ b/plugins/core/skills/flaky-debug/references/fix.md
@@ -12,6 +12,7 @@ Before editing, verify the plan is still current:
 - The proposed fix targets the diagnosed failure surface, not only the final assertion.
 - Any retry/wait change is safe and idempotent; it must not repeat one-time credentials, duplicate writes, or destructive actions.
 - The retry predicate names the exact transient failure signatures it matches: opaque 5xx yes; 4xx validation no; 429 only with a cap.
+- The retry has a finite attempt or total-call bound, and exhaustion reports the attempts plus the last stdout/stderr/status/body.
 - A retry against a rate-limited or quota-limited dependency such as Cognito, a 429-emitting API, token minting, one-time credential provisioning, or seed creation states its concurrency cap or call-volume bound. Without one, return to the plan and choose A7-style serialization or caching to de-stress the dependency. An uncapped retry is retry amplification and will be rejected under B1; a cap does not make a non-idempotent operation safe.
 
 ## Validate the Sibling Frontend Check

--- a/plugins/core/skills/flaky-debug/references/plan.md
+++ b/plugins/core/skills/flaky-debug/references/plan.md
@@ -51,9 +51,11 @@ Before proposing any retry, timeout, or wait change, pass the idempotency check:
 - Is the retried operation safe to repeat?
 - Does retrying preserve the same test scenario?
 - Could retrying amplify the root cause, such as rate limits, one-time credentials, duplicate writes, or destructive mutations?
+- Does the retry predicate name the exact transient failure signatures it matches (opaque 5xx yes; 4xx validation no; 429 only with a cap)?
+- For a rate-limited or quota-limited dependency such as Cognito, a 429-emitting API, token minting, one-time credentials, or seed creation, does the plan state a concurrency cap or call-volume bound?
 - Is there a deterministic signal to wait on instead of a longer timeout?
 
-If the answer is no or unclear, do not add a retry/wait as the fix. Propose a root-cause fix or instrumentation instead.
+If the answer is no or unclear, do not add a retry/wait as the fix. Propose a root-cause fix or instrumentation instead. When a rate-limited or quota-limited dependency has no safe cap, choose A7-style serialization or caching to de-stress it. An uncapped retry against such a dependency is retry amplification and will be rejected under B1.
 
 Common valid fix types:
 

--- a/plugins/core/skills/flaky-debug/references/plan.md
+++ b/plugins/core/skills/flaky-debug/references/plan.md
@@ -52,6 +52,7 @@ Before proposing any retry, timeout, or wait change, pass the idempotency check:
 - Does retrying preserve the same test scenario?
 - Could retrying amplify the root cause, such as rate limits, one-time credentials, duplicate writes, or destructive mutations?
 - Does the retry predicate name the exact transient failure signatures it matches (opaque 5xx yes; 4xx validation no; 429 only with a cap)?
+- Does the plan set a finite attempt or total-call bound, with exhaustion reporting the attempts and last stdout/stderr/status/body?
 - For a rate-limited or quota-limited dependency such as Cognito, a 429-emitting API, token minting, one-time credentials, or seed creation, does the plan state a concurrency cap or call-volume bound?
 - Is there a deterministic signal to wait on instead of a longer timeout?
 


### PR DESCRIPTION
## Summary

- Records the 2026-07-17 harness-contract terminus amendment in B8, with provenance from the 2026-07-16 backtest's case 1865 analog and the live false-positive rejection on [STAFF-1865](https://linear.app/clipboardhealth/issue/STAFF-1865).
- Requires flaky-debug plans and fix preflights to name exact retry signatures and cap concurrency or call volume for rate-limited and quota-limited dependencies.
- Directs uncapped retry proposals toward A7-style serialization or caching and keeps B1 unchanged.

## Validation

- `node --run sync-ai-rules`
- `node --run verify`
- Focused `oxfmt --check` and `markdownlint-cli2` on the three changed Markdown files

All commands ran with Node 24.15.0 and npm 11.12.0. The local validation environment blocks Unix IPC sockets, so the ignored `node_modules/.bin/tsx` symlink temporarily used `node --import tsx`; it was restored before commit.

## Notes

- Rubric changes are Rocky-approved — approval given 2026-07-17 for Proposal 2 specifically.
- Proposal 1 live follow-up: deferred because the enforce run produced no applicable live case; no further rubric change is included.
- Proposal 2: approved and recorded with the STAFF-1865 live false-positive provenance.
- Proposal 3: rejected; the dossier-backed deep-dive track adjudicates mechanism novelty.
- B1 planner evidence from the 2026-07-17 enforce run: [STAFF-1868](https://linear.app/clipboardhealth/issue/STAFF-1868) proposed an uncapped token-minting retry loop; [STAFF-1873](https://linear.app/clipboardhealth/issue/STAFF-1873) and [STAFF-1874](https://linear.app/clipboardhealth/issue/STAFF-1874) proposed uncapped 429 retries.
- This follows the backtest work merged in #794 and is textually independent of that branch.
- This PR must not be merged without Rocky's review.

Agent session: `codex resume 019f7047-2834-7b02-bf9b-30db911401eb`

<sub>🤖 <code>cb-ship:created v1 core@3.20.0</code></sub>
