### PR TITLE
fix: remove remaining CSpell references

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,3 @@
 {
-  "recommendations": [
-    "dbaeumer.vscode-eslint",
-    "oxc.oxc-vscode",
-    "streetsidesoftware.code-spell-checker",
-    "typescriptteam.native-preview"
-  ]
+  "recommendations": ["dbaeumer.vscode-eslint", "oxc.oxc-vscode", "typescriptteam.native-preview"]
 }

--- a/evals/assertions/frontendUiVerificationWorkflow.ts
+++ b/evals/assertions/frontendUiVerificationWorkflow.ts
@@ -1,5 +1,3 @@
-// cspell:ignore viewmode
-
 interface GradingResult {
   pass: boolean;
   score: number;

--- a/evals/assertions/typescriptRules.ts
+++ b/evals/assertions/typescriptRules.ts
@@ -34,14 +34,12 @@ function checkEnumDeclarations(output: string, issues: string[]): void {
   }
 }
 
-/* cspell:disable -- regex word boundaries */
 const PROHIBITED_NAMING_PATTERNS = [
   { pattern: /\bagent(?!s?\.)(?=[A-Z]|\b)/i, term: "agent" },
   { pattern: /\bhcp\b/i, term: "hcp" },
   { pattern: /\bfacility(?=[A-Z]|\b)/i, term: "facility" },
   { pattern: /\bhcf\b/i, term: "hcf" },
 ] as const;
