### PR TITLE
fix: highlight PR link in ship output

### DIFF
--- a/plugins/core/skills/cb-ship/SKILL.md
+++ b/plugins/core/skills/cb-ship/SKILL.md
@@ -32,7 +32,7 @@ Resolve bundled "./references" paths relative to SKILL.md.
 
    [Optional bullets for the most important user-facing outcomes. Omit when the sentence is sufficient.]
 
-   Additional information:
+   Details:
 
    - Directory: [Absolute path]
    - Branch: [Branch name]
@@ -46,4 +46,4 @@ Resolve bundled "./references" paths relative to SKILL.md.
    Keep the PR as the final line and visually separate it from everything else
    with a blank line. Use the middle section only for meaningful behavior or
    outcome details. Put lower-priority handoff metadata and caveats under
-   `Additional information`.
+   `Details`.

--- a/plugins/core/skills/cb-ship/SKILL.md
+++ b/plugins/core/skills/cb-ship/SKILL.md
@@ -40,7 +40,7 @@ Resolve bundled "./references" paths relative to SKILL.md.
    - Session: [Resume command from 6a] (omit if none)
    - Existing changes: [Uncommitted changes that remain outside the shipped scope] (omit if none)
 
-   🚀 PR: [Complete url] (e.g., `https://github.com/clipboardhealth/core-utils/pull/123`) 🚀
+   🚀 [Complete url] (e.g., `https://github.com/clipboardhealth/core-utils/pull/123`) 🚀
    ```
 
    Keep the PR as the final line and visually separate it from everything else

--- a/plugins/core/skills/cb-ship/SKILL.md
+++ b/plugins/core/skills/cb-ship/SKILL.md
@@ -28,8 +28,6 @@ Resolve bundled "./references" paths relative to SKILL.md.
 7. Output:
 
    ```plaintext
-   - PR: [Complete url] (e.g., `https://github.com/clipboardhealth/core-utils/pull/123`)
-
    [One concise sentence describing what was implemented and shipped.]
 
    [Optional bullets for the most important user-facing outcomes. Omit when the sentence is sufficient.]
@@ -41,9 +39,11 @@ Resolve bundled "./references" paths relative to SKILL.md.
    - Review: [N findings — M applied, K dismissed with a one-line reason each] (omit if step 4 skipped or found nothing)
    - Session: [Resume command from 6a] (omit if none)
    - Existing changes: [Uncommitted changes that remain outside the shipped scope] (omit if none)
+
+   🚀 PR: [Complete url] (e.g., `https://github.com/clipboardhealth/core-utils/pull/123`) 🚀
    ```
 
-   Keep the PR as the first bullet and visually separate it from everything
-   else with a blank line. Use the middle section only for meaningful behavior
-   or outcome details. Put lower-priority handoff metadata and caveats under
+   Keep the PR as the final line and visually separate it from everything else
+   with a blank line. Use the middle section only for meaningful behavior or
+   outcome details. Put lower-priority handoff metadata and caveats under
    `Additional information`.


### PR DESCRIPTION
## Summary

Moves the PR link to the final line of the `cb-ship` handoff so it is easy to find. Wraps the bare URL with 🚀 emoji, leaves it unlabeled, and renames the handoff metadata section to `Details:`.

## Validation

- `node --run sync-ai-rules`
- `node --run verify`

## Notes

Agent session: `codex resume 019f7094-d8b9-7f30-99c9-20c40dba46fa`

<sub>🤖 <code>cb-ship:created v1 core@3.20.0</code></sub>
