### PR TITLE
feat: make flaky recurrence deployment-aware (STAFF-1939)

### DIFF
--- a/plugins/core/skills/flaky-closeout/SKILL.md
+++ b/plugins/core/skills/flaky-closeout/SKILL.md
@@ -14,6 +14,8 @@ Read these files before deciding or writing:
 - `../flaky-debug/references/fix.md` for the KB close-out contract.
 - `../flaky-debug/references/root-cause-kb/README.md` and every plausible KB
   entry.
+- `../flaky-debug/references/deployment-aware-recurrence.md` for deployed-service
+  D3 and recurrence decisions.
 - `../flaky-critic/SKILL.md` and its rubric for D3, marker, and second-reject
   semantics.
 - `../create-groundcrew-ticket/SKILL.md` for dispatch eligibility.
@@ -28,6 +30,9 @@ Read these files before deciding or writing:
   supersession.
 - Require a clear mechanism match before D3 closure: the same KB entry or
   causal mechanism **and** the same failure-signature class.
+- For a deployed service, use the first fix-containing deployment boundary,
+  never PR merge time, and attach the complete deployment-provenance record to
+  every D3 or recurrence decision.
 - Decide the complete action ledger before any external write.
 - Search existing comments for the exact marker before every write. A marker is
   a lease for that action, not a substitute for checking current state.
@@ -98,6 +103,14 @@ evidence, and every flake sighting timestamp.
 
 If a PR lacks a source ticket ID, report it as unresolved and take no close-out
 action for it.
+
+For an actionable PR involving a deployed service, resolve its fix-bearing
+commit separately from its merge timestamp. For every candidate exact failure,
+retain the service, Datadog version, ECS task definition, runtime source SHA,
+runtime deployment run, ancestry result, and first fix-containing deployment
+boundary. Missing runtime version/SHA makes the decision
+`observability-blocked`; leave state unchanged while provenance lookup is
+pending.
 
 ### Bounce manifest
 
@@ -199,17 +212,36 @@ Use the KB mechanism as the cross-family join key:
    symptom.
 3. Confirm the signature class matches, such as provider-topology remount,
    query-row overlay teardown, Cognito alias lookup, or CDC readiness.
-4. Parse the candidate's earliest relevant sighting timestamp and prove it is
-   earlier than the PR merge timestamp. If no reliable sighting time exists, do
-   not close.
-5. Check that the ticket has no post-merge recurrence for that mechanism.
+4. Parse the candidate's earliest relevant sighting timestamp. If a deployed
+   service is implicated, build the exact runtime-provenance record and run the
+   fix-to-runtime ancestry check. Otherwise retain the existing comparison to
+   the fix commit.
+5. For a deployed service, find the first successful deployment in the same
+   environment whose runtime contains the fix and use its runtime-activation
+   time as the D3 boundary. Check for same-mechanism recurrence on or after that
+   boundary and prove each candidate runtime contains the fix. During rolling
+   deployment, exact runtime ancestry overrides wall-clock ordering. Never
+   substitute PR merge time.
+6. Compare signatures before titles. A different signature under the same test
+   title is a new mechanism, not recurrence or supersession evidence for this
+   fix.
 
 Classify the candidate:
 
 - **Clear match:** stage the D3 comment from
   [comment templates](./references/comment-templates.md), then set the ticket to
-  Done. Include the PR, mechanism, sighting and merge timestamps, 21-day
+  Done. Include the PR, mechanism, sighting, complete deployment-provenance
+  attachment when applicable, first fix-containing deployment boundary, 21-day
   verifying window, and recurrence-loop reopen safety net.
+- **Pre-deployment/stale runtime:** do not count the sighting as a failed merged
+  fix. It may be a clear D3 match only when the mechanism/signature match and no
+  proven recurrence exists on a fix-containing runtime.
+- **Genuine post-fix recurrence:** do not close under D3. Count it as failed-fix
+  evidence on the canonical family and preserve chronic-family routing.
+- **Observability-blocked:** require runtime provenance lookup and leave state
+  unchanged; do not post a possible-supersession guess based on merge time.
+- **New mechanism:** route by the new signature and take no D3 or failed-fix
+  action against this fix.
 - **Ambiguous:** stage one possible-supersession comment tagging Rocky and leave
   state unchanged.
 - **No match:** take no action.

--- a/plugins/core/skills/flaky-closeout/SKILL.md
+++ b/plugins/core/skills/flaky-closeout/SKILL.md
@@ -108,7 +108,8 @@ For an actionable PR involving a deployed service, resolve its fix-bearing
 commit separately from its merge timestamp. For every candidate exact failure,
 retain the service, Datadog version, ECS task definition, runtime source SHA,
 runtime deployment run, ancestry result, and first fix-containing deployment
-boundary. Missing runtime version/SHA makes the decision
+boundary. Missing runtime version/SHA, the observed runtime's deployment run, or
+the first fix-containing deployment boundary makes the decision
 `observability-blocked`; leave state unchanged while provenance lookup is
 pending.
 

