### PR TITLE
fix: allow Safehouse to run cmux agent hooks (TG-4209)

### DIFF
--- a/packages/clearance/README.md
+++ b/packages/clearance/README.md
@@ -158,9 +158,10 @@ alias claude-proxy="$SAFEHOUSE/safehouse-claude-proxy"
 `safehouse-claude-proxy` runs Claude through Safehouse with
 `--permission-mode auto`. When launched from a cmux terminal, it preserves
 cmux's Claude shim by forwarding the cmux session environment and granting
-read-only access to the cmux app/socket state and generated Codex hooks. It also
-points the shim at the real Claude binary so the shim does not recurse through
-itself.
+read-only access to the cmux app/socket state and generated Codex hooks. The
+integration also grants cmux's existing Sentry cache write access so diagnostics
+cannot corrupt hook JSON output. It points the shim at the real Claude binary so
+the shim does not recurse through itself.
 
 The cmux environment pass-through is an explicit reviewed allowlist. If a cmux
 update adds new `CMUX_*` variables to its Claude wrapper contract,

--- a/packages/clearance/README.md
+++ b/packages/clearance/README.md
@@ -158,8 +158,9 @@ alias claude-proxy="$SAFEHOUSE/safehouse-claude-proxy"
 `safehouse-claude-proxy` runs Claude through Safehouse with
 `--permission-mode auto`. When launched from a cmux terminal, it preserves
 cmux's Claude shim by forwarding the cmux session environment and granting
-read-only access to the cmux app/socket state. It also points the shim at the
-real Claude binary so the shim does not recurse through itself.
+read-only access to the cmux app/socket state and generated Codex hooks. It also
+points the shim at the real Claude binary so the shim does not recurse through
+itself.
 
 The cmux environment pass-through is an explicit reviewed allowlist. If a cmux
 update adds new `CMUX_*` variables to its Claude wrapper contract,

--- a/packages/clearance/src/safehouseClaudeProxyCli.ts
+++ b/packages/clearance/src/safehouseClaudeProxyCli.ts
@@ -28,6 +28,9 @@ try {
 
   const safehouseArgs = cmuxIntegration.isActive
     ? [
+        ...(cmuxIntegration.addDirs.length === 0
+          ? []
+          : [`--add-dirs=${cmuxIntegration.addDirs.join(":")}`]),
         `--add-dirs-ro=${cmuxIntegration.addDirsReadOnly.join(":")}`,
         `--env-pass=${cmuxIntegration.envPass.join(",")}`,
       ]

--- a/packages/clearance/src/safehouseCmux.test.ts
+++ b/packages/clearance/src/safehouseCmux.test.ts
@@ -75,6 +75,23 @@ describe(resolveSafehouseCmuxIntegration, () => {
     }
   });
 
