### PR TITLE
docs: flag double-negated presence checks in null rule

### DIFF
--- a/.rules/common/typeScript.md
+++ b/.rules/common/typeScript.md
@@ -37,8 +37,8 @@ When removing a usage of a function, constant, type, or other symbol, check whet
 
 In TypeScript code that has access to `@clipboard-health/util-ts`, prefer the named helpers over raw null/undefined comparisons:
 
-- Replace `x === undefined`, `x === null`, or `!x` (when used as a presence check) with `isNil(x)`.
-- Replace `x !== undefined`, `x !== null`, or `x` (as a truthy presence check) with `isDefined(x)`.
+- Replace `x === undefined`, `x === null`, `!isDefined(x)`, or `!x` (when used as a presence check) with `isNil(x)`.
+- Replace `x !== undefined`, `x !== null`, `!isNil(x)`, or `x` (as a truthy presence check) with `isDefined(x)`.
 
 Import from `@clipboard-health/util-ts`.
 

--- a/packages/ai-rules/rules/common/typeScript.md
+++ b/packages/ai-rules/rules/common/typeScript.md
@@ -37,8 +37,8 @@ When removing a usage of a function, constant, type, or other symbol, check whet
 
 In TypeScript code that has access to `@clipboard-health/util-ts`, prefer the named helpers over raw null/undefined comparisons:
 
-- Replace `x === undefined`, `x === null`, or `!x` (when used as a presence check) with `isNil(x)`.
-- Replace `x !== undefined`, `x !== null`, or `x` (as a truthy presence check) with `isDefined(x)`.
+- Replace `x === undefined`, `x === null`, `!isDefined(x)`, or `!x` (when used as a presence check) with `isNil(x)`.
+- Replace `x !== undefined`, `x !== null`, `!isNil(x)`, or `x` (as a truthy presence check) with `isDefined(x)`.
 
 Import from `@clipboard-health/util-ts`.
 


### PR DESCRIPTION
## Summary

Extend the Null/Undefined Checks rule in the shared TypeScript rules so double-negated presence checks are caught and simplified:

- `!isDefined(x)` → `isNil(x)`
- `!isNil(x)` → `isDefined(x)`

Both equivalences are logical inverses, so the guidance keeps presence checks in their single-helper form. The source rule (`packages/ai-rules/rules/common/typeScript.md`) and its generated mirror (`.rules/common/typeScript.md`) are updated together via the sync-ai-rules pipeline.

Agent session: `claude --resume 1defb1b8-b238-4269-8ffc-8774c792ab9f`

<sub>🤖 <code>cb-ship:created v1 core@3.23.0</code></sub>