--- a/plugins/core/skills/flaky-closeout/references/comment-templates.md
+++ b/plugins/core/skills/flaky-closeout/references/comment-templates.md
@@ -1,9 +1,11 @@
 # Flaky Closeout Comment Templates
 
 Fill every placeholder from fetched evidence. Do not post a state-changing
-template with an unknown timestamp, mechanism, or PR. A possible-supersession
-comment may use its explicit missing-timestamp statement because it leaves state
-unchanged.
+template with an unknown timestamp, mechanism, PR, or required runtime
+provenance. A possible-supersession comment may use its explicit
+missing-timestamp statement because it leaves state unchanged. Missing runtime
+version/SHA for a deployed service is instead `observability-blocked` and
+requires provenance lookup, not a possible-supersession guess.
 
 ## KB close-out
 
@@ -16,11 +18,42 @@ flaky-debug/references/fix.md verbatim.>
 
 ## Clear D3 supersession
 
+For a non-deployed mechanism, use:
+
 ```markdown
 Already fixed (D3): covered by merged PR <source PR URL> from <source ticket>.
 It fixes the same mechanism: <mechanism and causal locus>. This ticket's
-<signature class> sighting at <sighting timestamp> predates the merge at
-<merge timestamp>.
+<signature class> sighting at <sighting timestamp> predates the fix at
+<fix timestamp>.
+
+Closing Done: the family enters the 21-day verifying window. If this mechanism
+flakes again, the recurrence loop reopens the ticket with its history.
+
+<!-- flaky-closeout: superseded-by=<source PR URL> -->
+```
+
+For a deployed service, use:
+
+```markdown
+Already fixed (D3): covered by merged PR <source PR URL> from <source ticket>.
+It fixes the same mechanism: <mechanism and causal locus>. This ticket's
+<signature class> sighting at <sighting timestamp> ran on a stale runtime that
+does not contain the fix.
+
+Deployment provenance:
+
+- service: <service>
+- environment: <environment>
+- Datadog version: <version>
+- ECS task definition: <family:revision>
+- runtime SHA: <runtime SHA>
+- runtime deployment run: <runtime deployment URL>
+- fix PR / SHA: <source PR URL> / <fix SHA>
+- signature relation: same
+- mechanism relation: same
+- ancestry: does-not-contain-fix (<command and exit status>)
+- first fix-containing deployment: <run URL, runtime SHA, activation boundary>
+- classification: pre-deployment/stale-runtime
 
 Closing Done: the family enters the 21-day verifying window. If this mechanism
 flakes again, the recurrence loop reopens the ticket with its history.

--- a/plugins/core/skills/flaky-closeout/references/comment-templates.md
+++ b/plugins/core/skills/flaky-closeout/references/comment-templates.md
@@ -4,8 +4,9 @@ Fill every placeholder from fetched evidence. Do not post a state-changing
 template with an unknown timestamp, mechanism, PR, or required runtime
 provenance. A possible-supersession comment may use its explicit
 missing-timestamp statement because it leaves state unchanged. Missing runtime
-version/SHA for a deployed service is instead `observability-blocked` and
-requires provenance lookup, not a possible-supersession guess.
+version/SHA, the observed runtime's deployment run, or the first fix-containing
+deployment boundary for a deployed service is instead `observability-blocked`
+and requires provenance lookup, not a possible-supersession guess.
 
 ## KB close-out
 

--- a/plugins/core/skills/flaky-critic/SKILL.md
+++ b/plugins/core/skills/flaky-critic/SKILL.md
@@ -17,6 +17,10 @@ Your job is adversarial: assume the plan papers over the root cause until its ev
 
 - Load `references/rubric.md` (relative to this SKILL.md) before judging anything. Every rejection MUST cite rule IDs and quote the offending plan sentence or diff hunk. Every approval MUST name the fix class (A1–A7, C1–C5, D1–D5) and the evidence that satisfies its requirements.
 - In shadow/enforce mode, consult `../flaky-debug/references/root-cause-kb/README.md` for the plan's symptom signature and proposed mechanism, and read every plausible entry before applying B5's Prior-attempts rule. A KB entry's **What failed and why** section may supply substantive evidence that the proposed mechanism was already tried and failed; cite the entry and its linked recurrence evidence, not the index row alone. In backtest mode, do not open the live KB; use KB evidence only when the supplied historical snapshot includes the contemporaneous entry.
+- Before treating a deployed-service sighting as D3 or failed-fix evidence, apply
+  `../flaky-debug/references/deployment-aware-recurrence.md`. Missing runtime
+  provenance is `observability-blocked`, not permission to infer from merge
+  time.
 - One verdict per ticket per content-state: skip tickets whose latest `<!-- flaky-critic:` marker is newer than the last substantive edit/comment.
 - Findings from automated reviewers (Mendral, CodeRabbit) are advisory inputs, never binding (rubric §1).
 - A plan outside the rubric's taxonomy is **needs-human**, not a guess. Uncertainty bounces up, never through.
@@ -33,7 +37,7 @@ If the queue is empty, skip to the digest. Fetch linked investigation tickets an
 ## Phase 2: Verdict per ticket
 
 1. **Classify** the proposed fix into the rubric taxonomy. Multi-part plans get classified per part; the worst verdict wins.
-2. **B-rules first** (any violation → reject): B1–B8, per rubric §2. For B5 in shadow/enforce mode, compare the plan's mechanism with candidate KB entries. In backtest mode, make that comparison only when a contemporaneous entry is part of the supplied snapshot. Reject substantively when an eligible entry documents that the same proposed mechanism already merged and then recurred; a shared symptom signature without a matching mechanism is not enough.
+2. **B-rules first** (any violation → reject): B1–B8, per rubric §2. For B5 in shadow/enforce mode, compare the plan's mechanism with candidate KB entries. In backtest mode, make that comparison only when a contemporaneous entry is part of the supplied snapshot. Apply the shared deployment-aware contract to deployed-service recurrence evidence. If that evidence is `observability-blocked`, reject for amendment under `B5-prior-attempts`.
 3. **A/C requirements**: the named fix class's "Required evidence" must be present (A-rules), or the conditional justification stated verbatim (C-rules). A1 has a shared-helper carve-out that's easy to miss — check it explicitly before approving.
 4. **D dispositions**: a no-code plan must carry the disposition's required evidence (D1–D5).
 5. **Verdict**: `approve` / `reject` / `needs-human`, with confidence high/moderate/low. Low confidence → needs-human.

--- a/plugins/core/skills/flaky-critic/references/rubric.md
+++ b/plugins/core/skills/flaky-critic/references/rubric.md
@@ -206,7 +206,8 @@ implicated, "predates the fix" means the exact runtime classifies
 `pre-deployment/stale-runtime`; apply the shared
 [deployment-aware recurrence contract](../../flaky-debug/references/deployment-aware-recurrence.md).
 Attach the runtime SHA, fix SHA, deployment run, ancestry result, and first
-fix-containing deployment boundary. Missing runtime version/SHA is
+fix-containing deployment boundary. Missing runtime version/SHA, the observed
+runtime's deployment run, or the first fix-containing deployment boundary is
 `observability-blocked`, so D3 must wait for provenance lookup. Same-mechanism
 recurrences on a fix-containing runtime go to the canonical ticket; a different
 signature under the same test title routes as a new mechanism.

--- a/plugins/core/skills/flaky-critic/references/rubric.md
+++ b/plugins/core/skills/flaky-critic/references/rubric.md
@@ -56,7 +56,7 @@ Opening one plan/PR per failing test when the failures share one mechanism (same
 
 **Prior-sibling signal (backtest amendment, 2026-06-11):** sibling PRs for the same mechanism that were closed _unmerged_ are a strong reject signal, not mere context. A plan citing closed-unmerged siblings must explain what is materially different this time — narrower scope alone is not an answer (the backtest's one genuine false approval cited prior wontfix siblings and explained them away).
 
-**Prior attempts (amendment, 2026-07-16):** when a fingerprint family has prior implementation tickets, the plan MUST contain a **Prior attempts** section listing each prior ticket/PR, what it blamed, what it changed, and the recurrence evidence showing its diagnosis was wrong or incomplete. A missing section is statement-missing and gets amend-and-resubmit per §1. A plan that re-proposes a mechanism a prior merged fix already tried is a substantive reject. A family with **≥2 failed merged fixes** — merged fixes followed by recurrence — is disqualified from the normal fix path: verdict = reject and escalate as needs-human. Apply the `chronic` label and route the family to the credential-checked, dossier-first `flaky-deep-dive` skill. The ≥2 threshold is intentionally different from flaky-triage's ≥3-prior-implementation-tickets screen: triage counts tickets cheaply before any diagnosis exists, while the critic can see merge and recurrence outcomes and applies the sharper failed-merged-fix test. Either stage flagging chronic routes the same way; the counts are staged by the evidence available at each stage, not a contradiction.
+**Prior attempts (amendment, 2026-07-16; deployment amendment, 2026-07-20):** when a fingerprint family has prior implementation tickets, the plan MUST contain a **Prior attempts** section listing each prior ticket/PR, what it blamed, what it changed, and the recurrence evidence showing its diagnosis was wrong or incomplete. A missing section is statement-missing and gets amend-and-resubmit per §1. A plan that re-proposes a mechanism a prior merged fix already tried is a substantive reject. For a deployed service, recurrence evidence counts only when the exact failure runtime contains the fix commit according to `git merge-base --is-ancestor`; apply the shared [deployment-aware recurrence contract](../../flaky-debug/references/deployment-aware-recurrence.md). A same-mechanism sighting on a runtime that does not contain the fix is `pre-deployment/stale-runtime`, not a failed fix. Missing runtime version/SHA is `observability-blocked` and requires provenance lookup. A different signature under the same test title is a new mechanism. A family with **≥2 failed merged fixes** — fixes followed by proven same-mechanism recurrence on fix-containing runtimes — is disqualified from the normal fix path: verdict = reject and escalate as needs-human. Apply the `chronic` label and route the family to the credential-checked, dossier-first `flaky-deep-dive` skill. Preserve that route whenever the same-mechanism recurrence is proven on a fix-containing runtime. The ≥2 threshold is intentionally different from flaky-triage's ≥3-prior-implementation-tickets screen: triage counts tickets cheaply before any diagnosis exists, while the critic can see merge and deployment-proven recurrence outcomes and applies the sharper failed-merged-fix test. Either stage flagging chronic routes the same way; the counts are staged by the evidence available at each stage, not a contradiction.
 
 A claimed mechanism delta does not decrement the ≥2 failed-merged-fix count or return the family to the normal path; preserve the claim in the dossier and make mechanism identity the deep dive's first question.
 
@@ -200,7 +200,16 @@ Required evidence: fingerprint/test/file plus error shape matches an existing in
 
 ### D3 — Already fixed / stale
 
-Required evidence: the merged PR/commit on main that covers the flake (e.g., "covered by merged PR #6697"), and confirmation the failing sighting predates the fix. Recurrences after the fix go to the canonical ticket ("Still failing in CI; flake-intake deduplicated this sighting to the canonical fix ticket"), not a new one.
+Required evidence: the merged PR/commit on main that covers the flake and
+confirmation the failing sighting predates the fix. When a deployed service is
+implicated, "predates the fix" means the exact runtime classifies
+`pre-deployment/stale-runtime`; apply the shared
+[deployment-aware recurrence contract](../../flaky-debug/references/deployment-aware-recurrence.md).
+Attach the runtime SHA, fix SHA, deployment run, ancestry result, and first
+fix-containing deployment boundary. Missing runtime version/SHA is
+`observability-blocked`, so D3 must wait for provenance lookup. Same-mechanism
+recurrences on a fix-containing runtime go to the canonical ticket; a different
+signature under the same test title routes as a new mechanism.
 
 ### D4 — Burst with no shared cause identified
 

--- a/plugins/core/skills/flaky-debug/SKILL.md
+++ b/plugins/core/skills/flaky-debug/SKILL.md
@@ -85,6 +85,10 @@ Before diagnosing, build the fingerprint family's dossier, then check whether so
    See the checked-in [KB lookup and close-out dry run](./references/root-cause-kb/dry-run-workplace-review-sheet.md) for one full cycle.
 
 3. **Build the `Prior attempts` table before diagnosis.** Add one row for each prior implementation ticket and linked PR found through either query. The table columns are `Prior ticket/PR`, `What it blamed`, `What it changed`, and `Recurrence evidence`. The table must list each prior ticket/PR, what it blamed, what it changed, and the recurrence evidence showing its diagnosis was wrong or incomplete. Use later investigation sightings and post-merge failures as recurrence evidence; do not infer failure merely because an attempt is old. If there are no prior implementation tickets, record `None found` plus the fingerprint and test-title searches run. Keep KB-derived failed-fix history in the separate `KB match` statement unless the entry links a ticket or PR to this fingerprint family; do not manufacture family-specific prior attempts from a mechanism-level entry.
+   When a prior fix implicates a deployed service, read and apply
+   [`references/deployment-aware-recurrence.md`](./references/deployment-aware-recurrence.md):
+   a post-merge timestamp is insufficient, and the plan must retain the exact
+   failure's deployment-provenance attachment.
 4. **Search open PRs with the `flaky-test-fix` label** that touch the failing test file or its surrounding code. Use GitHub search scoped to the repo:
    - Search PRs labeled `flaky-test-fix` for the test file name or test directory
    - Review the PR's changes to assess whether they address the same flake pattern with reasonable confidence — if so, stop and report it to the user rather than opening a duplicate fix

--- a/plugins/core/skills/flaky-debug/references/deployment-aware-recurrence.md
+++ b/plugins/core/skills/flaky-debug/references/deployment-aware-recurrence.md
@@ -1,0 +1,117 @@
+# Deployment-Aware Recurrence Classification
+
+Use this contract whenever a flaky failure implicates a deployed service and a
+linked implementation PR may already cover the same mechanism. PR merge time is
+not evidence that the fix was running in the failure's environment.
+
+## Required provenance record
+
+Build the record from the exact failing attempt, request, trace, log, or task.
+Retain every value even when the final classification does not count as a
+recurrence:
+
+- failure signature and causal mechanism;
+- failure timestamp and environment;
+- service and owning repository;
+- Datadog `version` or image tag;
+- ECS task-definition family and revision;
+- full runtime source SHA;
+- linked implementation PR and full fix SHA;
+- deployment workflow run for the observed runtime;
+- ancestry command and result;
+- first successful deployment in the same environment whose runtime contains
+  the fix, including its runtime SHA, run URL, and runtime-activation boundary.
+
+Record an absent field as `missing`; do not silently omit it. A Datadog version
+or source SHA from a nearby request, another retry, or the CI checkout is not the
+runtime provenance of the exact failure.
+
+Within one run, fetch deployment history once per service and environment.
+Cache first-fix-containing deployment lookups by
+`<repository, fix SHA, service, environment>` and ancestry results by
+`<fix SHA, runtime SHA>`. A fix-containing deployment cannot predate the fix
+commit, so begin that search at the fix commit time. Reuse an exact provenance
+attachment across later pipeline stages only after confirming it identifies the
+same failing attempt and environment.
+
+## Decision procedure
+
+1. Compare failure signatures and causal mechanisms before comparing time or
+   commits. Recurrence requires both to match. A different signature under the
+   same test title, or the same signature from a different causal mechanism, is
+   a **new mechanism**, not recurrence of the linked fix. An unresolved
+   mechanism blocks recurrence judgment until the causal evidence is complete.
+2. Resolve the fix SHA from the linked implementation PR in the deployed
+   service's repository. Use the PR's fix-bearing merge commit (the squash
+   commit for a squash merge) and retain the PR URL and repository.
+3. Resolve the exact failure's service, Datadog version, ECS task definition,
+   and runtime source SHA. If the Datadog version or runtime SHA is missing,
+   classify **observability-blocked** and perform a provenance lookup. Do not
+   substitute the PR merge timestamp.
+4. In the service repository, fetch the necessary commits and run
+   `git merge-base --is-ancestor <fix-sha> <runtime-sha>`. Retain the command,
+   full SHAs, and exit status. Exit `0` means `contains-fix`; exit `1` means
+   `does-not-contain-fix`; any other result is **observability-blocked** until
+   repository provenance is repaired.
+5. Search successful deployments for the same service and environment in
+   chronological order. The first runtime SHA for which the ancestry command
+   succeeds defines the **first fix-containing deployment boundary**. Use the
+   recorded time at which that runtime became active; use workflow start or
+   completion only when the deployment evidence establishes that as the
+   activation boundary. Never use PR merge time as a proxy. If the observed
+   runtime's deployment run or the first fix-containing deployment boundary
+   cannot be resolved, classify the state-changing decision
+   **observability-blocked** until the deployment lookup completes.
+6. Apply the table below. A state-changing D3 close, failed-fix count, or
+   chronic escalation must carry the complete decision record.
+
+The first fix-containing deployment is the boundary for searching and auditing
+later recurrence. Exact runtime ancestry remains authoritative during rolling
+deployments: a stale task can serve a failure after that boundary and still
+classifies `pre-deployment/stale-runtime`.
+
+| Signature / mechanism relation | Runtime evidence                   | Ancestry               | Classification                 | Pipeline effect                                                                    |
+| ------------------------------ | ---------------------------------- | ---------------------- | ------------------------------ | ---------------------------------------------------------------------------------- |
+| Both same                      | Version or runtime SHA missing     | Unknown                | `observability-blocked`        | Require provenance lookup; no D3 close and no failed-fix count                     |
+| Both same                      | Deployment run or boundary missing | Known                  | `observability-blocked`        | Require deployment lookup; no D3 close, failed-fix count, or chronic escalation    |
+| Both same                      | Exact runtime resolved             | `does-not-contain-fix` | `pre-deployment/stale-runtime` | Do not count as a failed merged fix; attach the fix-containing deployment boundary |
+| Both same                      | Exact runtime resolved             | `contains-fix`         | `genuine-post-fix-recurrence`  | Count as failed-fix evidence; preserve chronic-family routing                      |
+| Either differs                 | Any                                | Any                    | `new-mechanism`                | Route by signature and mechanism, not test title; do not count against the fix     |
+
+## Decision attachment
+
+Attach this block to the triage, critic, deep-dive, or closeout decision:
+
+```text
+Deployment provenance:
+- service: <service>
+- environment: <environment>
+- Datadog version: <version or missing>
+- ECS task definition: <family:revision or missing>
+- runtime SHA: <full SHA or missing>
+- runtime deployment run: <URL or missing>
+- fix PR / SHA: <PR URL> / <full SHA>
+- signature relation: <same | different>
+- mechanism relation: <same | different | unresolved>
+- ancestry: <contains-fix | does-not-contain-fix | blocked> (<command and exit status>)
+- first fix-containing deployment: <run URL, runtime SHA, activation boundary>
+- classification: <observability-blocked | pre-deployment/stale-runtime | genuine-post-fix-recurrence | new-mechanism>
+```
+
+Use `lookup pending` only in a non-state-changing interim report that is
+explicitly classified `observability-blocked`. A D3 close, failed-fix count, or
+chronic escalation requires the observed-runtime deployment run and the first
+fix-containing deployment boundary.
+
+## Deterministic regression table
+
+These incident-derived cases are the minimum table-driven coverage for changes
+to recurrence, D3, or chronic routing. The short SHAs are stable fixture labels;
+live decisions retain full SHAs.
+
+| Runtime      | Fix          | Signature                                                         | Ancestry result | Expected classification        | Expected routing                                                               |
+| ------------ | ------------ | ----------------------------------------------------------------- | --------------- | ------------------------------ | ------------------------------------------------------------------------------ |
+| `0e396e1b88` | `2f0a47273d` | Same signature and mechanism                                      | Exit `1`        | `pre-deployment/stale-runtime` | Do not count as a failed fix; boundary is the first deployment of `9d32b50bdd` |
+| `9d32b50bdd` | `2f0a47273d` | Same signature and mechanism                                      | Exit `0`        | `genuine-post-fix-recurrence`  | Count the failed fix and preserve chronic-family routing                       |
+| Missing      | `2f0a47273d` | Same signature and mechanism                                      | Not runnable    | `observability-blocked`        | Require exact runtime lookup; do not infer from merge time                     |
+| `9d32b50bdd` | `2f0a47273d` | Different read-model signature and mechanism under the same title | Exit `0`        | `new-mechanism`                | Route by the new signature; do not count against this fix                      |

--- a/plugins/core/skills/flaky-debug/references/plan.md
+++ b/plugins/core/skills/flaky-debug/references/plan.md
@@ -99,6 +99,11 @@ Produce the plan with these fields:
 - **Current main status:** whether the failing commit's code path still exists on current `main`, has already been fixed, or has changed enough that the plan must be adjusted
 - **KB match:** cite the matching entry, matched symptom signature, mechanism hypothesis, and known failed fixes to avoid. If none matched, write `None` and list the symptom signatures/fingerprint checked against the index.
 - **Prior attempts:** list each prior ticket/PR, what it blamed, what it changed, and the recurrence evidence showing its diagnosis was wrong or incomplete. Use a table with `Prior ticket/PR`, `What it blamed`, `What it changed`, and `Recurrence evidence` columns. If the dossier search found no prior implementation tickets, write `None found` and include the fingerprint-family and exact-test-title searches run.
+- **Deployment provenance:** when a prior fix or current failure implicates a
+  deployed service, include the complete attachment from
+  [`deployment-aware-recurrence.md`](./deployment-aware-recurrence.md) for each
+  recurrence decision. Do not use merge time when runtime version/SHA is
+  missing.
 - **Symptom:** what failed and where
 - **Root cause:** concise technical explanation
 - **Causal chain:** each link from failing assertion to terminal cause with its evidence, or the explicit break point and the observability that would extend it (see [Causal Chain](#causal-chain))

--- a/plugins/core/skills/flaky-deep-dive/SKILL.md
+++ b/plugins/core/skills/flaky-deep-dive/SKILL.md
@@ -9,6 +9,10 @@ Run a diagnosis-and-design investigation for a chronic fingerprint family. Produ
 
 Read the bundled [Home Health dry run](references/dry-run-home-health-full-lifecycle.md) for the expected dossier and causal narrative depth. Its structure is distilled from Rocky's `hh-full-lifecycle.md` and `staging-seed-reliability.md` reference deep dives; the Phase 6 checklist remains binding where the historical artifact records an evidence limitation.
 
+Read and apply the shared
+[`deployment-aware-recurrence.md`](../flaky-debug/references/deployment-aware-recurrence.md)
+contract before classifying any deployed-service attempt as a failed fix.
+
 ## Phase 0: Enforce credential preconditions
 
 Run the preflight before reading source code or diagnosing:
@@ -53,7 +57,9 @@ The chronic track adds these requirements for every implementation attempt retur
 1. Read the ticket and investigation plan.
 2. Read the complete PR diff, review discussion, merge state, and fix commit through `gh`.
 3. Record what the attempt blamed and exactly what it changed.
-4. Find a later post-merge sighting that proves recurrence. Do not infer failure merely from age.
+4. Find a later same-mechanism sighting and classify it through the
+   deployment-aware recurrence contract. A post-merge timestamp alone does not
+   prove recurrence.
 5. Check current `main` in every repository the attempt touched.
 
 Create a `Prior attempts` table with these columns:
@@ -100,6 +106,15 @@ Use all applicable evidence sources:
 
 Preserve exact commands, absolute time windows, trace/request IDs, run URLs, commit SHAs, and zero-result limitations in the evidence appendix.
 
+When a deployed service is implicated, retain the exact failure's service,
+Datadog version, ECS task definition, and runtime source SHA. Resolve each linked
+implementation PR's fix SHA, run and retain the ancestry check against the
+failure runtime, then find the first successful deployment in that environment
+whose runtime contains the fix. If runtime version/SHA is missing, the attempt
+is `observability-blocked`: perform the provenance lookup and do not fall back to
+merge time. Treat a different signature under the same test title as a new
+mechanism.
+
 ## Phase 4: Terminate the causal chain
 
 Apply the causal-chain and confidence rules in `../flaky-debug/references/plan.md` without changing their score meanings or valid terminal states.
@@ -134,5 +149,10 @@ Write Markdown to the user-specified path, or `/tmp/flaky-deep-dive-<fingerprint
 7. Designed fix, or `Observability design` when the chain is broken.
 8. Fault-injection reproduction and validation plan.
 9. Evidence appendix with links, commands, IDs, timestamps, and citations.
