### PR TITLE
fix: keep shipped PR output to bare URL

### DIFF
--- a/plugins/core/skills/cb-ship/SKILL.md
+++ b/plugins/core/skills/cb-ship/SKILL.md
@@ -40,10 +40,11 @@ Resolve bundled "./references" paths relative to SKILL.md.
    - Session: [Resume command from 6a] (omit if none)
    - Existing changes: [Uncommitted changes that remain outside the shipped scope] (omit if none)
 
-   🚀 [Complete url] (e.g., `https://github.com/clipboardhealth/core-utils/pull/123`) 🚀
+   🚀 [Complete url] 🚀
    ```
 
-   Keep the PR as the final line and visually separate it from everything else
-   with a blank line. Use the middle section only for meaningful behavior or
-   outcome details. Put lower-priority handoff metadata and caveats under
-   `Details`.
+   Keep the PR as the final line using a complete URL, for example,
+   `https://github.com/clipboardhealth/core-utils/pull/123`. Visually separate
+   it from everything else with a blank line. Use the middle section only for
+   meaningful behavior or outcome details. Put lower-priority handoff metadata
+   and caveats under `Details`.


### PR DESCRIPTION
## Summary

Keeps the final `cb-ship` output line unambiguously limited to the rocket-wrapped PR URL. Moves the concrete example URL into the surrounding instructions so agents do not emit the example text or duplicate the URL.

## Validation

- `node --run sync-ai-rules`
- `node --run verify`
- `git diff --check`

## Notes

Follow-up to #800 after it merged. Addresses the CodeRabbit finding on the inline URL example.

Agent session: `codex resume 019f7094-d8b9-7f30-99c9-20c40dba46fa`

<sub>🤖 <code>cb-ship:created v1 core@3.20.0</code></sub>
