### PR TITLE
docs(usa-states): correct the inverted Micronesia comment (ACT-5927)

### DIFF
--- a/packages/usa-states/src/lib/usStates.test.ts
+++ b/packages/usa-states/src/lib/usStates.test.ts
@@ -37,6 +37,12 @@ describe("US_STATES", () => {
     expect(actual).toContainEqual({ name: "District of Columbia", code: "DC" });
   });
 
+  it('spells Micronesia with a lowercase "of"', () => {
+    const actual = US_STATES;
+
+    expect(actual).toContainEqual({ name: "Federated States of Micronesia", code: "FM" });
+  });
+
   it.each(TERRITORY_CODES)("includes the territory with code %s", (code) => {
     const actual = US_STATES.some((state) => state.code === code);
 

--- a/packages/usa-states/src/lib/usStates.ts
+++ b/packages/usa-states/src/lib/usStates.ts
@@ -11,7 +11,9 @@ const RAW_US_STATES = [
   { name: "Connecticut", code: "CT" },
   { name: "Delaware", code: "DE" },
   { name: "District of Columbia", code: "DC" },
-  // Lowercase "of" matches cbh-mobile-app and documents-service-backend; don't "correct" to cbh-admin-frontend's capitalized variant, which is the outlier.
+  // Lowercase "of" is the official English spelling and is consistent with "District of Columbia"
+  // above. Some consumers still hold a capitalized "Of" variant; match names through `toStateCode`
+  // or `toStateName` rather than by exact string.
   { name: "Federated States of Micronesia", code: "FM" },
   { name: "Florida", code: "FL" },
   { name: "Georgia", code: "GA" },


### PR DESCRIPTION
Summary
===

> **Direction changed after review.** This PR originally renamed the `FM` entry to `Federated States Of Micronesia` (capital "Of") to match the majority of the hand-maintained copies. @poldridge pointed out that only **one non-archived requirement mapping and one worker license** actually hold the capitalized variant — so the data-migration cost that justified adopting the minority-correct spelling is two records, not a backfill. The package now keeps the correct lowercase `of`, and the drift is resolved at the consumers instead.

What changes were made?
---
- Corrected the inverted comment above the `FM` entry in `packages/usa-states/src/lib/usStates.ts`. It claimed lowercase `of` matched `cbh-mobile-app` and `documents-service-backend` and that `cbh-admin-frontend` was the outlier — the reverse is true.
- Added a regression test pinning the spelling, so it is not "corrected" again in either direction.
- **No change to the exported data.** `US_STATES` is byte-identical to `main`, so no republish is required and `StateCode`, `StateName`, and every consumer type are unaffected.

Why were these changes made
---
- ACT-5927. `documents-service-backend`'s `requirement-mappings.service.ts#validateInput` validates STATE-level `requiredBy` with an exact-string membership check, while the admin dropdown emits `Federated States Of Micronesia`. Once that service swaps its local list for this package (ACT-5779), Micronesia would return `INVALID_STATE` on create and update.
- Lowercase `of` is the official English name and is consistent with `District of Columbia` in the same list. Baking a capitalized variant into a brand-new canonical source would make the list internally inconsistent for every future consumer, permanently, to avoid updating two rows once.
- Fixing it at the consumer is also strictly more general: routing `validateInput` through `toStateCode` (case-insensitive, already shipped in 1.1.0) protects all 59 names from casing drift rather than just this one.

Follow-ups (not in this PR)
---
- `documents-service-backend`: replace the exact-string membership check with `toStateCode` — folds into ACT-5779.
- Update the one requirement mapping and one worker license holding the capitalized variant.
- `cbh-mobile-app` / `cbh-admin-frontend`: the copies holding capital `Of` retire against the canonical lowercase list — ACT-5778, ACT-5780, ACT-5929.

Notes
===

Checklist :heavy_check_mark:
---
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).

Screenshots/Video :camera:
---
- No UI changes and no data changes — a corrected source comment plus a regression test. 244 tests pass across 4 files in `packages/usa-states`; `node --run verify` passes all 8 checks.