+
+For each deployed-service prior attempt or recurrence, include the complete
+deployment-provenance attachment from the shared contract. Preserve chronic
+routing when the same mechanism is proven on a fix-containing runtime; do not
+count stale runtimes or different mechanisms as failed fixes.
 
 End with the document path/link and a one-sentence review request. Never open a direct fix PR.

--- a/plugins/core/skills/flaky-deep-dive/SKILL.md
+++ b/plugins/core/skills/flaky-deep-dive/SKILL.md
@@ -57,9 +57,9 @@ The chronic track adds these requirements for every implementation attempt retur
 1. Read the ticket and investigation plan.
 2. Read the complete PR diff, review discussion, merge state, and fix commit through `gh`.
 3. Record what the attempt blamed and exactly what it changed.
-4. Find a later same-mechanism sighting and classify it through the
-   deployment-aware recurrence contract. A post-merge timestamp alone does not
-   prove recurrence.
+4. Find a later sighting with the same normalized failure signature and causal
+   mechanism, then classify it through the deployment-aware recurrence contract.
+   A post-merge timestamp alone does not prove recurrence.
 5. Check current `main` in every repository the attempt touched.
 
 Create a `Prior attempts` table with these columns:

--- a/plugins/core/skills/flaky-triage/SKILL.md
+++ b/plugins/core/skills/flaky-triage/SKILL.md
@@ -13,6 +13,9 @@ This skill routes and classifies known mechanisms from existing ticket evidence;
 - One implementation ticket per mechanism cluster per repository. A cross-repo mechanism match coordinates repository-owned fixes; it never consolidates them across repositories.
 - Never hold a ticket hostage: anything you cannot confidently cluster is released as a singleton. The worst case must equal the no-triage baseline.
 - Load `../flaky-critic/references/rubric.md` before citing close-out rules. Cite rubric rule IDs (B5, D1, D2, D3) in every close-out comment.
