### PR TITLE
feat(usa-states): add toStateCode/toStateCodeSet normalizer (ACT-5861)

### DIFF
--- a/packages/usa-states/README.md
+++ b/packages/usa-states/README.md
@@ -33,13 +33,13 @@ function parseStateCode(value: string): StateCode | undefined {
 }
 
 // Normalize a state name or code (case- and whitespace-insensitive) to a `StateCode`.
-toStateCode("  california ");
+toStateCode({ value: "  california " });
 // => "CA"
-toStateCode("Atlantis");
+toStateCode({ value: "Atlantis" });
 // => undefined
 
 // Normalize a list of names or codes to a `Set<StateCode>`, dropping unknown values.
-toStateCodeSet(["California", "ny", "Atlantis"]);
+toStateCodeSet({ values: ["California", "ny", "Atlantis"] });
 // => Set { "CA", "NY" }
 ```
 

--- a/packages/usa-states/README.md
+++ b/packages/usa-states/README.md
@@ -17,7 +17,13 @@ npm install @clipboard-health/usa-states
 ## Usage
 
 ```ts
-import { isStateCode, type StateCode, US_STATES } from "@clipboard-health/usa-states";
+import {
+  isStateCode,
+  type StateCode,
+  toStateCode,
+  toStateCodeSet,
+  US_STATES,
+} from "@clipboard-health/usa-states";
 
 US_STATES.find((state) => state.code === "CA");
 // => { name: "California", code: "CA" }
@@ -25,6 +31,16 @@ US_STATES.find((state) => state.code === "CA");
 function parseStateCode(value: string): StateCode | undefined {
   return isStateCode(value) ? value : undefined;
 }