+  it("includes the existing Sentry cache as a writable cmux directory", () => {
+    const tempHome = mkdtempSync(path.join(tmpdir(), "safehouse-cmux-home-"));
+    const sentryCacheDir = path.join(tempHome, "Library", "Caches", "io.sentry");
+    try {
+      mkdirSync(sentryCacheDir, { recursive: true });
+
+      const actual = resolveSafehouseCmuxIntegration({
+        env: { HOME: tempHome },
+        readFile: () => "",
+      });
+
+      expect(actual.addDirs).toStrictEqual([sentryCacheDir]);
+    } finally {
+      rmSync(tempHome, { force: true, recursive: true });
+    }
+  });
+
   it("prefers XDG_STATE_HOME and dedupes the socket directory", () => {
     const actual = resolveSafehouseCmuxIntegration({
       env: {
@@ -99,6 +116,7 @@ describe(resolveSafehouseCmuxIntegration, () => {
     });
 
     expect(actual.addDirsReadOnly).toStrictEqual(["/Applications/cmux.app"]);
+    expect(actual.addDirs).toStrictEqual([]);
   });
 
   it("reports cmux wrapper env names that have not been reviewed", () => {

--- a/packages/clearance/src/safehouseCmux.test.ts
+++ b/packages/clearance/src/safehouseCmux.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -56,6 +56,23 @@ describe(resolveSafehouseCmuxIntegration, () => {
       "/Users/dev/.local/state/cmux",
       "/tmp/cmux-state",
     ]);
+  });
+
+  it("includes cmux-owned Codex hook scripts when their directory exists", () => {
+    const tempHome = mkdtempSync(path.join(tmpdir(), "safehouse-cmux-home-"));
+    const hooksDir = path.join(tempHome, ".cmux", "hooks");
+    try {
+      mkdirSync(hooksDir, { recursive: true });
+
+      const actual = resolveSafehouseCmuxIntegration({
+        env: { HOME: tempHome },
+        readFile: () => "",
+      });
+
+      expect(actual.addDirsReadOnly).toContain(hooksDir);
+    } finally {
+      rmSync(tempHome, { force: true, recursive: true });
+    }
   });
 
   it("prefers XDG_STATE_HOME and dedupes the socket directory", () => {

--- a/packages/clearance/src/safehouseCmux.ts
+++ b/packages/clearance/src/safehouseCmux.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 
 export const SAFEHOUSE_CMUX_ENV_PASS = [
@@ -102,15 +102,22 @@ function resolveCmuxReadOnlyDirs(input: { env: NodeJS.ProcessEnv }): readonly st
   const xdgStateHome = normalizeAbsolutePath({ value: input.env["XDG_STATE_HOME"] });
   const stateDir =
     xdgStateHome === undefined ? homeStateDir({ env: input.env }) : path.join(xdgStateHome, "cmux");
+  const hooksDir = homeHooksDir({ env: input.env });
   const socketPath = normalizeAbsolutePath({ value: input.env["CMUX_SOCKET_PATH"] });
 
   return [
     ...new Set([
       "/Applications/cmux.app",
       ...(stateDir === undefined ? [] : [stateDir]),
+      ...(hooksDir === undefined || !existsSync(hooksDir) ? [] : [hooksDir]),
       ...(socketPath === undefined ? [] : [path.dirname(socketPath)]),
     ]),
   ];
+}
+
+function homeHooksDir(input: { env: NodeJS.ProcessEnv }): string | undefined {
+  const home = normalizeAbsolutePath({ value: input.env["HOME"] });
+  return home === undefined ? undefined : path.join(home, ".cmux", "hooks");
 }
 
 function homeStateDir(input: { env: NodeJS.ProcessEnv }): string | undefined {

--- a/packages/clearance/src/safehouseCmux.ts
+++ b/packages/clearance/src/safehouseCmux.ts
@@ -51,6 +51,7 @@ export interface ResolveSafehouseCmuxIntegrationInput {
 }
 
 export interface SafehouseCmuxIntegration {
+  addDirs: readonly string[];
   addDirsReadOnly: readonly string[];
   claudeCommandPrelude: string;
   envPass: readonly string[];
@@ -69,12 +70,18 @@ export function resolveSafehouseCmuxIntegration(
   const readFile = input.readFile ?? defaultReadFile;
 
   return {
+    addDirs: resolveCmuxWritableDirs({ env }),
     addDirsReadOnly: resolveCmuxReadOnlyDirs({ env }),
     claudeCommandPrelude: SAFEHOUSE_CMUX_CLAUDE_COMMAND_PRELUDE,
     envPass: SAFEHOUSE_CMUX_ENV_PASS,
     isActive: isSafehouseCmuxIntegrationActive({ env }),
     unreviewedEnvNames: resolveUnreviewedCmuxEnvNames({ env, readFile }),
   };
+}
+
+function resolveCmuxWritableDirs(input: { env: NodeJS.ProcessEnv }): readonly string[] {
+  const sentryCacheDir = homeSentryCacheDir({ env: input.env });
+  return sentryCacheDir === undefined || !existsSync(sentryCacheDir) ? [] : [sentryCacheDir];
 }
 
 export function safehouseCmuxIntegrationWarningLines(input: {
@@ -118,6 +125,11 @@ function resolveCmuxReadOnlyDirs(input: { env: NodeJS.ProcessEnv }): readonly st
 function homeHooksDir(input: { env: NodeJS.ProcessEnv }): string | undefined {
   const home = normalizeAbsolutePath({ value: input.env["HOME"] });
   return home === undefined ? undefined : path.join(home, ".cmux", "hooks");
+}
+
+function homeSentryCacheDir(input: { env: NodeJS.ProcessEnv }): string | undefined {
+  const home = normalizeAbsolutePath({ value: input.env["HOME"] });
+  return home === undefined ? undefined : path.join(home, "Library", "Caches", "io.sentry");
 }
 
 function homeStateDir(input: { env: NodeJS.ProcessEnv }): string | undefined {

--- a/packages/clearance/src/safehouseWrapper.test.ts
+++ b/packages/clearance/src/safehouseWrapper.test.ts
@@ -266,19 +266,22 @@ describe("safehouse-claude-proxy wrapper", () => {
 
   it("keeps the cmux claude shim active while pointing it at the real claude binary", async () => {
     const shimRoot = path.join(tempDir, "cmux-cli-shims", "surface-1");
+    const hooksDir = path.join(tempDir, ".cmux", "hooks");
+    mkdirSync(hooksDir, { recursive: true });
     const paths = await runClaudeProxy({
       args: ["--version"],
       env: {
         CMUX_CLAUDE_WRAPPER_SHIM: path.join(shimRoot, "claude"),
         CMUX_CLAUDE_WRAPPER_SHIM_ROOT: shimRoot,
         CMUX_SOCKET_PATH: path.join(tempDir, "cmux.sock"),
+        HOME: tempDir,
       },
       tempDir,
     });
 
     expect(readLines(paths.safehouseArgsPath)).toContain(EXPECTED_CMUX_ENV_PASS_FLAG);
     expect(readLines(paths.safehouseArgsPath)).toContain(
-      `--add-dirs-ro=/Applications/cmux.app:${paths.effectiveHome}/.local/state/cmux:${tempDir}`,
+      `--add-dirs-ro=/Applications/cmux.app:${paths.effectiveHome}/.local/state/cmux:${hooksDir}:${tempDir}`,
     );
     expect(readLines(paths.shimTracePath)).toStrictEqual(["shim"]);
     expect(readLines(paths.claudeCustomPathPath)).toStrictEqual([

--- a/packages/clearance/src/safehouseWrapper.test.ts
+++ b/packages/clearance/src/safehouseWrapper.test.ts
@@ -267,7 +267,9 @@ describe("safehouse-claude-proxy wrapper", () => {
   it("keeps the cmux claude shim active while pointing it at the real claude binary", async () => {
     const shimRoot = path.join(tempDir, "cmux-cli-shims", "surface-1");
     const hooksDir = path.join(tempDir, ".cmux", "hooks");
+    const sentryCacheDir = path.join(tempDir, "Library", "Caches", "io.sentry");
     mkdirSync(hooksDir, { recursive: true });
+    mkdirSync(sentryCacheDir, { recursive: true });
     const paths = await runClaudeProxy({
       args: ["--version"],
       env: {
@@ -280,6 +282,7 @@ describe("safehouse-claude-proxy wrapper", () => {
     });
 
     expect(readLines(paths.safehouseArgsPath)).toContain(EXPECTED_CMUX_ENV_PASS_FLAG);
+    expect(readLines(paths.safehouseArgsPath)).toContain(`--add-dirs=${sentryCacheDir}`);
     expect(readLines(paths.safehouseArgsPath)).toContain(
       `--add-dirs-ro=/Applications/cmux.app:${paths.effectiveHome}/.local/state/cmux:${hooksDir}:${tempDir}`,
     );
@@ -338,6 +341,9 @@ describe("safehouse-claude-proxy wrapper", () => {
     );
     expect(readLines(paths.safehouseArgsPath)).not.toContain(
       expect.stringContaining("--add-dirs-ro=/Applications/cmux.app"),
+    );
+    expect(readLines(paths.safehouseArgsPath)).not.toContain(
+      expect.stringContaining("--add-dirs="),
     );
     expect(readLines(paths.claudeOutputPath)).toStrictEqual([
       "--permission-mode",


### PR DESCRIPTION
## Summary

- grant Safehouse read-only access to cmux-generated Codex hook scripts when `~/.cmux/hooks` exists
- grant Safehouse write access to cmux’s existing `~/Library/Caches/io.sentry` cache so Sentry diagnostics cannot corrupt hook JSON output
- omit nonexistent paths so older and non-Codex cmux setups keep launching normally
- cover path resolution and the final Safehouse wrapper arguments

## Validation

- `npm exec nx -- test clearance --skipRemoteCache` (99 tests)
- `npm exec nx -- run-many -t build lint -p clearance --skipRemoteCache`
- `node --run verify`

### Before

Without access to `~/.cmux/hooks`, every generated hook failed before it could execute:

```text
SessionStart hook (failed)
error: hook exited with code 126

PreToolUse hook (failed)
error: hook exited with code 126

PostToolUse hook (failed)
error: hook exited with code 126

Stop hook (failed)
error: hook exited with code 126
```

After granting read access to the scripts, cmux executed them but contaminated their JSON response with a Sentry cache error:

```text
PreToolUse hook (failed)
error: hook returned invalid pre-tool-use JSON output

PostToolUse hook (failed)
error: hook returned invalid post-tool-use JSON output
```

The minimal reproduction returned `{}` followed by Sentry diagnostics on stdout, causing `jq` to exit 5:

```text
{}
[Sentry] [error] ... Can't create base path ... /Users/davidhuculak/Library/Caches/io.sentry ...
jq: parse error: Invalid numeric literal at line 2, column 8
json_exit=5
```

### After

- the same Safehouse reproduction returned `{}` and exited 0 with the writable Sentry cache grant
- a freshly recreated TG-4273 Groundcrew session on cmux 0.64.22 and Codex 0.146.0 completed SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, and Stop without hook failures
- the agent ran `printf 'hook smoke test\n'` and returned `hook smoke test`

## Notes

Related to [TG-4209](https://linear.app/clipboardhealth/issue/TG-4209/link-cmux-sidebar-task-headings-to-their-linear-issues). Groundcrew must consume the released Clearance version and forward both integration grant lists before the original cmux-link PR is retested.

<sub>🤖 <code>cb-ship:created v1 core@3.23.2</code></sub>