### PR TITLE
feat(usa-states): add toStateName canonical name resolver (ACT-5928)

### DIFF
--- a/packages/usa-states/README.md
+++ b/packages/usa-states/README.md
@@ -20,8 +20,10 @@ npm install @clipboard-health/usa-states
 import {
   isStateCode,
   type StateCode,
+  type StateName,
   toStateCode,
   toStateCodeSet,
+  toStateName,
   US_STATES,
 } from "@clipboard-health/usa-states";
 
@@ -41,6 +43,18 @@ toStateCode({ value: "Atlantis" });
 // Normalize a list of names or codes to a `Set<StateCode>`, dropping unknown values.
 toStateCodeSet({ values: ["California", "ny", "Atlantis"] });
 // => Set { "CA", "NY" }
+
+// Normalize a state name or code (case- and whitespace-insensitive) to a canonical `StateName`.
+toStateName({ value: "  california " });
+// => "California"
+toStateName({ value: "ca" });
+// => "California"
+toStateName({ value: "Atlantis" });
+// => undefined
+
+function formatState(name: StateName): string {
+  return `The great state of ${name}`;
+}
 ```
 
 ## Local development commands

--- a/packages/usa-states/README.md
+++ b/packages/usa-states/README.md
@@ -1,6 +1,6 @@
 # @clipboard-health/usa-states <!-- omit from toc -->
 
-Canonical US state and territory list and `StateCode` type.
+Canonical US state and territory list, `StateCode` and `StateName` types, and name/code normalizers.
 
 ## Table of contents <!-- omit from toc -->
 
@@ -52,10 +52,21 @@ toStateName({ value: "ca" });
 toStateName({ value: "Atlantis" });
 // => undefined
 
-function formatState(name: StateName): string {
-  return `The great state of ${name}`;
+interface LabelInput {
+  name: StateName;
+}
+
+function toLabel(input: LabelInput): string {
+  const { name } = input;
+
+  return `Licensed in ${name}`;
 }
 ```
+
+Prefer storing `StateCode` and resolving to `StateName` only for display; codes are the stable
+representation to compare across services. Both normalizers return `undefined` for unrecognized
+input — treat that as a validation failure rather than falling back to the raw value, otherwise
+unnormalized input reaches storage.
 
 ## Local development commands
 

--- a/packages/usa-states/package.json
+++ b/packages/usa-states/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@clipboard-health/usa-states",
   "version": "1.1.0",
-  "description": "Canonical US state and territory list and StateCode type.",
+  "description": "Canonical US state and territory list, StateCode and StateName types, and name/code normalizers.",
   "keywords": [],
   "bugs": "https://github.com/ClipboardHealth/core-utils/issues",
   "license": "MIT",

--- a/packages/usa-states/src/index.ts
+++ b/packages/usa-states/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./lib/isStateCode";
 export * from "./lib/toStateCode";
+export * from "./lib/toStateName";
 export * from "./lib/usStates";

--- a/packages/usa-states/src/lib/toStateName.test.ts
+++ b/packages/usa-states/src/lib/toStateName.test.ts
@@ -1,0 +1,70 @@
+import { toStateName } from "./toStateName";
+import { US_STATES } from "./usStates";
+
+describe(toStateName, () => {
+  it.each([
+    { value: "California", expected: "California" },
+    { value: "District of Columbia", expected: "District of Columbia" },
+    { value: "New York", expected: "New York" },
+  ])("maps the full name $value to $expected", ({ value, expected }) => {
+    const actual = toStateName({ value });
+
+    expect(actual).toBe(expected);
+  });
+
+  it.each([
+    { value: "CA", expected: "California" },
+    { value: "NY", expected: "New York" },
+    { value: "DC", expected: "District of Columbia" },
+  ])("maps the code $value to $expected", ({ value, expected }) => {
+    const actual = toStateName({ value });
+
+    expect(actual).toBe(expected);
+  });
+
+  it.each([
+    { value: "california", expected: "California" },
+    { value: "NEW YORK", expected: "New York" },
+    { value: "ca", expected: "California" },
+    { value: "district Of columbia", expected: "District of Columbia" },
+  ])("is case-insensitive: $value to $expected", ({ value, expected }) => {
+    const actual = toStateName({ value });
+
+    expect(actual).toBe(expected);
+  });
+
+  it.each([
+    { value: "  California  ", expected: "California" },
+    { value: "\tNY\n", expected: "New York" },
+    { value: " new york ", expected: "New York" },
+  ])("trims surrounding whitespace: $value to $expected", ({ value, expected }) => {
+    const actual = toStateName({ value });
+
+    expect(actual).toBe(expected);
+  });
+
+  it.each([
+    { value: "North  Dakota", expected: "North Dakota" },
+    { value: "New\tHampshire", expected: "New Hampshire" },
+    { value: "District  of\n Columbia", expected: "District of Columbia" },
+  ])("collapses interior whitespace: $value to $expected", ({ value, expected }) => {
+    const actual = toStateName({ value });
+
+    expect(actual).toBe(expected);
+  });
+
+  it.each(["", "   ", "zz", "Atlantis", "USA", "C A"])(
+    "returns undefined for the unknown value %j",
+    (value) => {
+      const actual = toStateName({ value });
+
+      expect(actual).toBeUndefined();
+    },
+  );
+
+  it.each(US_STATES)("resolves both the name and the code of $name to $name", ({ name, code }) => {
+    const actual = [toStateName({ value: name }), toStateName({ value: code })];
+
+    expect(actual).toStrictEqual([name, name]);
+  });
+});

