### PR TITLE
fix: diagnose Mailpit polling timeouts (STAFF-2016)

### DIFF
--- a/packages/playwright-toolkit/src/lib/mailpit.test.ts
+++ b/packages/playwright-toolkit/src/lib/mailpit.test.ts
@@ -7,6 +7,7 @@ import {
   type MailpitClient,
   type MailpitMessage,
   type MailpitMessageSummary,
+  MailpitRequestError,
 } from "../index";
 
 describe("Mailpit polling", () => {
@@ -277,7 +278,190 @@ describe("Mailpit polling", () => {
 
     await expect(actualPromise).rejects.not.toThrow(email);
   });
+
+  it("reports when Mailpit searches return no messages", async () => {
+    const mockClient: MailpitClient = {
+      searchMessages: vi.fn<MailpitClient["searchMessages"]>(async () => []),
+      getMessage: vi.fn<MailpitClient["getMessage"]>(),
+    };
+
+    const actualPromise = fetchMagicLinkFromMailpit({
+      client: mockClient,
+      email: "user@example.test",
+      ...createImmediateTimeout(),
+    });
+
+    await expect(actualPromise).rejects.toThrow(
+      "Polling snapshot: searchAttempts=1, rawResultCount=0, " +
+        "postSentAfterCandidateCount=0, invalidOrMissingTimestampCount=0, " +
+        "fetchedMessageCount=0, extractionMissCount=0, excludedValueCount=0, " +
+        "transientRequestErrorCount=0, transientRequestErrorStatuses=[], " +
+        "newestCandidateAgeMs=unavailable",
+    );
+  });
+
+  it("reports the polling snapshot when a Mailpit request consumes the timeout budget", async () => {
+    const mockClient: MailpitClient = {
+      searchMessages: vi.fn<MailpitClient["searchMessages"]>(
+        async () =>
+          await new Promise<MailpitMessageSummary[]>(() => {
+            // The request remains pending until the polling deadline.
+          }),
+      ),
+      getMessage: vi.fn<MailpitClient["getMessage"]>(),
+    };
+
+    const actualPromise = fetchMagicLinkFromMailpit({
+      client: mockClient,
+      email: "user@example.test",
+      timeoutMs: 5,
+    });
+
+    await expect(actualPromise).rejects.toThrow(
+      "Polling snapshot: searchAttempts=1, rawResultCount=0, " +
+        "postSentAfterCandidateCount=0, invalidOrMissingTimestampCount=0, " +
+        "fetchedMessageCount=0, extractionMissCount=0, excludedValueCount=0, " +
+        "transientRequestErrorCount=0, transientRequestErrorStatuses=[], " +
+        "newestCandidateAgeMs=unavailable",
+    );
+  });
+
+  it("reports when sentAfter filters every Mailpit search result", async () => {
+    const mockClient: MailpitClient = {
+      searchMessages: vi.fn<MailpitClient["searchMessages"]>(async () => [
+        createSearchSummary({
+          id: "too-old",
+          created: "2026-07-16T11:00:00.000Z",
+        }),
+      ]),
+      getMessage: vi.fn<MailpitClient["getMessage"]>(),
+    };
+
+    const actualPromise = fetchMagicLinkFromMailpit({
+      client: mockClient,
+      email: "user@example.test",
+      sentAfter: new Date("2026-07-16T12:00:00.000Z"),
+      ...createImmediateTimeout(),
+    });
+
+    await expect(actualPromise).rejects.toThrow(
+      "Polling snapshot: searchAttempts=1, rawResultCount=1, " +
+        "postSentAfterCandidateCount=0, invalidOrMissingTimestampCount=0, " +
+        "fetchedMessageCount=0, extractionMissCount=0, excludedValueCount=0, " +
+        "transientRequestErrorCount=0, transientRequestErrorStatuses=[], " +
+        "newestCandidateAgeMs=unavailable",
+    );
+  });
+
+  it("reports transient Mailpit message fetch failures and statuses", async () => {
+    const mockClient: MailpitClient = {
+      searchMessages: vi.fn<MailpitClient["searchMessages"]>(async () => [
+        createSearchSummary({ id: "unavailable" }),
+      ]),
+      getMessage: vi.fn<MailpitClient["getMessage"]>(async () => {
+        throw new MailpitRequestError({
+          message: "upstream unavailable",
+          status: 503,
+        });
+      }),
+    };
+
+    const actualPromise = fetchMagicLinkFromMailpit({
+      client: mockClient,
+      email: "user@example.test",
+      ...createImmediateTimeout(),
+    });
+
+    await expect(actualPromise).rejects.toThrow(
+      "Polling snapshot: searchAttempts=1, rawResultCount=1, " +
+        "postSentAfterCandidateCount=1, invalidOrMissingTimestampCount=0, " +
+        "fetchedMessageCount=0, extractionMissCount=0, excludedValueCount=0, " +
+        "transientRequestErrorCount=1, transientRequestErrorStatuses=[503], " +
+        "newestCandidateAgeMs=1000",
+    );
+  });
+
+  it("reports messages that do not contain an extractable value", async () => {
+    const mockClient: MailpitClient = {
+      searchMessages: vi.fn<MailpitClient["searchMessages"]>(async () => [
+        createSearchSummaryWithoutTimestamp({ id: "no-value" }),
+      ]),
+      getMessage: vi.fn<MailpitClient["getMessage"]>(async () =>
+        createMessage({
+          id: "no-value",
+          text: "The expected value is absent.",
+        }),
+      ),
+    };
+
+    const actualPromise = fetchMagicLinkFromMailpit({
+      client: mockClient,
+      email: "user@example.test",
+      ...createImmediateTimeout(),
+    });
+
+    await expect(actualPromise).rejects.toThrow(
+      "Polling snapshot: searchAttempts=1, rawResultCount=1, " +
+        "postSentAfterCandidateCount=1, invalidOrMissingTimestampCount=1, " +
+        "fetchedMessageCount=1, extractionMissCount=1, excludedValueCount=0, " +
+        "transientRequestErrorCount=0, transientRequestErrorStatuses=[], " +
+        "newestCandidateAgeMs=unavailable",
+    );
+  });
+
+  it("reports excluded values without exposing recipient PII or extracted secrets", async () => {
+    const email = "sensitive-user@example.test";
+    const excludedCode = "81027033";
+    const sensitiveLink = "https://app.test/v2/email-login-link?credential=sensitive";
+    const mockClient: MailpitClient = {
+      searchMessages: vi.fn<MailpitClient["searchMessages"]>(async () => [
+        createSearchSummary({ id: "excluded" }),
+      ]),
+      getMessage: vi.fn<MailpitClient["getMessage"]>(async () =>
+        createMessage({
+          id: "excluded",
+          text: `${excludedCode} ${sensitiveLink}`,
+        }),
+      ),
+    };
+
+    const actualPromise = fetchEmailOtpCodeFromMailpit({
+      client: mockClient,
+      email,
+      excludeCodes: [excludedCode],
+      ...createImmediateTimeout(),
+    });
+
+    await expect(actualPromise).rejects.toThrow(
+      "Polling snapshot: searchAttempts=1, rawResultCount=1, " +
+        "postSentAfterCandidateCount=1, invalidOrMissingTimestampCount=0, " +
+        "fetchedMessageCount=1, extractionMissCount=0, excludedValueCount=1, " +
+        "transientRequestErrorCount=0, transientRequestErrorStatuses=[], " +
+        "newestCandidateAgeMs=1000",
+    );
+    await expect(actualPromise).rejects.not.toThrow(email);
+    await expect(actualPromise).rejects.not.toThrow(excludedCode);
+    await expect(actualPromise).rejects.not.toThrow(sensitiveLink);
+  });
 });
