### PR TITLE
feat(util-ts): prototype typed ServiceResult errors

### DIFF
--- a/packages/notifications/src/lib/errorsInResult.test.ts
+++ b/packages/notifications/src/lib/errorsInResult.test.ts
@@ -1,9 +1,13 @@
-import { failure, ServiceError, success } from "@clipboard-health/util-ts";
+import { failure, ServiceError, type ServiceResult, success } from "@clipboard-health/util-ts";
 
 import { ERROR_CODES, type ErrorCode, type TriggerResponse } from "..";
 import { errorsInResult } from "./errorsInResult";
 
 const errors: ErrorCode[] = [ERROR_CODES.unknown];
+
+class TestNotificationError extends ServiceError {
+  public readonly _tag = "TestNotificationError" as const;
+}
 
 describe(errorsInResult, () => {
   const mockTriggerResponse: TriggerResponse = {
@@ -62,4 +66,28 @@ describe(errorsInResult, () => {
 
     expect(actual).toBe(false);
   });
+
+  it("preserves the typed error when the result is a failure", () => {
+    const input = failure(
+      new TestNotificationError({
+        issues: [{ code: ERROR_CODES.unknown, message: "Unknown error" }],
+      }),
+    );
+
+    const actual = errorsInResult(input);
+    const error = getNotificationError(input);
+
+    expect(actual).toBe(true);
+    expectTypeOf(error).toEqualTypeOf<TestNotificationError>();
+  });
 });
+
+function getNotificationError(
+  result: ServiceResult<TriggerResponse, TestNotificationError>,
+): TestNotificationError {
+  if (!errorsInResult(result)) {
+    throw new Error("Expected matching notification error");
+  }
+
+  return result.error;
+}

--- a/packages/notifications/src/lib/errorsInResult.ts
+++ b/packages/notifications/src/lib/errorsInResult.ts
@@ -2,6 +2,7 @@ import {
   type ErrorCode,
   type FailureResult,
   isSuccess,
+  type ServiceError,
   type ServiceResult,
 } from "@clipboard-health/util-ts";
 
@@ -13,10 +14,10 @@ import type { TriggerResponse } from "./types";
  * @param result - ServiceResult containing an error or T.
  * @param errorCodes - Array of error codes to check for. If empty, any error will match.
  */
-export function errorsInResult<T = TriggerResponse>(
-  result: ServiceResult<T>,
+export function errorsInResult<T = TriggerResponse, ErrorType extends ServiceError = ServiceError>(
+  result: ServiceResult<T, ErrorType>,
   errorCodes: ErrorCode[] = [],
-): result is FailureResult {
+): result is FailureResult<ErrorType> {
   if (isSuccess(result)) {
     return false;
   }

--- a/packages/testing-core/src/lib/expectToBeFailure.ts
+++ b/packages/testing-core/src/lib/expectToBeFailure.ts
@@ -13,9 +13,9 @@ import { expectToBeLeft } from "./expectToBeLeft";
 /**
  * Alias for {@link expectToBeLeft}
  */
-export function expectToBeFailure<A>(
-  value: ServiceResult<A> | undefined,
-): asserts value is E.Left<ServiceError> & Failure<ServiceError> {
+export function expectToBeFailure<A, ErrorType extends ServiceError>(
+  value: ServiceResult<A, ErrorType> | undefined,
+): asserts value is E.Left<ErrorType> & Failure<ErrorType> {
   expectToBeLeft(value);
   ok(isFailure(value), "Expected Failure, got Success");
 }

--- a/packages/testing-core/src/lib/expectToBeFailure.ts
+++ b/packages/testing-core/src/lib/expectToBeFailure.ts
@@ -13,7 +13,7 @@ import { expectToBeLeft } from "./expectToBeLeft";
 /**
  * Alias for {@link expectToBeLeft}
  */
-export function expectToBeFailure<A, ErrorType extends ServiceError>(
+export function expectToBeFailure<A, ErrorType extends ServiceError = ServiceError>(
   value: ServiceResult<A, ErrorType> | undefined,
 ): asserts value is E.Left<ErrorType> & Failure<ErrorType> {
   expectToBeLeft(value);

--- a/packages/testing-core/src/lib/expectToBeServiceResult.test.ts
+++ b/packages/testing-core/src/lib/expectToBeServiceResult.test.ts
@@ -8,6 +8,14 @@ class TestServiceError extends ServiceError {
 }
 
 describe("ServiceResult expectations", () => {
+  it("preserves the existing explicit generic arguments", () => {
+    const failureResult: ServiceResult<string> = failure(new ServiceError("test error"));
+    const successResult: ServiceResult<string> = success("value");
+
+    expectToBeFailure<string>(failureResult);
+    expectToBeSuccess<string>(successResult);
+  });
+
   it("preserves the typed error when expecting a failure", () => {
     const input = createFailure(new TestServiceError("test error"));
 

--- a/packages/testing-core/src/lib/expectToBeServiceResult.test.ts
+++ b/packages/testing-core/src/lib/expectToBeServiceResult.test.ts
@@ -1,0 +1,30 @@
+import { failure, ServiceError, type ServiceResult, success } from "@clipboard-health/util-ts";
+
+import { expectToBeFailure } from "./expectToBeFailure";
+import { expectToBeSuccess } from "./expectToBeSuccess";
+
+class TestServiceError extends ServiceError {
+  public readonly _tag = "TestServiceError" as const;
+}
+
+describe("ServiceResult expectations", () => {
+  it("preserves the typed error when expecting a failure", () => {
+    const input = createFailure(new TestServiceError("test error"));
+
+    expectToBeFailure(input);
+
+    expectTypeOf(input.error).toEqualTypeOf<TestServiceError>();
+  });
+
+  it("accepts a success with a typed error channel", () => {
+    const input: ServiceResult<string, TestServiceError> = success("value");
+
+    expectToBeSuccess(input);
+
+    expectTypeOf(input.value).toEqualTypeOf<string>();
+  });
+});
+
+function createFailure(error: TestServiceError): ServiceResult<string, TestServiceError> {
+  return failure(error);
+}

--- a/packages/testing-core/src/lib/expectToBeSuccess.ts
+++ b/packages/testing-core/src/lib/expectToBeSuccess.ts
@@ -3,6 +3,7 @@ import { ok } from "node:assert/strict";
 import {
   type either as E,
   isSuccess,
+  type ServiceError,
   type ServiceResult,
   type Success,
 } from "@clipboard-health/util-ts";
@@ -12,8 +13,8 @@ import { expectToBeRight } from "./expectToBeRight";
 /**
  * Alias for {@link expectToBeRight}
  */
-export function expectToBeSuccess<A>(
-  value: ServiceResult<A> | undefined,
+export function expectToBeSuccess<A, ErrorType extends ServiceError>(
+  value: ServiceResult<A, ErrorType> | undefined,
 ): asserts value is E.Right<A> & Success<A> {
   expectToBeRight(value);
   ok(isSuccess(value), "Expected Success, got Failure");

--- a/packages/testing-core/src/lib/expectToBeSuccess.ts
+++ b/packages/testing-core/src/lib/expectToBeSuccess.ts
@@ -13,7 +13,7 @@ import { expectToBeRight } from "./expectToBeRight";
 /**
  * Alias for {@link expectToBeRight}
  */
-export function expectToBeSuccess<A, ErrorType extends ServiceError>(
+export function expectToBeSuccess<A, ErrorType extends ServiceError = ServiceError>(
   value: ServiceResult<A, ErrorType> | undefined,
 ): asserts value is E.Right<A> & Success<A> {
   expectToBeRight(value);

--- a/packages/util-ts/README.md
+++ b/packages/util-ts/README.md
@@ -8,6 +8,7 @@ TypeScript utilities.
 - [Usage](#usage)
   - [ServiceError](#serviceerror)
   - [ServiceResult](#serviceresult)
+    - [`matchServiceResult`](#matchserviceresult)
     - [`tryCatchAsync`](#trycatchasync)
     - [`tryCatch`](#trycatch)
     - [`fromSafeParseReturnType`](#fromsafeparsereturntype)
@@ -117,6 +118,10 @@ try {
 
 ### ServiceResult
 
+`ServiceResult<A, E>` represents either a successful `A` value or a `ServiceError` subtype `E`.
+The error type defaults to `ServiceError` for compatibility with existing callers. Pass an explicit
+union when callers need to branch on the errors an operation can return.
+
 <embedex source="packages/util-ts/examples/serviceResult.ts">
 
 ```ts
@@ -148,6 +153,77 @@ function validateUser(params: { email: string; phone: string }): ServiceResult<{
 
 ok(isFailure(validateUser({ email: "invalidEmail", phone: "invalidPhoneNumber" })));
 ok(isSuccess(validateUser({ email: "user@example.com", phone: "555-555-5555" })));
+```
+
+</embedex>
+
+#### `matchServiceResult`
+
+`matchServiceResult` maps a typed `ServiceResult` to one output while requiring a handler for every
+literal `_tag` in its error union. Adding or removing an error type therefore updates every exhaustive
+match at compile time. Callers that do not need exhaustive handling can continue using `isFailure` and
+`isSuccess`.
+
+<embedex source="packages/util-ts/examples/matchServiceResult.ts">
+
+```ts
+import { strictEqual } from "node:assert/strict";
+
+import {
+  failure,
+  matchServiceResult,
+  ServiceError,
+  type ServiceResult,
+  success,
+} from "@clipboard-health/util-ts";
+
+interface User {
+  id: string;
+  name: string;
+}
+
+class InvalidUserIdError extends ServiceError {
+  public readonly _tag = "InvalidUserIdError" as const;
+
+  public constructor() {
+    super("User ID is required");
+  }
+}
+
+class UserNotFoundError extends ServiceError {
+  public readonly _tag = "UserNotFoundError" as const;
+
+  public readonly userId: string;
+
+  public constructor({ userId }: { userId: string }) {
+    super(`User ${userId} was not found`);
+    this.userId = userId;
+  }
+}
+
+type FindUserError = InvalidUserIdError | UserNotFoundError;
+
+function findUser({ userId }: { userId: string }): ServiceResult<User, FindUserError> {
+  if (userId.length === 0) {
+    return failure(new InvalidUserIdError());
+  }
+
+  if (userId === "missing") {
+    return failure(new UserNotFoundError({ userId }));
+  }
+
+  return success({ id: userId, name: "Ada" });
+}
+
+const message = matchServiceResult(findUser({ userId: "missing" }), {
+  onSuccess: (user) => `Found ${user.name}`,
+  onError: {
+    InvalidUserIdError: (error) => error.message,
+    UserNotFoundError: (error) => `User ${error.userId} was not found`,
+  },
+});
+
+strictEqual(message, "User missing was not found");
 ```
 
 </embedex>

--- a/packages/util-ts/examples/matchServiceResult.ts
+++ b/packages/util-ts/examples/matchServiceResult.ts
@@ -1,0 +1,58 @@
+// embedex: packages/util-ts/src/lib/functional/matchServiceResult.ts,packages/util-ts/README.md
+import { strictEqual } from "node:assert/strict";
+
+import {
+  failure,
+  matchServiceResult,
+  ServiceError,
+  type ServiceResult,
+  success,
+} from "@clipboard-health/util-ts";
+
+interface User {
+  id: string;
+  name: string;
+}
+
+class InvalidUserIdError extends ServiceError {
+  public readonly _tag = "InvalidUserIdError" as const;
+
+  public constructor() {
+    super("User ID is required");
+  }
+}
+
+class UserNotFoundError extends ServiceError {
+  public readonly _tag = "UserNotFoundError" as const;
+
+  public readonly userId: string;
+
+  public constructor({ userId }: { userId: string }) {
+    super(`User ${userId} was not found`);
+    this.userId = userId;
+  }
+}
+
+type FindUserError = InvalidUserIdError | UserNotFoundError;
+
+function findUser({ userId }: { userId: string }): ServiceResult<User, FindUserError> {
+  if (userId.length === 0) {
+    return failure(new InvalidUserIdError());
+  }
+
+  if (userId === "missing") {
+    return failure(new UserNotFoundError({ userId }));
+  }
+
+  return success({ id: userId, name: "Ada" });
+}
+
+const message = matchServiceResult(findUser({ userId: "missing" }), {
+  onSuccess: (user) => `Found ${user.name}`,
+  onError: {
+    InvalidUserIdError: (error) => error.message,
+    UserNotFoundError: (error) => `User ${error.userId} was not found`,
+  },
+});
+
+strictEqual(message, "User missing was not found");

--- a/packages/util-ts/src/lib/errors/serviceError.test.ts
+++ b/packages/util-ts/src/lib/errors/serviceError.test.ts
@@ -4,6 +4,8 @@ import { ZodError } from "zod";
 
 import { ERROR_CODES, ServiceError, type ServiceErrorParams } from "./serviceError";
 
+class TestServiceError extends ServiceError {}
+
 describe(ServiceError, () => {
   describe("fromZodLike", () => {
     it("converts ZodLike to ServiceError", () => {
@@ -95,6 +97,15 @@ describe(ServiceError, () => {
 
       expect(actual).toBe(input);
       expect(actual.status).toBe(404);
+    });
+
+    it("preserves the type of an existing ServiceError subtype", () => {
+      const input = new TestServiceError("test error");
+
+      const actual = ServiceError.fromUnknown(input);
+
+      expectTypeOf(actual).toEqualTypeOf<TestServiceError>();
+      expect(actual).toBe(input);
     });
   });
 
@@ -655,13 +666,14 @@ describe(ServiceError, () => {
   });
 
   describe("merge", () => {
-    it("returns same error when merging single error", () => {
-      const error = new ServiceError({
+    it("preserves the error subtype when merging a single error", () => {
+      const error = new TestServiceError({
         issues: [{ code: ERROR_CODES.notFound, message: "Not found" }],
       });
 
       const result = ServiceError.merge(error);
 
+      expectTypeOf(result).toEqualTypeOf<TestServiceError>();
       expect(result).toBe(error);
     });
 

--- a/packages/util-ts/src/lib/errors/serviceError.ts
+++ b/packages/util-ts/src/lib/errors/serviceError.ts
@@ -116,6 +116,8 @@ export class ServiceError extends Error {
    * @returns If the value is already a `ServiceError`, returns it unchanged. Otherwise, convert it
    *          to a `ServiceError`.
    */
+  public static fromUnknown<E extends ServiceError>(value: E): E;
+  public static fromUnknown(value: unknown): ServiceError;
   public static fromUnknown(value: unknown): ServiceError {
     if (value instanceof ServiceError) {
       return value;
@@ -150,7 +152,12 @@ export class ServiceError extends Error {
    * @param errors - Additional ServiceErrors
    * @returns New ServiceError containing all issues from input errors
    */
-  public static merge(error: ServiceError, ...errors: readonly ServiceError[]): ServiceError;
+  public static merge<E extends ServiceError>(error: E): E;
+  public static merge(
+    error: ServiceError,
+    additionalError: ServiceError,
+    ...errors: readonly ServiceError[]
+  ): ServiceError;
   public static merge(error: unknown, ...errors: readonly unknown[]): ServiceError;
   public static merge(error: Readonly<unknown>, ...errors: readonly unknown[]): ServiceError {
     const firstError = error instanceof ServiceError ? error : ServiceError.fromUnknown(error);

--- a/packages/util-ts/src/lib/functional/index.ts
+++ b/packages/util-ts/src/lib/functional/index.ts
@@ -1,5 +1,6 @@
 export * from "./cbhResponse";
 export * as either from "./either";
+export * from "./matchServiceResult";
 export * as option from "./option";
 export * from "./pipe";
 export * from "./serviceResult";

--- a/packages/util-ts/src/lib/functional/matchServiceResult.test.ts
+++ b/packages/util-ts/src/lib/functional/matchServiceResult.test.ts
@@ -16,6 +16,16 @@ class BroadTagTestServiceError extends ServiceError {
   }
 }
 
+class UnionTagTestServiceError extends ServiceError {
+  public get _tag(): "FirstUnionTag" | "SecondUnionTag" {
+    return "FirstUnionTag";
+  }
+}
+
+class ToStringTagTestServiceError extends ServiceError {
+  public readonly _tag = "toString" as const;
+}
+
 type TestServiceError = FirstTestServiceError | SecondTestServiceError;
 
 type MatchOutput =
@@ -105,6 +115,24 @@ describe(matchServiceResult, () => {
     expect(actual).toBe("success");
   });
 
+  it("rejects a union-valued tag on one error type", () => {
+    const result: ServiceResult<number, UnionTagTestServiceError> = success(42);
+
+    const actual = matchServiceResult(
+      // @ts-expect-error: each error type must have exactly one literal tag
+      result,
+      {
+        onSuccess: () => "success",
+        onError: {
+          FirstUnionTag: () => "first",
+          SecondUnionTag: () => "second",
+        },
+      },
+    );
+
+    expect(actual).toBe("success");
+  });
+
   it("rejects a failure whose handler is missing at runtime", () => {
     const input = new SecondTestServiceError("second failure");
     const result = createFailureResult(input);
@@ -121,6 +149,20 @@ describe(matchServiceResult, () => {
       });
 
     expect(actual).toThrow("Missing ServiceResult error handler for SecondTestServiceError");
+  });
+
+  it("rejects an inherited handler property", () => {
+    const result = failure(new ToStringTagTestServiceError("test failure"));
+    const onError = { toString: () => "handled" };
+    Reflect.deleteProperty(onError, "toString");
+
+    const actual = () =>
+      matchServiceResult(result, {
+        onSuccess: () => "success",
+        onError,
+      });
+
+    expect(actual).toThrow("Missing ServiceResult error handler for toString");
   });
 });
 

--- a/packages/util-ts/src/lib/functional/matchServiceResult.test.ts
+++ b/packages/util-ts/src/lib/functional/matchServiceResult.test.ts
@@ -10,6 +10,12 @@ class SecondTestServiceError extends ServiceError {
   public readonly _tag = "SecondTestServiceError" as const;
 }
 
+class BroadTagTestServiceError extends ServiceError {
+  public get _tag(): string {
+    return "BroadTagTestServiceError";
+  }
+}
+
 type TestServiceError = FirstTestServiceError | SecondTestServiceError;
 
 type MatchOutput =
@@ -82,6 +88,39 @@ describe(matchServiceResult, () => {
     });
 
     expect(actual).toBe("success");
+  });
+
+  it("requires literal error tags", () => {
+    const result: ServiceResult<number, BroadTagTestServiceError> = success(42);
+
+    const actual = matchServiceResult(
+      // @ts-expect-error: a broad string tag cannot be matched exhaustively
+      result,
+      {
+        onSuccess: () => "success",
+        onError: {},
+      },
+    );
+
+    expect(actual).toBe("success");
+  });
+
+  it("rejects a failure whose handler is missing at runtime", () => {
+    const input = new SecondTestServiceError("second failure");
+    const result = createFailureResult(input);
+    const onError = {
+      FirstTestServiceError: () => "first",
+      SecondTestServiceError: () => "second",
+    };
+    Reflect.deleteProperty(onError, "SecondTestServiceError");
+
+    const actual = () =>
+      matchServiceResult(result, {
+        onSuccess: () => "success",
+        onError,
+      });
+
+    expect(actual).toThrow("Missing ServiceResult error handler for SecondTestServiceError");
   });
 });
 

--- a/packages/util-ts/src/lib/functional/matchServiceResult.test.ts
+++ b/packages/util-ts/src/lib/functional/matchServiceResult.test.ts
@@ -1,0 +1,94 @@
+import { ServiceError } from "../errors/serviceError";
+import { matchServiceResult } from "./matchServiceResult";
+import { failure, type ServiceResult, success } from "./serviceResult";
+
+class FirstTestServiceError extends ServiceError {
+  public readonly _tag = "FirstTestServiceError" as const;
+}
+
+class SecondTestServiceError extends ServiceError {
+  public readonly _tag = "SecondTestServiceError" as const;
+}
+
+type TestServiceError = FirstTestServiceError | SecondTestServiceError;
+
+type MatchOutput =
+  | { kind: "success"; value: number }
+  | { error: FirstTestServiceError; kind: "first" }
+  | { error: SecondTestServiceError; kind: "second" };
+
+describe(matchServiceResult, () => {
+  it("maps a successful result", () => {
+    const result = createSuccessResult();
+
+    const actual = matchServiceResult(result, {
+      onSuccess: (value) => ({ kind: "success" as const, value }),
+      onError: {
+        FirstTestServiceError: (error) => ({ error, kind: "first" as const }),
+        SecondTestServiceError: (error) => ({ error, kind: "second" as const }),
+      },
+    });
+
+    expectTypeOf(actual).toEqualTypeOf<MatchOutput>();
+    expect(actual).toStrictEqual({ kind: "success", value: 42 });
+  });
+
+  it("dispatches a failure to its exactly typed tag handler", () => {
+    const input = new SecondTestServiceError("second failure");
+    const result = createFailureResult(input);
+
+    const actual = matchServiceResult(result, {
+      onSuccess: (value) => ({ kind: "success" as const, value }),
+      onError: {
+        FirstTestServiceError: (error) => {
+          expectTypeOf(error).toEqualTypeOf<FirstTestServiceError>();
+          return { error, kind: "first" as const };
+        },
+        SecondTestServiceError: (error) => {
+          expectTypeOf(error).toEqualTypeOf<SecondTestServiceError>();
+          return { error, kind: "second" as const };
+        },
+      },
+    });
+
+    expect(actual).toStrictEqual({ error: input, kind: "second" });
+  });
+
+  it("requires a handler for every error tag", () => {
+    const result = createSuccessResult();
+
+    const actual = matchServiceResult(result, {
+      onSuccess: () => "success",
+      // @ts-expect-error: SecondTestServiceError handler is required
+      onError: {
+        FirstTestServiceError: () => "first",
+      },
+    });
+
+    expect(actual).toBe("success");
+  });
+
+  it("rejects handlers outside the error union", () => {
+    const result = createSuccessResult();
+
+    const actual = matchServiceResult(result, {
+      onSuccess: () => "success",
+      onError: {
+        FirstTestServiceError: () => "first",
+        SecondTestServiceError: () => "second",
+        // @ts-expect-error: handlers must correspond to a member of the error union
+        UnexpectedServiceError: () => "unexpected",
+      },
+    });
+
+    expect(actual).toBe("success");
+  });
+});
+
+function createSuccessResult(): ServiceResult<number, TestServiceError> {
+  return success(42);
+}
+
+function createFailureResult(error: TestServiceError): ServiceResult<number, TestServiceError> {
+  return failure(error);
+}

--- a/packages/util-ts/src/lib/functional/matchServiceResult.ts
+++ b/packages/util-ts/src/lib/functional/matchServiceResult.ts
@@ -33,6 +33,71 @@ type LiteralErrorTagConstraint<E extends TaggedServiceError> = string extends E[
  * the call will compile.
  *
  * @throws {TypeError} If a runtime caller omits the handler for a failure's tag.
+ *
+ * @example
+ * <embedex source="packages/util-ts/examples/matchServiceResult.ts">
+ *
+ * ```ts
+ * import { strictEqual } from "node:assert/strict";
+ *
+ * import {
+ *   failure,
+ *   matchServiceResult,
+ *   ServiceError,
+ *   type ServiceResult,
+ *   success,
+ * } from "@clipboard-health/util-ts";
+ *
+ * interface User {
+ *   id: string;
+ *   name: string;
+ * }
+ *
+ * class InvalidUserIdError extends ServiceError {
+ *   public readonly _tag = "InvalidUserIdError" as const;
+ *
+ *   public constructor() {
+ *     super("User ID is required");
+ *   }
+ * }
+ *
+ * class UserNotFoundError extends ServiceError {
+ *   public readonly _tag = "UserNotFoundError" as const;
+ *
+ *   public readonly userId: string;
+ *
+ *   public constructor({ userId }: { userId: string }) {
+ *     super(`User ${userId} was not found`);
+ *     this.userId = userId;
+ *   }
+ * }
+ *
+ * type FindUserError = InvalidUserIdError | UserNotFoundError;
+ *
+ * function findUser({ userId }: { userId: string }): ServiceResult<User, FindUserError> {
+ *   if (userId.length === 0) {
+ *     return failure(new InvalidUserIdError());
+ *   }
+ *
+ *   if (userId === "missing") {
+ *     return failure(new UserNotFoundError({ userId }));
+ *   }
+ *
+ *   return success({ id: userId, name: "Ada" });
+ * }
+ *
+ * const message = matchServiceResult(findUser({ userId: "missing" }), {
+ *   onSuccess: (user) => `Found ${user.name}`,
+ *   onError: {
+ *     InvalidUserIdError: (error) => error.message,
+ *     UserNotFoundError: (error) => `User ${error.userId} was not found`,
+ *   },
+ * });
+ *
+ * strictEqual(message, "User missing was not found");
+ * ```
+ *
+ * </embedex>
  */
 export function matchServiceResult<
   A,

--- a/packages/util-ts/src/lib/functional/matchServiceResult.ts
+++ b/packages/util-ts/src/lib/functional/matchServiceResult.ts
@@ -22,12 +22,36 @@ type ExactErrorHandlers<
   Handlers extends ServiceResultErrorHandlers<E>,
 > = Handlers & Record<Exclude<keyof Handlers, E["_tag"]>, never>;
 
-type LiteralErrorTagConstraint<E extends TaggedServiceError> = string extends E["_tag"]
-  ? never
-  : unknown;
+type IsUnion<Value, Whole = Value> = Value extends unknown
+  ? [Whole] extends [Value]
+    ? false
+    : true
+  : never;
+
+type IsSingleLiteralTag<Tag extends string> = [Tag] extends [never]
+  ? false
+  : string extends Tag
+    ? false
+    : IsUnion<Tag> extends true
+      ? false
+      : true;
+
+type InvalidLiteralTagMember<E extends TaggedServiceError> = E extends unknown
+  ? IsSingleLiteralTag<E["_tag"]> extends true
+    ? never
+    : E
+  : never;
+
+type LiteralErrorTagConstraint<E extends TaggedServiceError> = [
+  InvalidLiteralTagMember<E>,
+] extends [never]
+  ? unknown
+  : never;
 
 /**
  * Exhaustively maps a ServiceResult with tagged errors to a single output value.
+ *
+ * Each member of the error union must expose exactly one literal `_tag`.
  *
  * Adding a member to the error union requires adding its `_tag` handler before
  * the call will compile.
@@ -118,7 +142,8 @@ export function matchServiceResult<
   // TypeScript cannot correlate an indexed handler with the matching member of
   // a discriminated union. ExactErrorHandlers guarantees this relationship.
   const handlers = options.onError as ServiceResultErrorHandlers<E>;
-  const handler = handlers[result.error._tag as E["_tag"]] as
+  const tag = result.error._tag as E["_tag"];
+  const handler = (Object.hasOwn(handlers, tag) ? handlers[tag] : undefined) as
     | ((error: E) => ErrorHandlerOutput<Handlers>)
     | undefined;
 

--- a/packages/util-ts/src/lib/functional/matchServiceResult.ts
+++ b/packages/util-ts/src/lib/functional/matchServiceResult.ts
@@ -22,11 +22,17 @@ type ExactErrorHandlers<
   Handlers extends ServiceResultErrorHandlers<E>,
 > = Handlers & Record<Exclude<keyof Handlers, E["_tag"]>, never>;
 
+type LiteralErrorTagConstraint<E extends TaggedServiceError> = string extends E["_tag"]
+  ? never
+  : unknown;
+
 /**
  * Exhaustively maps a ServiceResult with tagged errors to a single output value.
  *
  * Adding a member to the error union requires adding its `_tag` handler before
  * the call will compile.
+ *
+ * @throws {TypeError} If a runtime caller omits the handler for a failure's tag.
  */
 export function matchServiceResult<
   A,
@@ -34,7 +40,7 @@ export function matchServiceResult<
   SuccessOutput,
   const Handlers extends ServiceResultErrorHandlers<E>,
 >(
-  result: ServiceResult<A, E>,
+  result: ServiceResult<A, E> & LiteralErrorTagConstraint<E>,
   options: {
     readonly onSuccess: (value: A) => SuccessOutput;
     readonly onError: ExactErrorHandlers<E, Handlers>;

--- a/packages/util-ts/src/lib/functional/matchServiceResult.ts
+++ b/packages/util-ts/src/lib/functional/matchServiceResult.ts
@@ -1,0 +1,59 @@
+import type { ServiceError } from "../errors/serviceError";
+import { isSuccess, type ServiceResult } from "./serviceResult";
+
+/** A service error with a literal discriminant used for exhaustive matching. */
+export type TaggedServiceError = ServiceError & { readonly _tag: string };
+
+/** A handler for every tagged member of a ServiceResult error union. */
+export type ServiceResultErrorHandlers<E extends TaggedServiceError> = {
+  readonly [Tag in E["_tag"]]: (error: Extract<E, { readonly _tag: Tag }>) => unknown;
+};
+
+type ErrorHandlerOutput<Handlers> = {
+  readonly [Tag in keyof Handlers]: Handlers[Tag] extends (
+    ...arguments_: infer _Arguments
+  ) => infer Output
+    ? Output
+    : never;
+}[keyof Handlers];
+
+type ExactErrorHandlers<
+  E extends TaggedServiceError,
+  Handlers extends ServiceResultErrorHandlers<E>,
+> = Handlers & Record<Exclude<keyof Handlers, E["_tag"]>, never>;
+
+/**
+ * Exhaustively maps a ServiceResult with tagged errors to a single output value.
+ *
+ * Adding a member to the error union requires adding its `_tag` handler before
+ * the call will compile.
+ */
+export function matchServiceResult<
+  A,
+  E extends TaggedServiceError,
+  SuccessOutput,
+  const Handlers extends ServiceResultErrorHandlers<E>,
+>(
+  result: ServiceResult<A, E>,
+  options: {
+    readonly onSuccess: (value: A) => SuccessOutput;
+    readonly onError: ExactErrorHandlers<E, Handlers>;
+  },
+): SuccessOutput | ErrorHandlerOutput<Handlers> {
+  if (isSuccess(result)) {
+    return options.onSuccess(result.value);
+  }
+
+  // TypeScript cannot correlate an indexed handler with the matching member of
+  // a discriminated union. ExactErrorHandlers guarantees this relationship.
+  const handlers = options.onError as ServiceResultErrorHandlers<E>;
+  const handler = handlers[result.error._tag as E["_tag"]] as
+    | ((error: E) => ErrorHandlerOutput<Handlers>)
+    | undefined;
+
+  if (handler === undefined) {
+    throw new TypeError(`Missing ServiceResult error handler for ${result.error._tag}`);
+  }
+
+  return handler(result.error);
+}

--- a/packages/util-ts/src/lib/functional/serviceResult.test.ts
+++ b/packages/util-ts/src/lib/functional/serviceResult.test.ts
@@ -5,6 +5,7 @@ import { isLeft, isRight, type Left, type Right } from "./either";
 import {
   type Failure,
   failure,
+  type FailureResult,
   fromSafeParseReturnType,
   isFailure,
   isSuccess,
@@ -15,6 +16,16 @@ import {
   tryCatch,
   tryCatchAsync,
 } from "./serviceResult";
+
+class FirstTestServiceError extends ServiceError {
+  public readonly _tag = "FirstTestServiceError" as const;
+}
+
+class SecondTestServiceError extends ServiceError {
+  public readonly _tag = "SecondTestServiceError" as const;
+}
+
+type TestServiceError = FirstTestServiceError | SecondTestServiceError;
 
 function getServiceErrorMessage(error: ServiceError): string {
   return error.issues[0]?.message ?? "no message";
@@ -27,6 +38,7 @@ describe("ServiceResult", () => {
 
       const actual = success(input);
 
+      expectTypeOf(actual).toEqualTypeOf<ServiceResult<{ data: string }>>();
       expect(isSuccess(actual)).toBe(true);
       expect(isFailure(actual)).toBe(false);
       expect(actual.isSuccess).toBe(true);
@@ -39,6 +51,13 @@ describe("ServiceResult", () => {
 
       expect(isSuccess(actual)).toBe(true);
       expect(actual.isSuccess).toBe(true);
+      expect((actual as Success<void>).value).toBeUndefined();
+    });
+
+    it("can be used with a specific error channel", () => {
+      const actual: ServiceResult<void, TestServiceError> = success();
+
+      expect(isSuccess(actual)).toBe(true);
       expect((actual as Success<void>).value).toBeUndefined();
     });
   });
@@ -75,6 +94,38 @@ describe("ServiceResult", () => {
       expect(error.issues).toStrictEqual([
         { code: ERROR_CODES.internal, title: "Internal server error", message: "test error" },
       ]);
+    });
+
+    it("preserves a ServiceError subtype", () => {
+      const input = new FirstTestServiceError("test error");
+
+      const actual = failure(input);
+
+      expectTypeOf(actual).toEqualTypeOf<FailureResult<FirstTestServiceError>>();
+      expect(actual.error).toBe(input);
+    });
+  });
+
+  describe("typed error channels", () => {
+    it("preserves an error union through the failure guard", () => {
+      const input = new FirstTestServiceError("test error");
+      const result = createTypedFailure(input);
+
+      const actual = isFailure(result);
+      const error = getTypedFailureError(result);
+
+      expect(actual).toBe(true);
+      expectTypeOf(error).toEqualTypeOf<TestServiceError>();
+      expect(error).toBe(input);
+    });
+
+    it("provides the typed error to mapFailure", () => {
+      const input = createTypedFailure(new SecondTestServiceError("test error"));
+      const transformError = mapFailure((error: TestServiceError) => error._tag);
+
+      const actual = transformError(input);
+
+      expect(actual).toStrictEqual({ isRight: false, left: "SecondTestServiceError" });
     });
   });
 
@@ -334,4 +385,16 @@ describe("ServiceResult", () => {
 
 function faultyOnError(): never {
   throw new Error("onError function failed");
+}
+
+function createTypedFailure(error: TestServiceError): ServiceResult<string, TestServiceError> {
+  return failure(error);
+}
+
+function getTypedFailureError(result: ServiceResult<string, TestServiceError>): TestServiceError {
+  if (isSuccess(result)) {
+    throw new Error("Expected failure");
+  }
+
+  return result.error;
 }

--- a/packages/util-ts/src/lib/functional/serviceResult.test.ts
+++ b/packages/util-ts/src/lib/functional/serviceResult.test.ts
@@ -107,6 +107,19 @@ describe("ServiceResult", () => {
   });
 
   describe("typed error channels", () => {
+    it("preserves the existing explicit generic arguments", () => {
+      const successfulResult: ServiceResult<string> = success("value");
+      const failedResult: ServiceResult<string> = failure(new ServiceError("test error"));
+      const getErrorMessage = mapFailure<string>((error) => getServiceErrorMessage(error));
+
+      expect(isSuccess<string>(successfulResult)).toBe(true);
+      expect(isFailure<string>(failedResult)).toBe(true);
+      expect(getErrorMessage(failedResult)).toStrictEqual({
+        isRight: false,
+        left: "test error",
+      });
+    });
+
     it("preserves an error union through the failure guard", () => {
       const input = new FirstTestServiceError("test error");
       const result = createTypedFailure(input);

--- a/packages/util-ts/src/lib/functional/serviceResult.ts
+++ b/packages/util-ts/src/lib/functional/serviceResult.ts
@@ -64,7 +64,7 @@ export function failure(params: ServiceErrorParams | ServiceError): FailureResul
 /**
  * Type guard for failure results.
  */
-export function isFailure<A, E extends ServiceError>(
+export function isFailure<A, E extends ServiceError = ServiceError>(
   result: ServiceResult<A, E>,
 ): result is FailureResult<E> {
   return !result.isSuccess;
@@ -73,7 +73,7 @@ export function isFailure<A, E extends ServiceError>(
 /**
  * Type guard for success results.
  */
-export function isSuccess<A, E extends ServiceError>(
+export function isSuccess<A, E extends ServiceError = ServiceError>(
   result: ServiceResult<A, E>,
 ): result is SuccessResult<A> {
   return result.isSuccess;
@@ -83,7 +83,7 @@ export function isSuccess<A, E extends ServiceError>(
  * Alias for {@link mapLeft}.
  * Note: returns an {@link Either}, not a ServiceResult.
  */
-export function mapFailure<E extends ServiceError, G>(
+export function mapFailure<G, E extends ServiceError = ServiceError>(
   f: (left: E) => G,
 ): <A>(result: ServiceResult<A, E>) => Either<G, A> {
   return mapLeft(f);

--- a/packages/util-ts/src/lib/functional/serviceResult.ts
+++ b/packages/util-ts/src/lib/functional/serviceResult.ts
@@ -14,7 +14,7 @@ export interface Failure<E> {
 }
 
 export type SuccessResult<A> = Right<A> & Success<A>;
-export type FailureResult = Left<ServiceError> & Failure<ServiceError>;
+export type FailureResult<E extends ServiceError = ServiceError> = Left<E> & Failure<E>;
 
 /**
  * Represents the result of a service operation that may fail.
@@ -22,17 +22,22 @@ export type FailureResult = Left<ServiceError> & Failure<ServiceError>;
  * The type is also an {@link Either}, allowing functions built for {@link Either}.
  *
  * @template A The type of the successful result value
+ * @template E The type of the failed result error
  */
-export type ServiceResult<A> = SuccessResult<A> | FailureResult;
+export type ServiceResult<A, E extends ServiceError = ServiceError> =
+  | SuccessResult<A>
+  | FailureResult<E>;
 
 /**
  * Creates a successful ServiceResult.
  *
  * Call with no argument for a `ServiceResult<void>`; the value is `undefined`.
  */
-export function success(): ServiceResult<void>;
-export function success<A>(value: A): ServiceResult<A>;
-export function success<A>(value?: A): ServiceResult<A | void> {
+export function success<E extends ServiceError = ServiceError>(): ServiceResult<void, E>;
+export function success<A, E extends ServiceError = ServiceError>(value: A): ServiceResult<A, E>;
+export function success<A, E extends ServiceError = ServiceError>(
+  value?: A,
+): ServiceResult<A | void, E> {
   return Object.freeze({
     isRight: true,
     isSuccess: true,
@@ -44,6 +49,8 @@ export function success<A>(value?: A): ServiceResult<A | void> {
 /**
  * Creates a failed ServiceResult.
  */
+export function failure<E extends ServiceError>(error: E): FailureResult<E>;
+export function failure(params: ServiceErrorParams): FailureResult;
 export function failure(params: ServiceErrorParams | ServiceError): FailureResult {
   const error = params instanceof ServiceError ? params : new ServiceError(params);
   return Object.freeze({
@@ -57,16 +64,18 @@ export function failure(params: ServiceErrorParams | ServiceError): FailureResul
 /**
  * Type guard for failure results.
  */
-export function isFailure<A>(
-  result: ServiceResult<A>,
-): result is Left<ServiceError> & Failure<ServiceError> {
+export function isFailure<A, E extends ServiceError>(
+  result: ServiceResult<A, E>,
+): result is FailureResult<E> {
   return !result.isSuccess;
 }
 
 /**
  * Type guard for success results.
  */
-export function isSuccess<A>(result: ServiceResult<A>): result is Right<A> & Success<A> {
+export function isSuccess<A, E extends ServiceError>(
+  result: ServiceResult<A, E>,
+): result is SuccessResult<A> {
   return result.isSuccess;
 }
 
@@ -74,9 +83,9 @@ export function isSuccess<A>(result: ServiceResult<A>): result is Right<A> & Suc
  * Alias for {@link mapLeft}.
  * Note: returns an {@link Either}, not a ServiceResult.
  */
-export function mapFailure<G>(
-  f: (left: ServiceError) => G,
-): <A>(result: ServiceResult<A>) => Either<G, A> {
+export function mapFailure<E extends ServiceError, G>(
+  f: (left: E) => G,
+): <A>(result: ServiceResult<A, E>) => Either<G, A> {
   return mapLeft(f);
 }
 


### PR DESCRIPTION
## Context

This PR implements the incremental alternative described in the [recent IS Effect Adoption comment](https://app.notion.com/p/IS-Effect-Adoption-3648643321f480f28f83d3edffeda1bb?d=0a18643321f48245b41703101ab30953&source=copy_link): the primary requirement is preserving a branchable error union through service boundaries, while retaining the existing `ServiceResult` infrastructure around conversion, JSON:API formatting, logging, and controllers.

The MSA experiments provide the concrete comparison:

| Approach | Clipboard-health reference |
| --- | --- |
| Effect baseline | [`f577386440` — prototype typed Effect errors in MSA](https://github.com/ClipboardHealth/clipboard-health/commit/f577386440) |
| Typed `ServiceResult` baseline | [`8a418b89d3` — prototype typed ServiceResult errors](https://github.com/ClipboardHealth/clipboard-health/commit/8a418b89d3) |
| Typed `ServiceResult` plus exhaustive helper | [`cc9a997066` — exhaustively match ServiceResult errors](https://github.com/ClipboardHealth/clipboard-health/commit/cc9a997066) |

The Effect link intentionally points to the initial migration commit, before the later three-tier architecture and projection-inference refactors, so the two baseline approaches remain directly comparable. We are exploring this path after the Effect adoption proved more involved than originally expected.

## What this changes

- Extends `ServiceResult` to `ServiceResult<A, E extends ServiceError = ServiceError>` without changing its runtime representation.
- Preserves concrete error subtypes through `failure`, `isFailure`, `isSuccess`, `mapFailure`, existing testing helpers, and notification-result helpers.
- Preserves an already-typed `ServiceError` subtype through `ServiceError.fromUnknown` and the single-error `ServiceError.merge` case.
- Exports `matchServiceResult`, an opt-in matcher over literal `_tag` values that:
  - requires a handler for every member of the declared error union;
  - rejects handlers outside that union;
  - narrows each handler argument to its exact error subtype; and
  - returns the union of the success and error-handler outputs.

Existing callers can continue using `ServiceResult<A>`, `isFailure`, and the current controller/helper patterns. Exhaustive handling is opt-in rather than imposed on every call site.

## Example

```ts
type SearchByCoordinatesError =
  | InvalidMsaCoordinatesError
  | MsaDataAccessError
  | MsaGeocodingError;

const result: ServiceResult<SearchData, SearchByCoordinatesError> =
  await searchByCoordinates(input);

return matchServiceResult(result, {
  onSuccess: (body) => ({ status: 200 as const, body }),
  onError: {
    InvalidMsaCoordinatesError: (error) => toErrorResponse(400, error),
    MsaDataAccessError: (error) => toErrorResponse(500, error),
    MsaGeocodingError: (error) => toErrorResponse(500, error),
  },
});
```

Adding a new member to `SearchByCoordinatesError` makes this call fail typechecking until its handler is added. The resulting response union composes with the existing ts-rest controller contract in the MSA trial.

## Compatibility and open questions

- The second generic defaults to `ServiceError`, preserving current source compatibility.
- Existing untagged errors remain usable with `ServiceResult`; only `matchServiceResult` requires a literal `_tag` discriminant.
- The legacy catch helpers remain broad in this spike. We should separately decide whether to make their mapper return type generic or introduce explicitly typed variants.
- The helper name and object shape are provisional and are part of this review.
- This explores whether the key typed-error benefit is enough to justify evolving `ServiceResult`, before committing to the larger runtime and programming-model adoption of Effect.

## Validation

- `node --run verify`
- util-ts build and focused TypeScript spec typecheck
- util-ts test target
- clipboard-health full typecheck against the locally built package
- clipboard-health MSA tests: 3 suites, 8 tests
- clipboard-health controller lint with both configured linters