+
+// Normalize a state name or code (case- and whitespace-insensitive) to a `StateCode`.
+toStateCode("  california ");
+// => "CA"
+toStateCode("Atlantis");
+// => undefined
+
+// Normalize a list of names or codes to a `Set<StateCode>`, dropping unknown values.
+toStateCodeSet(["California", "ny", "Atlantis"]);
+// => Set { "CA", "NY" }
 ```
 
 ## Local development commands

--- a/packages/usa-states/src/index.ts
+++ b/packages/usa-states/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./lib/isStateCode";
+export * from "./lib/toStateCode";
 export * from "./lib/usStates";

--- a/packages/usa-states/src/lib/toStateCode.test.ts
+++ b/packages/usa-states/src/lib/toStateCode.test.ts
@@ -2,59 +2,59 @@ import { toStateCode, toStateCodeSet } from "./toStateCode";
 
 describe(toStateCode, () => {
   it.each([
-    { input: "California", expected: "CA" },
-    { input: "District of Columbia", expected: "DC" },
-    { input: "New York", expected: "NY" },
-  ])("maps the full name $input to $expected", ({ input, expected }) => {
-    const actual = toStateCode(input);
+    { value: "California", expected: "CA" },
+    { value: "District of Columbia", expected: "DC" },
+    { value: "New York", expected: "NY" },
+  ])("maps the full name $value to $expected", ({ value, expected }) => {
+    const actual = toStateCode({ value });
 
     expect(actual).toBe(expected);
   });
 
   it.each([
-    { input: "CA", expected: "CA" },
-    { input: "NY", expected: "NY" },
-  ])("maps the code $input to $expected", ({ input, expected }) => {
-    const actual = toStateCode(input);
+    { value: "CA", expected: "CA" },
+    { value: "NY", expected: "NY" },
+  ])("maps the code $value to $expected", ({ value, expected }) => {
+    const actual = toStateCode({ value });
 
     expect(actual).toBe(expected);
   });
 
   it.each([
-    { input: "california", expected: "CA" },
-    { input: "NEW YORK", expected: "NY" },
-    { input: "ca", expected: "CA" },
-    { input: "district of columbia", expected: "DC" },
-  ])("is case-insensitive: $input to $expected", ({ input, expected }) => {
-    const actual = toStateCode(input);
+    { value: "california", expected: "CA" },
+    { value: "NEW YORK", expected: "NY" },
+    { value: "ca", expected: "CA" },
+    { value: "district of columbia", expected: "DC" },
+  ])("is case-insensitive: $value to $expected", ({ value, expected }) => {
+    const actual = toStateCode({ value });
 
     expect(actual).toBe(expected);
   });
 
   it.each([
-    { input: "  California  ", expected: "CA" },
-    { input: "\tNY\n", expected: "NY" },
-    { input: " new york ", expected: "NY" },
-  ])("trims surrounding whitespace: $input to $expected", ({ input, expected }) => {
-    const actual = toStateCode(input);
+    { value: "  California  ", expected: "CA" },
+    { value: "\tNY\n", expected: "NY" },
+    { value: " new york ", expected: "NY" },
+  ])("trims surrounding whitespace: $value to $expected", ({ value, expected }) => {
+    const actual = toStateCode({ value });
 
     expect(actual).toBe(expected);
   });
 
   it.each([
-    { input: "North  Dakota", expected: "ND" },
-    { input: "New\tHampshire", expected: "NH" },
-    { input: "District  of\n Columbia", expected: "DC" },
-  ])("collapses interior whitespace: $input to $expected", ({ input, expected }) => {
-    const actual = toStateCode(input);
+    { value: "North  Dakota", expected: "ND" },
+    { value: "New\tHampshire", expected: "NH" },
+    { value: "District  of\n Columbia", expected: "DC" },
+  ])("collapses interior whitespace: $value to $expected", ({ value, expected }) => {
+    const actual = toStateCode({ value });
 
     expect(actual).toBe(expected);
   });
 
   it.each(["", "   ", "zz", "Atlantis", "USA", "C A"])(
     "returns undefined for the unknown value %j",
-    (input) => {
-      const actual = toStateCode(input);
+    (value) => {
+      const actual = toStateCode({ value });
 
       expect(actual).toBeUndefined();
     },
@@ -63,33 +63,33 @@ describe(toStateCode, () => {
 
 describe(toStateCodeSet, () => {
   it("maps a list of names and codes to a Set of codes", () => {
-    const input = ["California", "ny", " Texas "];
+    const values = ["California", "ny", " Texas "];
 
-    const actual = toStateCodeSet(input);
+    const actual = toStateCodeSet({ values });
 
     expect(actual).toStrictEqual(new Set(["CA", "NY", "TX"]));
   });
 
   it("drops unknown values", () => {
-    const input = ["California", "Atlantis", "", "NY"];
+    const values = ["California", "Atlantis", "", "NY"];
 
-    const actual = toStateCodeSet(input);
+    const actual = toStateCodeSet({ values });
 
     expect(actual).toStrictEqual(new Set(["CA", "NY"]));
   });
 
   it("deduplicates names and codes that resolve to the same state", () => {
-    const input = ["California", "ca", "CALIFORNIA"];
+    const values = ["California", "ca", "CALIFORNIA"];
 
-    const actual = toStateCodeSet(input);
+    const actual = toStateCodeSet({ values });
 
     expect(actual).toStrictEqual(new Set(["CA"]));
   });
 
   it("returns an empty Set for an empty list", () => {
-    const input: string[] = [];
+    const values: string[] = [];
 
-    const actual = toStateCodeSet(input);
+    const actual = toStateCodeSet({ values });
 
     expect(actual).toStrictEqual(new Set());
   });

--- a/packages/usa-states/src/lib/toStateCode.test.ts
+++ b/packages/usa-states/src/lib/toStateCode.test.ts
@@ -1,0 +1,96 @@
+import { toStateCode, toStateCodeSet } from "./toStateCode";
+
+describe(toStateCode, () => {
+  it.each([
+    { input: "California", expected: "CA" },
+    { input: "District of Columbia", expected: "DC" },
+    { input: "New York", expected: "NY" },
+  ])("maps the full name $input to $expected", ({ input, expected }) => {
+    const actual = toStateCode(input);
+
+    expect(actual).toBe(expected);
+  });
+
+  it.each([
+    { input: "CA", expected: "CA" },
+    { input: "NY", expected: "NY" },
+  ])("maps the code $input to $expected", ({ input, expected }) => {
+    const actual = toStateCode(input);
+
+    expect(actual).toBe(expected);
+  });
+
+  it.each([
+    { input: "california", expected: "CA" },
+    { input: "NEW YORK", expected: "NY" },
+    { input: "ca", expected: "CA" },
+    { input: "district of columbia", expected: "DC" },
+  ])("is case-insensitive: $input to $expected", ({ input, expected }) => {
+    const actual = toStateCode(input);
+
+    expect(actual).toBe(expected);
+  });
+
+  it.each([
+    { input: "  California  ", expected: "CA" },
+    { input: "\tNY\n", expected: "NY" },
+    { input: " new york ", expected: "NY" },
+  ])("trims surrounding whitespace: $input to $expected", ({ input, expected }) => {
+    const actual = toStateCode(input);
+
+    expect(actual).toBe(expected);
+  });
+
+  it.each([
+    { input: "North  Dakota", expected: "ND" },
+    { input: "New\tHampshire", expected: "NH" },
+    { input: "District  of\n Columbia", expected: "DC" },
+  ])("collapses interior whitespace: $input to $expected", ({ input, expected }) => {
+    const actual = toStateCode(input);
+
+    expect(actual).toBe(expected);
+  });
+
+  it.each(["", "   ", "zz", "Atlantis", "USA", "C A"])(
+    "returns undefined for the unknown value %j",
+    (input) => {
+      const actual = toStateCode(input);
+
+      expect(actual).toBeUndefined();
+    },
+  );
+});
+
+describe(toStateCodeSet, () => {
+  it("maps a list of names and codes to a Set of codes", () => {
+    const input = ["California", "ny", " Texas "];
+
+    const actual = toStateCodeSet(input);
+
+    expect(actual).toStrictEqual(new Set(["CA", "NY", "TX"]));
+  });
+
+  it("drops unknown values", () => {
+    const input = ["California", "Atlantis", "", "NY"];
+
+    const actual = toStateCodeSet(input);
+
+    expect(actual).toStrictEqual(new Set(["CA", "NY"]));
+  });
+
+  it("deduplicates names and codes that resolve to the same state", () => {
+    const input = ["California", "ca", "CALIFORNIA"];
+
+    const actual = toStateCodeSet(input);
+
+    expect(actual).toStrictEqual(new Set(["CA"]));
+  });
+
+  it("returns an empty Set for an empty list", () => {
+    const input: string[] = [];
+
+    const actual = toStateCodeSet(input);
+
+    expect(actual).toStrictEqual(new Set());
+  });
+});

--- a/packages/usa-states/src/lib/toStateCode.ts
+++ b/packages/usa-states/src/lib/toStateCode.ts
@@ -7,12 +7,19 @@ const STATE_CODE_BY_NORMALIZED_NAME: ReadonlyMap<string, StateCode> = new Map(
   US_STATES.map((state) => [normalize(state.name), state.code]),
 );
 
+export interface ToStateCodeInput {
+  /** A state name (e.g. "California") or 2-letter code (e.g. "CA"). */
+  value: string;
+}
+
 /**
  * Maps a state name or code to its canonical {@link StateCode}, case-insensitive
  * and whitespace-insensitive (surrounding trimmed, interior runs collapsed).
  * Returns `undefined` for unrecognized values.
  */
-export function toStateCode(value: string): StateCode | undefined {
+export function toStateCode(input: ToStateCodeInput): StateCode | undefined {
+  const { value } = input;
+
   const code = value.trim().toUpperCase();
   if (isStateCode(code)) {
     return code;
@@ -21,12 +28,19 @@ export function toStateCode(value: string): StateCode | undefined {
   return STATE_CODE_BY_NORMALIZED_NAME.get(normalize(value));
 }
 
+export interface ToStateCodeSetInput {
+  /** State names or 2-letter codes to normalize. */
+  values: readonly string[];
+}
+
 /**
  * Maps a list of state names or codes to a `Set` of canonical {@link StateCode}s,
  * dropping unrecognized values.
  */
-export function toStateCodeSet(values: readonly string[]): Set<StateCode> {
-  return new Set(values.map((value) => toStateCode(value)).filter(isDefined));
+export function toStateCodeSet(input: ToStateCodeSetInput): Set<StateCode> {
+  const { values } = input;
+
+  return new Set(values.map((value) => toStateCode({ value })).filter(isDefined));
 }
 
 function normalize(value: string): string {

--- a/packages/usa-states/src/lib/toStateCode.ts
+++ b/packages/usa-states/src/lib/toStateCode.ts
@@ -1,0 +1,34 @@
+import { isDefined } from "@clipboard-health/util-ts";
+
+import { isStateCode } from "./isStateCode";
+import { type StateCode, US_STATES } from "./usStates";
+
+const STATE_CODE_BY_NORMALIZED_NAME: ReadonlyMap<string, StateCode> = new Map(
+  US_STATES.map((state) => [normalize(state.name), state.code]),
+);
+
+/**
+ * Maps a state name or code to its canonical {@link StateCode}, case-insensitive
+ * and whitespace-insensitive (surrounding trimmed, interior runs collapsed).
+ * Returns `undefined` for unrecognized values.
+ */
+export function toStateCode(value: string): StateCode | undefined {
+  const code = value.trim().toUpperCase();
+  if (isStateCode(code)) {
+    return code;
+  }
+
+  return STATE_CODE_BY_NORMALIZED_NAME.get(normalize(value));
+}
+
+/**
+ * Maps a list of state names or codes to a `Set` of canonical {@link StateCode}s,
+ * dropping unrecognized values.
+ */
+export function toStateCodeSet(values: readonly string[]): Set<StateCode> {
+  return new Set(values.map((value) => toStateCode(value)).filter(isDefined));
+}
+
+function normalize(value: string): string {
+  return value.trim().replaceAll(/\s+/gu, " ").toLowerCase();
+}


### PR DESCRIPTION
Summary
  ===

  What changes were made?
  ---
  - Added `toStateCode(value: string): StateCode | undefined` to `@clipboard-health/usa-states` — a pure helper that
  normalizes a state **name or code** to its canonical USPS `StateCode`. Case-insensitive and whitespace-insensitive:
  surrounding whitespace is trimmed and interior whitespace runs are collapsed to a single space. Returns `undefined`
  for unrecognized values.
  - Added `toStateCodeSet(values: readonly string[]): Set<StateCode>` — maps a list of names/codes to a
  `Set<StateCode>`, dropping unknowns and deduplicating.
  - Built on the existing `US_STATES` + `isStateCode` primitives (name lookup via a normalized-name `Map`, code path
  via `isStateCode`); no framework dependencies.
  - Exported both functions from the package index (`src/index.ts`).
  - Added 25 unit tests in `toStateCode.test.ts` covering full names, codes, mixed case, surrounding whitespace,
  interior-whitespace collapsing, unknown-dropped, empty input, and dedup.
  - Documented both helpers with usage examples in the package README.

  Why were these changes made
  ---
  - **ACT-5861.** `documents-service-backend` (`normalizeStateCode`), `cbh-mobile-app` (`useNlcStates`), and the
  incoming admin NLC-state marker (`useNlcStateCodes`) each hand-roll "state name → USPS code" normalization
  independently. That case/whitespace drift is exactly what silently broke NLC compact matching (full names vs.
  2-letter codes).
  - A single shared, pure normalizer in the package that already owns `US_STATES` removes the duplication and the
  drift risk. ACT-5862 (admin) and the mobile hook can now drop their local mappings and adopt this helper.
  - Interior-whitespace collapsing was added deliberately to match the admin's `normalizeStateValue` (the copy
  ACT-5862 replaces), making the helper a strict superset of all three copies being consolidated so migration can't
  regress multi-word state names (e.g. `"North  Dakota"`).

  Notes
  ===

  Checklist :heavy_check_mark:
  ---
  - [x] I have added tests that prove my fix is effective or that my feature works.
  - [ ] I have added necessary documentation (if appropriate).

  Screenshots/Video :camera:
  ---
  - No UI changes — pure library helper + tests. 25 tests passing for `toStateCode`/`toStateCodeSet` covering names,
  codes, mixed case, surrounding + interior whitespace, unknown-dropped, empty, and dedup. Typecheck, ESLint, Oxlint,
  and cspell all pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/clipboardhealth/core-utils/pull/832" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->