+
+function createImmediateTimeout(): {
+  timeoutMs: number;
+  pollIntervalMs: number;
+  nowImplementation: () => number;
+  sleepImplementation: (params: { durationMs: number }) => Promise<void>;
+} {
+  let currentTimeMs = Date.parse("2026-07-16T12:00:01.000Z");
+
+  return {
+    timeoutMs: 100,
+    pollIntervalMs: 100,
+    nowImplementation: () => currentTimeMs,
+    sleepImplementation: async ({ durationMs }) => {
+      currentTimeMs += durationMs;
+    },
+  };
+}
 
 function createMessage(params: {
   id: string;
@@ -300,6 +484,15 @@ function createSearchSummary(params: { id: string; created?: string }): MailpitM
   return {
     ID: params.id,
     Created: params.created ?? "2026-07-16T12:00:00.000Z",
+    From: { Address: "noreply@example.test", Name: "Clipboard" },
+    To: [{ Address: "user@example.test", Name: "User" }],
+    Subject: "Sign in",
+  };
+}
+
+function createSearchSummaryWithoutTimestamp(params: { id: string }): MailpitMessageSummary {
+  return {
+    ID: params.id,
     From: { Address: "noreply@example.test", Name: "Clipboard" },
     To: [{ Address: "user@example.test", Name: "User" }],
     Subject: "Sign in",

--- a/packages/playwright-toolkit/src/lib/mailpit.test.ts
+++ b/packages/playwright-toolkit/src/lib/mailpit.test.ts
@@ -130,6 +130,30 @@ describe("Mailpit polling", () => {
     ]);
   });
 
+  it("keeps Mailpit search summaries with a null creation timestamp", async () => {
+    const searchSummary = {
+      ID: "message-1",
+      Created: null,
+      From: { Address: "noreply@example.test", Name: "Clipboard" },
+      To: [{ Address: "user@example.test", Name: "User" }],
+      Subject: "Sign in",
+    };
+    const client = createMailpitClient({
+      baseUrl: "https://mailpit.example.test/api/v1",
+      password: "secret",
+      fetchImplementation: vi.fn<typeof fetch>(
+        async () =>
+          new Response(JSON.stringify({ messages: [searchSummary] }), {
+            status: 200,
+          }),
+      ),
+    });
+
+    await expect(client.searchMessages({ query: "to:user@example.test" })).resolves.toEqual([
+      searchSummary,
+    ]);
+  });
+
   it("does not retry malformed Mailpit response schemas", async () => {
     let currentTimeMs = 0;
     const mockFetch = vi.fn<typeof fetch>(
@@ -432,18 +456,75 @@ describe("Mailpit polling", () => {
       ...createImmediateTimeout(),
     });
 
-    await expect(actualPromise).rejects.toThrow(
+    const actualError = await captureError({ promise: actualPromise });
+    const actualErrorChain = getErrorChainMessage({ error: actualError });
+
+    expect(actualError.message).toContain(
       "Polling snapshot: searchAttempts=1, rawResultCount=1, " +
         "postSentAfterCandidateCount=1, invalidOrMissingTimestampCount=0, " +
         "fetchedMessageCount=1, extractionMissCount=0, excludedValueCount=1, " +
         "transientRequestErrorCount=0, transientRequestErrorStatuses=[], " +
         "newestCandidateAgeMs=1000",
     );
-    await expect(actualPromise).rejects.not.toThrow(email);
-    await expect(actualPromise).rejects.not.toThrow(excludedCode);
-    await expect(actualPromise).rejects.not.toThrow(sensitiveLink);
+    expect(actualErrorChain).not.toContain(email);
+    expect(actualErrorChain).not.toContain(excludedCode);
+    expect(actualErrorChain).not.toContain(sensitiveLink);
+  });
+
+  it("does not retain sensitive details from transient Mailpit request errors", async () => {
+    const email = "sensitive-user@example.test";
+    const secret = "sensitive-upstream-detail";
+    const mockClient: MailpitClient = {
+      searchMessages: vi.fn<MailpitClient["searchMessages"]>(async () => {
+        throw new MailpitRequestError({
+          message: `Mailpit request failed for ${email}`,
+          status: 503,
+          cause: new Error(secret),
+        });
+      }),
+      getMessage: vi.fn<MailpitClient["getMessage"]>(),
+    };
+
+    const actualPromise = fetchMagicLinkFromMailpit({
+      client: mockClient,
+      email,
+      ...createImmediateTimeout(),
+    });
+
+    const actualError = await captureError({ promise: actualPromise });
+    const actualErrorChain = getErrorChainMessage({ error: actualError });
+
+    expect(actualError.message).toContain(
+      "transientRequestErrorCount=1, transientRequestErrorStatuses=[503]",
+    );
+    expect(actualErrorChain).not.toContain(email);
+    expect(actualErrorChain).not.toContain(secret);
   });
 });
+
+async function captureError(params: { promise: Promise<unknown> }): Promise<Error> {
+  try {
+    await params.promise;
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      return error;
+    }
+  }
+
+  throw new Error("Expected promise to reject with an Error");
+}
+
+function getErrorChainMessage(params: { error: Error }): string {
+  const messages: string[] = [];
+  let currentError: unknown = params.error;
+
+  while (currentError instanceof Error) {
+    messages.push(currentError.message);
+    currentError = currentError.cause;
+  }
+
+  return messages.join(" | ");
+}
 
 function createImmediateTimeout(): {
   timeoutMs: number;

--- a/packages/playwright-toolkit/src/lib/mailpit.ts
+++ b/packages/playwright-toolkit/src/lib/mailpit.ts
@@ -1,4 +1,4 @@
-import { isRecord, toErrorMessage as getErrorMessage } from "@clipboard-health/util-ts";
+import { isNil, isRecord, toErrorMessage as getErrorMessage } from "@clipboard-health/util-ts";
 
 import { RetryError, type RetrySuccess, runWithRetry, type RunWithRetryParams } from "./retry";
 import { isRetryableHttpStatus } from "./setupRetry";
@@ -22,7 +22,7 @@ export interface MailpitMessageHeaders {
 }
 
 export interface MailpitMessageSummary extends MailpitMessageHeaders {
-  Created?: string | undefined;
+  Created?: string | null | undefined;
 }
 
 export interface MailpitMessage extends MailpitMessageHeaders {
@@ -186,7 +186,6 @@ export async function fetchMailpitValue(
 
         recordTransientRequestError({ error, pollingSnapshot });
         throw createMailpitValueNotFoundError({
-          cause: error,
           nowMs: nowImplementation(),
           pollingSnapshot,
           valueLabel: params.valueLabel,
@@ -427,6 +426,7 @@ function isMessageSentAfter(params: {
 
   const messageTimestampMs = getMailpitMessageTimestampMs({ message: params.message });
   if (messageTimestampMs === undefined) {
+    // Unparseable timestamps stay eligible so metadata gaps cannot hide a delivered message.
     return true;
   }
 
@@ -465,7 +465,7 @@ function isMailpitMessageSummary(value: unknown): value is MailpitMessageSummary
   return (
     isRecord(value) &&
     hasMailpitMessageHeaders(value) &&
-    (value["Created"] === undefined || typeof value["Created"] === "string")
+    (isNil(value["Created"]) || typeof value["Created"] === "string")
   );
 }
 
@@ -545,7 +545,7 @@ function formatMailpitPollingSnapshot(params: {
 function getMailpitMessageTimestampMs(params: {
   message: MailpitMessageSummary;
 }): number | undefined {
-  if (params.message.Created === undefined) {
+  if (isNil(params.message.Created)) {
     return undefined;
   }
 

--- a/packages/playwright-toolkit/src/lib/mailpit.ts
+++ b/packages/playwright-toolkit/src/lib/mailpit.ts
@@ -1,6 +1,6 @@
 import { isRecord, toErrorMessage as getErrorMessage } from "@clipboard-health/util-ts";
 
-import { runWithRetry } from "./retry";
+import { RetryError, type RetrySuccess, runWithRetry, type RunWithRetryParams } from "./retry";
 import { isRetryableHttpStatus } from "./setupRetry";
 
 const DEFAULT_MAILPIT_BASE_URL = "https://mailpit.tools.cbh.rocks/api/v1";
@@ -22,7 +22,7 @@ export interface MailpitMessageHeaders {
 }
 
 export interface MailpitMessageSummary extends MailpitMessageHeaders {
-  Created: string;
+  Created?: string | undefined;
 }
 
 export interface MailpitMessage extends MailpitMessageHeaders {
@@ -80,6 +80,19 @@ interface MailpitRequestErrorParams {
   status?: number | undefined;
   cause?: unknown;
   isTransient?: boolean | undefined;
+}
+
+interface MailpitPollingSnapshot {
+  searchAttempts: number;
+  rawResultCount: number;
+  postSentAfterCandidateCount: number;
+  invalidOrMissingTimestampCount: number;
+  fetchedMessageCount: number;
+  extractionMissCount: number;
+  excludedValueCount: number;
+  transientRequestErrorCount: number;
+  transientRequestErrorStatuses: Set<string>;
+  newestCandidateTimestampMs: number | undefined;
 }
 
 export class MailpitRequestError extends Error {
@@ -153,14 +166,48 @@ export async function fetchMailpitValue(
 ): Promise<FetchMailpitValueResult> {
   const excludedValues = new Set(params.excludedValues ?? []);
   const valuesByMessageId = new Map<string, string | undefined>();
-  const result = await runWithRetry({
-    operationName: `wait for Mailpit ${params.valueLabel}`,
+  const pollingSnapshot = createMailpitPollingSnapshot();
+  const nowImplementation = params.nowImplementation ?? Date.now;
+  const operationName = `wait for Mailpit ${params.valueLabel}`;
+  const retryParams: RunWithRetryParams<FetchMailpitValueResult> = {
+    operationName,
     operation: async () => {
-      const messages = await params.client.searchMessages({
-        query: `to:${params.email}`,
+      pollingSnapshot.searchAttempts += 1;
+      let messages: MailpitMessageSummary[];
+
+      try {
+        messages = await params.client.searchMessages({
+          query: `to:${params.email}`,
+        });
+      } catch (error: unknown) {
+        if (!isTransientMailpitError({ error })) {
+          throw error;
+        }
+
+        recordTransientRequestError({ error, pollingSnapshot });
+        throw createMailpitValueNotFoundError({
+          cause: error,
+          nowMs: nowImplementation(),
+          pollingSnapshot,
+          valueLabel: params.valueLabel,
+        });
+      }
+
+      pollingSnapshot.rawResultCount += messages.length;
+      pollingSnapshot.invalidOrMissingTimestampCount += messages.filter(
+        (message) => getMailpitMessageTimestampMs({ message }) === undefined,
+      ).length;
+
+      const postSentAfterCandidates = messages.filter((message) =>
+        isMessageSentAfter({ message, sentAfter: params.sentAfter }),
+      );
+      pollingSnapshot.postSentAfterCandidateCount += postSentAfterCandidates.length;
+      recordNewestCandidateTimestamp({
+        candidates: postSentAfterCandidates,
+        pollingSnapshot,
       });
-      const candidates = messages
-        .filter((message) => isMessageSentAfter({ message, sentAfter: params.sentAfter }))
+
+      const candidates = postSentAfterCandidates
         .toSorted(compareMailpitMessagesNewestFirst)
         .slice(0, MAX_MESSAGES_TO_FETCH);
 
@@ -180,22 +227,31 @@ export async function fetchMailpitValue(
           const fullMessage = await params.client.getMessage({
             messageId: message.ID,
           });
+          pollingSnapshot.fetchedMessageCount += 1;
           const value = params.extractValue({ message: fullMessage });
           valuesByMessageId.set(message.ID, value);
 
-          if (value !== undefined && !excludedValues.has(value)) {
+          if (value === undefined) {
+            pollingSnapshot.extractionMissCount += 1;
+          } else if (excludedValues.has(value)) {
+            pollingSnapshot.excludedValueCount += 1;
+          } else {
             return { value, messageId: message.ID };
           }
         } catch (error: unknown) {
           if (!isTransientMailpitError({ error })) {
             throw error;
           }
+
+          recordTransientRequestError({ error, pollingSnapshot });
         }
       }
 
-      throw new MailpitValueNotFoundError(
-        `No matching Mailpit ${params.valueLabel} is available yet`,
-      );
+      throw createMailpitValueNotFoundError({
+        nowMs: nowImplementation(),
+        pollingSnapshot,
+        valueLabel: params.valueLabel,
+      });
     },
     mode: {
       kind: "poll",
@@ -205,8 +261,34 @@ export async function fetchMailpitValue(
         error instanceof MailpitValueNotFoundError || isTransientMailpitError({ error }),
     },
     sleepImplementation: params.sleepImplementation,
-    nowImplementation: params.nowImplementation,
-  });
+    nowImplementation,
+  };
+  let result: RetrySuccess<FetchMailpitValueResult>;
+
+  try {
+    result = await runWithRetry(retryParams);
+  } catch (error: unknown) {
+    if (
+      error instanceof RetryError &&
+      error.reason === "timeout" &&
+      !(error.cause instanceof MailpitValueNotFoundError)
+    ) {
+      throw new RetryError({
+        operationName,
+        attempts: error.attempts,
+        elapsedMs: error.elapsedMs,
+        reason: error.reason,
+        cause: createMailpitValueNotFoundError({
+          cause: error.cause,
+          nowMs: nowImplementation(),
+          pollingSnapshot,
+          valueLabel: params.valueLabel,
+        }),
+      });
+    }
+
+    throw error;
+  }
 
   return result.value;
 }
@@ -343,26 +425,26 @@ function isMessageSentAfter(params: {
     return true;
   }
 
-  const messageTimestamp = Date.parse(params.message.Created);
-  if (!Number.isFinite(messageTimestamp)) {
+  const messageTimestampMs = getMailpitMessageTimestampMs({ message: params.message });
+  if (messageTimestampMs === undefined) {
     return true;
   }
 
-  return messageTimestamp >= params.sentAfter.getTime() - SENT_AFTER_TOLERANCE_MS;
+  return messageTimestampMs >= params.sentAfter.getTime() - SENT_AFTER_TOLERANCE_MS;
 }
 
 function compareMailpitMessagesNewestFirst(
   first: MailpitMessageSummary,
   second: MailpitMessageSummary,
 ): number {
-  const firstTimestamp = Date.parse(first.Created);
-  const secondTimestamp = Date.parse(second.Created);
+  const firstTimestamp = getMailpitMessageTimestampMs({ message: first });
+  const secondTimestamp = getMailpitMessageTimestampMs({ message: second });
 
-  if (!Number.isFinite(firstTimestamp)) {
-    return Number.isFinite(secondTimestamp) ? 1 : 0;
+  if (firstTimestamp === undefined) {
+    return secondTimestamp === undefined ? 0 : 1;
   }
 
-  if (!Number.isFinite(secondTimestamp)) {
+  if (secondTimestamp === undefined) {
     return -1;
   }
 
@@ -380,7 +462,11 @@ function isMailpitMessage(value: unknown): value is MailpitMessage {
 }
 
 function isMailpitMessageSummary(value: unknown): value is MailpitMessageSummary {
-  return isRecord(value) && hasMailpitMessageHeaders(value) && typeof value["Created"] === "string";
+  return (
+    isRecord(value) &&
+    hasMailpitMessageHeaders(value) &&
+    (value["Created"] === undefined || typeof value["Created"] === "string")
+  );
 }
 
 function hasMailpitMessageHeaders(value: Record<string, unknown>): boolean {
@@ -397,4 +483,103 @@ function isMailpitAddress(value: unknown): value is MailpitAddress {
   return (
     isRecord(value) && typeof value["Address"] === "string" && typeof value["Name"] === "string"
   );
+}
+
+function createMailpitPollingSnapshot(): MailpitPollingSnapshot {
+  return {
+    searchAttempts: 0,
+    rawResultCount: 0,
+    postSentAfterCandidateCount: 0,
+    invalidOrMissingTimestampCount: 0,
+    fetchedMessageCount: 0,
+    extractionMissCount: 0,
+    excludedValueCount: 0,
+    transientRequestErrorCount: 0,
+    transientRequestErrorStatuses: new Set(),
+    newestCandidateTimestampMs: undefined,
+  };
+}
+
+function createMailpitValueNotFoundError(params: {
+  cause?: unknown;
+  nowMs: number;
+  pollingSnapshot: MailpitPollingSnapshot;
+  valueLabel: string;
+}): MailpitValueNotFoundError {
+  return new MailpitValueNotFoundError(
+    `No matching Mailpit ${params.valueLabel} is available yet. ` +
+      formatMailpitPollingSnapshot({
+        nowMs: params.nowMs,
+        pollingSnapshot: params.pollingSnapshot,
+      }),
+    { cause: params.cause },
+  );
+}
+
+function formatMailpitPollingSnapshot(params: {
+  nowMs: number;
+  pollingSnapshot: MailpitPollingSnapshot;
+}): string {
+  const newestCandidateAgeMs =
+    params.pollingSnapshot.newestCandidateTimestampMs === undefined
+      ? "unavailable"
+      : String(params.nowMs - params.pollingSnapshot.newestCandidateTimestampMs);
+  const transientRequestErrorStatuses = [
+    ...params.pollingSnapshot.transientRequestErrorStatuses,
+  ].join(",");
+
+  return (
+    `Polling snapshot: searchAttempts=${params.pollingSnapshot.searchAttempts}, ` +
+    `rawResultCount=${params.pollingSnapshot.rawResultCount}, ` +
+    `postSentAfterCandidateCount=${params.pollingSnapshot.postSentAfterCandidateCount}, ` +
+    `invalidOrMissingTimestampCount=${params.pollingSnapshot.invalidOrMissingTimestampCount}, ` +
+    `fetchedMessageCount=${params.pollingSnapshot.fetchedMessageCount}, ` +
+    `extractionMissCount=${params.pollingSnapshot.extractionMissCount}, ` +
+    `excludedValueCount=${params.pollingSnapshot.excludedValueCount}, ` +
+    `transientRequestErrorCount=${params.pollingSnapshot.transientRequestErrorCount}, ` +
+    `transientRequestErrorStatuses=[${transientRequestErrorStatuses}], ` +
+    `newestCandidateAgeMs=${newestCandidateAgeMs}`
+  );
+}
+
+function getMailpitMessageTimestampMs(params: {
+  message: MailpitMessageSummary;
+}): number | undefined {
+  if (params.message.Created === undefined) {
+    return undefined;
+  }
+
+  const timestampMs = Date.parse(params.message.Created);
+  return Number.isFinite(timestampMs) ? timestampMs : undefined;
+}
+
+function recordNewestCandidateTimestamp(params: {
+  candidates: readonly MailpitMessageSummary[];
+  pollingSnapshot: MailpitPollingSnapshot;
+}): void {
+  const candidateTimestampsMs = params.candidates
+    .map((message) => getMailpitMessageTimestampMs({ message }))
+    .filter((timestampMs) => timestampMs !== undefined);
+
+  if (candidateTimestampsMs.length === 0) {
+    return;
+  }
+
+  params.pollingSnapshot.newestCandidateTimestampMs = Math.max(
+    params.pollingSnapshot.newestCandidateTimestampMs ?? Number.NEGATIVE_INFINITY,
+    ...candidateTimestampsMs,
+  );
+}
+
+function recordTransientRequestError(params: {
+  error: unknown;
+  pollingSnapshot: MailpitPollingSnapshot;
+}): void {
+  params.pollingSnapshot.transientRequestErrorCount += 1;
+
+  if (params.error instanceof MailpitRequestError) {
+    params.pollingSnapshot.transientRequestErrorStatuses.add(
+      params.error.status?.toString() ?? "unavailable",
+    );
+  }
 }


### PR DESCRIPTION
## Summary

- Add a sanitized cumulative snapshot to terminal Mailpit polling errors so the next Cognito OTP timeout identifies whether search, sent-after filtering, message fetching, extraction, or excluded values exhausted the poll.
- Preserve missing or invalid timestamp summaries for classification and report only counts, status codes, and relative candidate age—never recipient addresses, subjects, bodies, OTPs, links, credentials, headers, or message IDs.
- Cover empty search results, fully filtered results, transient fetch failures, extraction misses, excluded values, missing timestamps, and requests that consume the remaining polling deadline.

## Validation

- `NX_ISOLATE_PLUGINS=false NX_CLOUD=false npm exec nx -- lint playwright-toolkit --verbose`
- `NX_ISOLATE_PLUGINS=false NX_CLOUD=false npm exec nx -- test playwright-toolkit --configuration ci --verbose --maxWorkers=2` — 91 tests passed with coverage
- `NX_ISOLATE_PLUGINS=false NX_CLOUD=false npm exec nx -- build playwright-toolkit --skip-nx-cache --verbose`
- `NX_ISOLATE_PLUGINS=false NX_CLOUD=false node --run verify`
- Spec-aware `cb-review --effort low --report`: 1 finding applied; the final request-deadline path now retains the snapshot

## Notes

- No timeout increase, unbounded retry, or speculative resend was added. This remains an observability fix; a later occurrence is still required to select the smallest behavioral or infrastructure fix.
- The existing release workflow will publish the next `@clipboard-health/playwright-toolkit` patch after merge. The `cbh-admin-frontend` consumer bump must follow that publication so its lockfile can resolve the released artifact.
- [STAFF-2016](https://linear.app/clipboardhealth/issue/STAFF-2016)

Closes staff-2016

Agent session: `codex resume 019faba6-3940-7563-a1b5-6d75fc78f31f`

<sub>🤖 <code>cb-ship:created v1 core@3.23.1</code></sub>