+- Load and apply
+  `../flaky-debug/references/deployment-aware-recurrence.md` before any D3,
+  prior-fix, or recurrence decision involving a deployed service.
 - Decide the full cluster picture before writing anything to Linear.
 - Keep bulky data in local scratch files; keep only the manifest and decisions in context.
 - All Linear writes are idempotent. Use exact markers only to deduplicate comments. Immediately before state, label, relation, or marker-comment writes, re-read the current value and skip only when the desired state, label, relation, or exact marker already exists.
@@ -23,7 +26,9 @@ This skill routes and classifies known mechanisms from existing ticket evidence;
 - **B5** — one repository-owned canonical ticket per root cause, never one per sighting within an implementation repository.
 - **D1** — infra/environment incident: cancel with incident window + correlation evidence + why no code fix applies + re-arm note.
 - **D2** — duplicate of canonical: matching evidence + no new implementation ticket needed beyond the canonical.
-- **D3** — already-fixed: matches an investigation/implementation ticket closed in the last 14 days.
+- **D3** — already-fixed: matches an investigation/implementation ticket
+  closed in the last 14 days and, for a deployed service, the exact sighting
+  classifies `pre-deployment/stale-runtime` under the shared contract.
 
 ## Phase 1: Queue
 
@@ -31,7 +36,15 @@ Fetch candidate tickets from Linear: project `Groundcrew`, label `flaky-investig
 
 Use `list_issues` only to enumerate the queue; fetch each candidate with `get_issue` — list results truncate descriptions and will silently drop the Flake details JSON. Fetch candidate details in parallel when the available tooling supports it.
 
-Build one manifest row per ticket from its Flake details JSON: `issueId`, `repo`, `framework`, `testFile`, `testName`, `suite` (top-level describe / file basename family), `firstErrorLine`, `firstProjectStackFrame`, `pipelineUrl`, `commit`, `timestamps`, `priorTickets` (from the Prior Related Tickets section). Storm (`[storm:`) and burst (`[burst:`) tickets are pre-clustered by intake: treat each as a single-member cluster and release it; never merge them into other clusters.
+Build one manifest row per ticket from its Flake details JSON: `issueId`, `repo`,
+`framework`, `testFile`, `testName`, `suite` (top-level describe / file basename
+family), `firstErrorLine`, `firstProjectStackFrame`, `pipelineUrl`, `commit`,
+`timestamps`, `priorTickets` (from the Prior Related Tickets section). When the
+exact failure implicates a deployed service, also retain `service`, Datadog
+`version`, ECS task definition, runtime source SHA, and the evidence link for
+each value; record missing fields explicitly. Storm (`[storm:`) and burst
+(`[burst:`) tickets are pre-clustered by intake: treat each as a single-member
+cluster and release it; never merge them into other clusters.
 
 Phase 1 is done when every non-skipped candidate has a manifest row — don't carry a partial manifest into Phase 2.
 
@@ -42,7 +55,10 @@ Fetch what is already being worked, to catch duplicates before they spawn plans.
 - Open Linear tickets labeled `flaky-implementation` (any state but terminal). Collect plausible IDs first, then fetch each with `get_issue` and read its comments in parallel when the available tooling supports it; list results truncate the plan, `KB match:` statement, critic approval, and PR context needed for mechanism coordination.
 - PRs: search `flaky-test-fix` in both `open` and `closed` states; treat closed-unmerged siblings as duplicate signals, not already-fixed proof. Also try title keywords `flaky`/`deflake`.
 - Open `[storm:` / `[burst:` tickets and their contained fingerprints.
-- Investigation/implementation tickets closed in the last 14 days, for already-fixed matches only after confirming the merged fix is on main and the sighting predates it (D3).
+- Investigation/implementation tickets closed in the last 14 days. For a
+  deployed-service match, resolve the fix SHA and classify the exact sighting
+  through the deployment-aware recurrence contract; do not compare only the
+  sighting and merge timestamps (D3).
 
 Check all four sources before Phase 3 — a cluster decided against partial in-flight context can't be trusted.
 
@@ -61,6 +77,11 @@ Cluster by strongest shared evidence first:
 7. **Same environment incident:** multiple otherwise-distinct clusters whose failures all reduce to backend 5xx in seed/setup/readiness helpers within the same few minutes, across ≥2 repos or ≥3 pipelines. Different helpers and error text do not separate them — one staging outage surfaces through every helper that touches it. Merge them into one incident cluster (backtest lesson: 2026-06-09's 13 tickets were four helper-level clusters but one incident).
 
 Do not merge clusters merely because failures share a run. Same-run failures can have different root causes.
+
+A shared test title is likewise insufficient recurrence evidence. When a
+candidate prior fix exists, compare the normalized signature and causal
+mechanism first. Route a different signature as a new mechanism even when the
+runtime contains the prior fix.
 
 ### Knowledge-base mechanism coordination
 
@@ -103,7 +124,7 @@ Scope: STAFF-X owns <repo-a>. Skip this ticket's sibling-repo step that would cr
 <!-- flaky-triage: mechanism-cluster=<entry-slug> members=STAFF-X,STAFF-Y -->
 ```
 
-For every planned canonical release, search Linear for the fingerprint family with the `flaky-implementation` label across all states and without a date-window restriction, then count unique prior implementation ticket IDs. At **≥3 prior implementation tickets**, remove the planned normal release and leave the canonical in `Triage` unassigned. Create the Linear `chronic` label first if it does not exist. Apply the `chronic` label and route the family to the credential-checked, dossier-first `flaky-deep-dive` skill. Add a ticket comment with the marker `<!-- flaky-triage: chronic -->` and dossier pointers listing every prior implementation ticket ID — but first search the ticket's existing comments for that exact marker and skip posting when it is already present; that absence check is what makes the comment idempotent across retries and re-runs. This ≥3-ticket count is a cheap screen staged before any diagnosis exists; the critic separately applies a sharper **≥2 failed merged fixes** test (see the flaky-critic rubric's Prior-attempts amendment) with the same chronic routing. The thresholds differ by design — by the evidence available at each stage — not by accident.
+For every planned canonical release, search Linear for the fingerprint family with the `flaky-implementation` label across all states and without a date-window restriction, then count unique prior implementation ticket IDs. At **≥3 prior implementation tickets**, remove the planned normal release and leave the canonical in `Triage` unassigned. Create the Linear `chronic` label first if it does not exist. Apply the `chronic` label and route the family to the credential-checked, dossier-first `flaky-deep-dive` skill. Add a ticket comment with the marker `<!-- flaky-triage: chronic -->` and dossier pointers listing every prior implementation ticket ID — but first search the ticket's existing comments for that exact marker and skip posting when it is already present; that absence check is what makes the comment idempotent across retries and re-runs. This ≥3-ticket count is a cheap screen staged before any diagnosis exists; the critic separately applies a sharper **≥2 failed merged fixes** test (see the flaky-critic rubric's Prior-attempts amendment) with the same chronic routing. The thresholds differ by design — by the evidence available at each stage — not by accident. Preserve this chronic-family route when the dossier proves the same mechanism recurred on a runtime containing the fix. A stale runtime is not failed-fix evidence, and a different signature remains a new mechanism for recurrence judgment.
 
 **Release** = set state to `Todo` and assign to the Linear API user (the viewer). Before release, ensure the ticket satisfies the Groundcrew eligibility contract from `../create-groundcrew-ticket/SKILL.md`: repository text in the description, exactly one `agent-*` label, leaf issue, and no non-terminal blockers unless intentionally blocked. Assignment + Todo is what makes groundcrew dispatch it; it also serves as the lease — released tickets never re-enter the queue.
 


### PR DESCRIPTION
## Summary

Classify deployed-service D3 and failed-fix recurrence from the exact failure runtime and fix-commit ancestry. The workflow now records service, Datadog version, ECS task definition, runtime SHA, deployment run, ancestry result, and the first fix-containing deployment boundary.

Stale runtimes do not count as failed fixes. Missing provenance blocks state changes, different signatures route as new mechanisms, and proven same-mechanism recurrences on fix-containing runtimes keep chronic-family routing.

## Validation

- `node --run verify`
- Blind decision-table backtest: 4/4 expected classifications for runtime `0e396e1b88`, fix `2f0a47273d`, positive ancestry control `9d32b50bdd`, missing provenance, and a different signature
- AI-rules build and sync completed through the underlying build/sync commands because this execution environment blocks the `tsx` CLI IPC socket; generated files were unchanged

## Notes

Closes STAFF-1939.

Source investigation: STAFF-1938, https://linear.app/clipboardhealth/issue/STAFF-1938

Datadog `attempt_to_fix_id`: `4LKR2H`

Agent session: `codex resume 019f826a-b397-7080-8c91-ca6d4cd453d8`

<sub>🤖 <code>cb-ship:created v1 core@3.22.6</code></sub>