--- a/packages/usa-states/src/lib/toStateName.ts
+++ b/packages/usa-states/src/lib/toStateName.ts
@@ -1,0 +1,26 @@
+import { isDefined } from "@clipboard-health/util-ts";
+
+import { toStateCode } from "./toStateCode";
+import { type StateCode, type StateName, US_STATES } from "./usStates";
+
+const STATE_NAME_BY_CODE: ReadonlyMap<StateCode, StateName> = new Map(
+  US_STATES.map((state) => [state.code, state.name]),
+);
+
+export interface ToStateNameInput {
+  /** A state name (e.g. "California") or 2-letter code (e.g. "CA"). */
+  value: string;
+}
+
+/**
+ * Maps a state name or code to its canonical {@link StateName}, case-insensitive
+ * and whitespace-insensitive (surrounding trimmed, interior runs collapsed).
+ * Returns `undefined` for unrecognized values.
+ */
+export function toStateName(input: ToStateNameInput): StateName | undefined {
+  const { value } = input;
+
+  const code = toStateCode({ value });
+
+  return isDefined(code) ? STATE_NAME_BY_CODE.get(code) : undefined;
+}

--- a/packages/usa-states/src/lib/usStates.test.ts
+++ b/packages/usa-states/src/lib/usStates.test.ts
@@ -1,4 +1,4 @@
-import { type StateCode, US_STATES } from "./usStates";
+import { type StateCode, type StateName, US_STATES } from "./usStates";
 
 const TERRITORY_CODES = ["AS", "FM", "GU", "MH", "MP", "PR", "PW", "VI"] as const;
 
@@ -47,6 +47,14 @@ describe("US_STATES", () => {
     const code: StateCode = "CA";
 
     const actual = US_STATES.some((state) => state.code === code);
+
+    expect(actual).toBe(true);
+  });
+
+  it("derives a StateName literal type from the name field", () => {
+    const name: StateName = "California";
+
+    const actual = US_STATES.some((state) => state.name === name);
 
     expect(actual).toBe(true);
   });

--- a/packages/usa-states/src/lib/usStates.ts
+++ b/packages/usa-states/src/lib/usStates.ts
@@ -67,6 +67,8 @@ export const US_STATES = deepFreeze(RAW_US_STATES);
 
 export type StateCode = (typeof US_STATES)[number]["code"];
 
+export type StateName = (typeof US_STATES)[number]["name"];
+
 export interface UsState {
   name: string;
   code: StateCode;


### PR DESCRIPTION
Summary
===

What changes were made?
---

- Added `toStateName({ value }): StateName | undefined` to `@clipboard-health/usa-states` — the name-side counterpart to `toStateCode`. It accepts a full state name **or** a 2-letter code, is case-insensitive and whitespace-insensitive (surrounding whitespace trimmed, interior runs collapsed), and returns the single canonical name string. Unknown values return `undefined` (drop semantics, matching `toStateCode`).
- Implemented on the existing primitives — `toStateCode` followed by a code→name lookup — so the two resolvers can never disagree about what a value means.
- Added a `StateName` literal union type derived from `US_STATES[number]["name"]`, mirroring `StateCode`. Derived, not hand-maintained.
- Exported both from the package index.
- Added 59 unit tests in `toStateName.test.ts` (full names, codes, mixed case, surrounding whitespace, interior whitespace collapsing, unknown-dropped, empty) plus an exhaustive case asserting every entry in `US_STATES` resolves from both its own name and its code, and a `StateName` literal-type test alongside the existing `StateCode` one.
- Documented the helper and the type with usage examples in the package README.

Why were these changes made
---

- **ACT-5928.** Any consumer that compares state **names** rather than codes breaks the moment a producer's capitalization differs by one letter, because the package offered no way to resolve a name to its canonical form. `documents-service-backend`'s `requirement-mappings.service.ts#validateInput` does exact-string matching against `US_STATES[].name` for STATE-level `requiredBy`, which is why `Federated States Of Micronesia` vs `…of…` turns into a hard `INVALID_STATE` rejection on a live admin flow (ACT-5927).
- Correcting a single canonical spelling fixes one instance; a resolver removes the class. Any producer capitalization becomes acceptable and every consumer converges on one string to display and store.
- ACT-5861 added `toStateCode`/`toStateCodeSet`; this is the missing name-side half. It independently unblocks ACT-5779 (documents-service-backend migration) — with either this or ACT-5927 landed, the backend's STATE-level validation stops rejecting the admin dropdown's value.

Notes
---

- **`UsState.name` left as `string`.** Narrowing it to the new `StateName` union would be a breaking type change for external consumers who construct their own `UsState` values, which doesn't belong in a `feat` minor. `US_STATES` entries still carry the literal types regardless, so `StateName` is exact where it matters.
- **No `toStateNameSet`.** `toStateCodeSet` exists because callers need to dedupe codes for membership checks; no consumer needs a set of names today. Easy to add later if one does.
- **Micronesia spelling untouched** — that decision belongs to ACT-5927 and lands independently. Once this ships, that spelling stops being load-bearing for validation either way.
- Consumer follow-up worth considering separately: have `documents-service-backend` **store** the resolved canonical name rather than the raw input, so stored `requiredBy` values stop varying by whatever the client sent.

Checklist :heavy_check_mark:
---

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate).

Screenshots/Video :camera:
---

No UI changes — pure library helper, type, and tests. 243 tests pass for the package (59 new for `toStateName`, plus the `StateName` type test); `nx run-many --targets build,lint,test --projects usa-states` and `node --run verify` (architecture:check, cpd, embed:check, format:check, knip, lint, markdown:lint, syncpack:lint) all pass.

Closes act-5928
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/clipboardhealth/core-utils/pull/834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->