-/* cspell:enable */
 
 function checkNamingViolations(codeLines: string[], issues: string[]): void {
   for (const { pattern, term } of PROHIBITED_NAMING_PATTERNS) {

--- a/packages/json-api/src/lib/query/stringifyQuery.test.ts
+++ b/packages/json-api/src/lib/query/stringifyQuery.test.ts
@@ -9,7 +9,6 @@ describe(stringifyQuery, () => {
   it("encodes", () => {
     const actual = stringifyQuery({ fields: { user: "age" } });
 
-    // cspell:disable-next-line
     expect(actual).toBe("fields%5Buser%5D=age");
   });
 

--- a/packages/playwright-reporter-llm/src/lib/internal/consoleProcessing.test.ts
+++ b/packages/playwright-reporter-llm/src/lib/internal/consoleProcessing.test.ts
@@ -106,7 +106,7 @@ describe(buildConsoleEntryFromEvent, () => {
     const event = {
       type: "console",
       messageType: "error",
-      text: `\u001B[31mred error\u001B[39m`, // cspell:disable-line
+      text: `\u001B[31mred error\u001B[39m`,
     };
 
     const result = buildConsoleEntryFromEvent(event, undefined, 0);

--- a/packages/playwright-reporter-llm/src/lib/internal/textProcessing.test.ts
+++ b/packages/playwright-reporter-llm/src/lib/internal/textProcessing.test.ts
@@ -10,7 +10,7 @@ import {
 
 describe(stripAnsi, () => {
   it("removes ANSI escape codes from text", () => {
-    const ansiRed = `\u001B[31mred text\u001B[39m`; // cspell:disable-line
+    const ansiRed = `\u001B[31mred text\u001B[39m`;
 
     expect(stripAnsi(ansiRed)).toBe("red text");
   });
@@ -95,7 +95,7 @@ describe(extractFirstLine, () => {
   });
 
   it("strips ANSI from the first line", () => {
-    const ansiInput = `\u001B[31mcolored\u001B[39m\nrest`; // cspell:disable-line
+    const ansiInput = `\u001B[31mcolored\u001B[39m\nrest`;
 
     expect(extractFirstLine(ansiInput)).toBe("colored");
   });

--- a/packages/playwright-toolkit/src/lib/adminAuthToken.ts
+++ b/packages/playwright-toolkit/src/lib/adminAuthToken.ts
@@ -10,7 +10,6 @@ import { createDeterministicHash, isDefined, isNil, isRecord } from "@clipboard-
 
 import { runWithRetry } from "./retry";
 
-// cspell:ignore defineauthchallenge getparameters maketesttoken
 const DEFAULT_CACHE_DIRECTORY_NAME = "clipboard-health-playwright-admin-auth";
 const DEFAULT_LOCK_STALE_AFTER_MS = 5 * 60 * 1000;
 const DEFAULT_LOCK_WAIT_TIMEOUT_MS = 6 * 60 * 1000;

--- a/packages/playwright-toolkit/src/lib/cognitoDiagnostics.ts
+++ b/packages/playwright-toolkit/src/lib/cognitoDiagnostics.ts
@@ -1,4 +1,3 @@
-// cspell:ignore requestfailed
 import { isRecord, toErrorMessage as getErrorMessage } from "@clipboard-health/util-ts";
 import type { Page, Request, Response, TestInfo } from "@playwright/test";
 

--- a/plugins/core/skills/flaky-closeout/SKILL.md
+++ b/plugins/core/skills/flaky-closeout/SKILL.md
@@ -3,8 +3,6 @@ name: flaky-closeout
 description: Sweep the flaky-test pipeline after fixes merge by closing out the root-cause KB, closing clearly superseded tickets as Done under D3, and re-dispatching critic-rejected plans for amendment. Use for the recurring flaky close-out task, a post-merge flaky-fix sweep, or a dry-run/backtest of close-out decisions.
 ---
 
-<!-- cspell:ignore backtest backtesting groundcrew redispatch worktree -->
-
 # Flaky Closeout
 
 Run three post-merge sweeps in one read-first, write-later pass. This stage

--- a/plugins/core/skills/flaky-closeout/references/acceptance-report-2026-07-17.md
+++ b/plugins/core/skills/flaky-closeout/references/acceptance-report-2026-07-17.md
@@ -1,5 +1,3 @@
-<!-- cspell:ignore backtest -->
-
 # 2026-07-17 Acceptance Report
 
 This is a targeted, write-free acceptance check for the handoff examples. It is

--- a/plugins/core/skills/flaky-closeout/references/comment-templates.md
+++ b/plugins/core/skills/flaky-closeout/references/comment-templates.md
@@ -1,5 +1,3 @@
-<!-- cspell:ignore redispatch -->
-
 # Flaky Closeout Comment Templates
 
 Fill every placeholder from fetched evidence. Do not post a state-changing

--- a/plugins/core/skills/flaky-critic/references/backtests/2026-07-16-b8-prior-attempts/inputs/case-19.md
+++ b/plugins/core/skills/flaky-critic/references/backtests/2026-07-16-b8-prior-attempts/inputs/case-19.md
@@ -82,7 +82,6 @@ Fix the shared workplace magic-link Playwright sign-in harness so successful but
 
 - `npm run lint:fast -- playwright/helpers/workplaceSignIn.ts playwright/helpers/scheduleSeed.ts playwright/e2e/auth.spec.ts playwright/e2e/cognito/cognitoEmailOtpAuth.spec.ts`
 - `npx oxfmt --check playwright/helpers/workplaceSignIn.ts playwright/helpers/scheduleSeed.ts playwright/e2e/auth.spec.ts playwright/e2e/cognito/cognitoEmailOtpAuth.spec.ts`
-- `npx cspell --no-must-find-files playwright/helpers/workplaceSignIn.ts playwright/helpers/scheduleSeed.ts playwright/e2e/auth.spec.ts playwright/e2e/cognito/cognitoEmailOtpAuth.spec.ts`
 - `npm run typecheck`
 - With staging E2E credentials available: `npx playwright test playwright/e2e/reporting.spec.ts --project="Desktop Chrome" --grep "page chrome and all four KPI cards render on landing"`
 - Prefer also running the desktop auth magic-link test if credentials are available: `npx playwright test playwright/e2e/auth.spec.ts --project="Desktop Chrome" --grep "clicking the emailed verification link signs the user in"`

--- a/plugins/core/skills/flaky-triage/SKILL.md
+++ b/plugins/core/skills/flaky-triage/SKILL.md
@@ -3,8 +3,6 @@ name: flaky-triage
 description: Scheduled triage stage between flake-intake and agent dispatch. Clusters flaky-investigation tickets by shared root cause, closes duplicates and infra blips, and releases one repository-owned canonical ticket per cluster for dispatch. Use when running the recurring flaky-triage task, when asked to triage the flaky queue, or to backtest clustering against historical tickets.
 ---
 
-<!-- cspell:words backtest backtesting deflake dispatchable groundcrew -->
-
 The pipeline stage between flake-intake (deterministic, string-level collapse: bursts and storms) and per-ticket dispatch. Intake creates investigation tickets in the **Triage** state, where groundcrew ignores them. This skill clusters them semantically — same root cause, even when error text differs — then performs ticket surgery and releases exactly one dispatchable ticket per root cause and implementation repository.
 
 This skill routes and classifies known mechanisms from existing ticket evidence; it never performs a new source-level diagnosis. Do not propose fixes, read test source files, or run flaky-debug. Diagnosis happens later, on the released ticket, through the normal dispatch flow.

--- a/plugins/core/skills/frontend-ui-verification/scripts/inspect-ui-verification-surface.sh
+++ b/plugins/core/skills/frontend-ui-verification/scripts/inspect-ui-verification-surface.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# cspell:ignore dockerless
 set -euo pipefail
 
 usage() {

--- a/plugins/core/skills/seed-data/SKILL.md
+++ b/plugins/core/skills/seed-data/SKILL.md
@@ -78,8 +78,6 @@ gh workflow run "Generate Seed Data" \
 
 ## Scenario Lookup Table
 
-<!-- cspell:ignore usecase -->
-
 > **Note:** Scenario numbers 13 and 18 do not exist. If a user references them, let them know and present the full list below.
 
 | Key                                                                  | Description                                                                  | Keyword Hints                                                           |


### PR DESCRIPTION
## Summary

- remove remaining CSpell directives from source, tests, and plugin documentation
- remove the CSpell VS Code recommendation and obsolete backtest validation command
- leave the repository with zero tracked CSpell references

## Verification

- npm run sync-ai-rules
- npm run verify
- git diff --check

Follow-up to #792.