### PR TITLE
fix: fail fast on Cognito OTP rejection (STAFF-2131)

### DIFF
--- a/packages/playwright-toolkit/src/lib/cognitoDiagnostics.test.ts
+++ b/packages/playwright-toolkit/src/lib/cognitoDiagnostics.test.ts
@@ -1,3 +1,4 @@
+import { isNil, toError } from "@clipboard-health/util-ts";
 import type { Page, Request, Response, TestInfo } from "@playwright/test";
 
 import {
@@ -56,6 +57,37 @@ describe("Cognito diagnostics", () => {
     expect(mockFill).toHaveBeenCalledWith("123456");
   });
 
+  it("continues waiting for the redirect after a successful Cognito response", async () => {
+    const listeners = new Map<string, (value: Request | Response) => Promise<void> | void>();
+    const redirect = createDeferredPromise();
+    const mockRequest = createMockPlaywrightRequest();
+    const mockResponse = {
+      request: () => mockRequest,
+      status: () => 200,
+      statusText: () => "OK",
+      text: async () => await Promise.resolve('{"AuthenticationResult":"secret-token"}'),
+    } as unknown as Response;
+    const mockPage = createMockPage({
+      listeners,
+      waitForUrl: async () => {
+        await redirect.promise;
+      },
+    });
+
+    const actualPromise = fillOtpAndWaitForCognitoRedirect({
+      expectedUrl: /dashboard/,
+      otp: "123456",
+      page: mockPage,
+    });
+
+    await getListener({ eventName: "response", listeners })(mockResponse);
+    redirect.resolve();
+
+    await expect(actualPromise).resolves.toEqual({
+      redirectUrl: "https://app.example.test/dashboard",
+    });
+  });
+
   it("attaches sanitized Cognito response diagnostics when redirect fails", async () => {
     const listeners = new Map<string, (value: Request | Response) => Promise<void> | void>();
     const mockRequest = createMockPlaywrightRequest();
@@ -92,6 +124,66 @@ describe("Cognito diagnostics", () => {
       "cognito-otp-diagnostics",
       expect.objectContaining({ contentType: "image/png" }),
     );
+  });
+
+  it("fails without waiting for the redirect after a terminal Cognito response", async () => {
+    const listeners = new Map<string, (value: Request | Response) => Promise<void> | void>();
+    const mockRequest = createMockPlaywrightRequest();
+    const mockResponse = {
+      request: () => mockRequest,
+      status: () => 400,
+      statusText: () => "Bad Request",
+      text: async () => await Promise.resolve('{"message":"CodeMismatchException"}'),
+    } as unknown as Response;
+    const mockPage = createMockPage({
+      listeners,
+      waitForUrl: async () => {
+        await createNeverSettlingPromise();
+      },
+    });
+
+    const actualPromise = fillOtpAndWaitForCognitoRedirect({
+      expectedUrl: /dashboard/,
+      otp: "123456",
+      page: mockPage,
+      expectedUrlTimeoutMs: 10,
+    });
+    const actualErrorPromise = captureError({ promise: actualPromise });
+
+    await getListener({ eventName: "response", listeners })(mockResponse);
+
+    const actualError = await actualErrorPromise;
+    expect(actualError.message).toContain("status=400 Bad Request");
+  });
+
+  it("fails without waiting for the redirect after a Cognito request failure", async () => {
+    const listeners = new Map<string, (value: Request | Response) => Promise<void> | void>();
+    const sensitiveEmail = "sensitive-user@example.test";
+    const sensitiveOtp = "12345678";
+    const mockRequest = createMockPlaywrightRequest({
+      failureText: `request failed for ${sensitiveEmail} with code=${sensitiveOtp}`,
+    });
+    const mockPage = createMockPage({
+      listeners,
+      waitForUrl: async () => {
+        await createNeverSettlingPromise();
+      },
+    });
+
+    const actualPromise = fillOtpAndWaitForCognitoRedirect({
+      expectedUrl: /dashboard/,
+      otp: sensitiveOtp,
+      page: mockPage,
+      expectedUrlTimeoutMs: 10,
+    });
+    const actualErrorPromise = captureError({ promise: actualPromise });
+
+    await getListener({ eventName: "requestfailed", listeners })(mockRequest);
+
+    const actualError = await actualErrorPromise;
+    expect(actualError.message).toContain('failureText="request failed for [redacted-email]');
+    expect(actualError.message).not.toContain(sensitiveEmail);
+    expect(actualError.message).not.toContain(sensitiveOtp);
   });
 
   it("redacts the final redirect error, URL path, and retained cause", async () => {
@@ -160,9 +252,11 @@ function createMockPage(params: {
   } as unknown as Page;
 }
 
-function createMockPlaywrightRequest(): Request {
+function createMockPlaywrightRequest(params: { failureText?: string } = {}): Request {
   return {
-    failure: vi.fn<() => null>(() => null),
+    failure: vi.fn<() => { errorText: string } | null>(() =>
+      params.failureText === undefined ? null : { errorText: params.failureText },
+    ),
     headers: vi.fn<() => Record<string, string>>(() => ({
       "x-amz-target": "AWSCognitoIdentityProviderService.RespondToAuthChallenge",
     })),
@@ -186,4 +280,38 @@ function getListener(params: {
   }
 
   return listener;
+}
+
+function createDeferredPromise(): { promise: Promise<void>; resolve(): void } {
+  let resolvePromise: (() => void) | undefined;
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  return {
+    promise,
+    resolve() {
+      if (isNil(resolvePromise)) {
+        throw new Error("Deferred promise was not initialized");
+      }
+
+      resolvePromise();
+    },
+  };
+}
+
+async function createNeverSettlingPromise(): Promise<never> {
+  return await new Promise<never>((resolve) => {
+    void resolve;
+  });
+}
+
+async function captureError(params: { promise: Promise<unknown> }): Promise<Error> {
+  try {
+    await params.promise;
+  } catch (error: unknown) {
+    return toError(error);
+  }
+
+  throw new Error("Expected promise to reject");
 }

--- a/packages/playwright-toolkit/src/lib/cognitoDiagnostics.test.ts
+++ b/packages/playwright-toolkit/src/lib/cognitoDiagnostics.test.ts
@@ -317,6 +317,7 @@ async function captureError(params: { promise: Promise<unknown> }): Promise<Erro
 
 async function expectPromiseToRemainPending(params: { promise: Promise<unknown> }): Promise<void> {
   const state = await Promise.race([
+    // eslint-disable-next-line promise/prefer-await-to-then -- Observing settlement without awaiting is the behavior under test.
     params.promise.then(
       () => "resolved" as const,
       () => "rejected" as const,

--- a/packages/playwright-toolkit/src/lib/cognitoDiagnostics.test.ts
+++ b/packages/playwright-toolkit/src/lib/cognitoDiagnostics.test.ts
@@ -81,6 +81,7 @@ describe("Cognito diagnostics", () => {
     });
 
     await getListener({ eventName: "response", listeners })(mockResponse);
+    await expectPromiseToRemainPending({ promise: actualPromise });
     redirect.resolve();
 
     await expect(actualPromise).resolves.toEqual({
@@ -128,6 +129,7 @@ describe("Cognito diagnostics", () => {
 
   it("fails without waiting for the redirect after a terminal Cognito response", async () => {
     const listeners = new Map<string, (value: Request | Response) => Promise<void> | void>();
+    const redirect = createDeferredPromise();
     const mockRequest = createMockPlaywrightRequest();
     const mockResponse = {
       request: () => mockRequest,
@@ -138,7 +140,7 @@ describe("Cognito diagnostics", () => {
     const mockPage = createMockPage({
       listeners,
       waitForUrl: async () => {
-        await createNeverSettlingPromise();
+        await redirect.promise;
       },
     });
 
@@ -154,10 +156,12 @@ describe("Cognito diagnostics", () => {
 
     const actualError = await actualErrorPromise;
     expect(actualError.message).toContain("status=400 Bad Request");
+    redirect.resolve();
   });
 
   it("fails without waiting for the redirect after a Cognito request failure", async () => {
     const listeners = new Map<string, (value: Request | Response) => Promise<void> | void>();
+    const redirect = createDeferredPromise();
     const sensitiveEmail = "sensitive-user@example.test";
     const sensitiveOtp = "12345678";
     const mockRequest = createMockPlaywrightRequest({
@@ -166,7 +170,7 @@ describe("Cognito diagnostics", () => {
     const mockPage = createMockPage({
       listeners,
       waitForUrl: async () => {
-        await createNeverSettlingPromise();
+        await redirect.promise;
       },
     });
 
@@ -184,6 +188,7 @@ describe("Cognito diagnostics", () => {
     expect(actualError.message).toContain('failureText="request failed for [redacted-email]');
     expect(actualError.message).not.toContain(sensitiveEmail);
     expect(actualError.message).not.toContain(sensitiveOtp);
+    redirect.resolve();
   });
 
   it("redacts the final redirect error, URL path, and retained cause", async () => {
@@ -300,12 +305,6 @@ function createDeferredPromise(): { promise: Promise<void>; resolve(): void } {
   };
 }
 
-async function createNeverSettlingPromise(): Promise<never> {
-  return await new Promise<never>((resolve) => {
-    void resolve;
-  });
-}
-
 async function captureError(params: { promise: Promise<unknown> }): Promise<Error> {
   try {
     await params.promise;
@@ -314,4 +313,16 @@ async function captureError(params: { promise: Promise<unknown> }): Promise<Erro
   }
 
   throw new Error("Expected promise to reject");
+}
+
+async function expectPromiseToRemainPending(params: { promise: Promise<unknown> }): Promise<void> {
+  const state = await Promise.race([
+    params.promise.then(
+      () => "resolved" as const,
+      () => "rejected" as const,
+    ),
+    Promise.resolve("pending" as const),
+  ]);
+
+  expect(state).toBe("pending");
 }

--- a/packages/playwright-toolkit/src/lib/cognitoDiagnostics.ts
+++ b/packages/playwright-toolkit/src/lib/cognitoDiagnostics.ts
@@ -81,7 +81,10 @@ export async function fillOtpAndWaitForCognitoRedirect(
   }
 
   try {
-    await params.page.waitForURL(params.expectedUrl, { timeout: timeoutMs });
+    await Promise.race([
+      params.page.waitForURL(params.expectedUrl, { timeout: timeoutMs }),
+      waitForTerminalCognitoChallengeFailure({ attemptPromise: monitor.result }),
+    ]);
     monitor.dispose();
     return { redirectUrl: params.page.url() };
   } catch (error: unknown) {
@@ -154,6 +157,23 @@ export function sanitizeCognitoDiagnosticText(params: { text: string }): string 
     .replaceAll(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[redacted-email]")
     .replaceAll(/\+?\d[\d\s().-]{5,}\d/g, "[redacted-number]")
     .replaceAll(/\b\d{4,}\b/g, "[redacted-number]");
+}
+
+async function waitForTerminalCognitoChallengeFailure(params: {
+  attemptPromise: Promise<CognitoChallengeAttempt>;
+}): Promise<never> {
+  const attempt = await params.attemptPromise;
+
+  if (
+    attempt.type === "not-observed" ||
+    (attempt.type === "response" && attempt.status >= 200 && attempt.status < 300)
+  ) {
+    return await new Promise<never>((resolve) => {
+      void resolve;
+    });
+  }
+
+  throw new Error(`Terminal Cognito OTP challenge failure: ${formatAttempt(attempt)}`);
 }
 
 function createCognitoChallengeMonitor(params: {

--- a/packages/playwright-toolkit/src/lib/mailpit.test.ts
+++ b/packages/playwright-toolkit/src/lib/mailpit.test.ts
@@ -36,6 +36,19 @@ describe("Mailpit polling", () => {
     expect(actual).toEqual({
       value: "https://app.test/v2/email-login-link?payload=old",
       messageId: "old",
+      messageCreatedAt: "2026-07-16T11:00:00.000Z",
+      pollingDiagnostics: {
+        searchAttempts: 1,
+        rawResultCount: 2,
+        postSentAfterCandidateCount: 2,
+        invalidOrMissingTimestampCount: 0,
+        fetchedMessageCount: 2,
+        extractionMissCount: 0,
+        excludedValueCount: 1,
+        transientRequestErrorCount: 0,
+        transientRequestErrorStatuses: [],
+        newestCandidateTimestamp: "2026-07-16T12:00:00.000Z",
+      },
     });
   });
 
@@ -58,7 +71,23 @@ describe("Mailpit polling", () => {
       timeoutMs: 1000,
     });
 
-    expect(actual).toEqual({ value: "81027033", messageId: "otp" });
+    expect(actual).toEqual({
+      value: "81027033",
+      messageId: "otp",
+      messageCreatedAt: "2026-07-16T12:00:00.000Z",
+      pollingDiagnostics: {
+        searchAttempts: 1,
+        rawResultCount: 1,
+        postSentAfterCandidateCount: 1,
+        invalidOrMissingTimestampCount: 0,
+        fetchedMessageCount: 1,
+        extractionMissCount: 0,
+        excludedValueCount: 0,
+        transientRequestErrorCount: 0,
+        transientRequestErrorStatuses: [],
+        newestCandidateTimestamp: "2026-07-16T12:00:00.000Z",
+      },
+    });
   });
 
   it("uses authenticated Mailpit HTTP search and message endpoints", async () => {

--- a/packages/playwright-toolkit/src/lib/mailpit.ts
+++ b/packages/playwright-toolkit/src/lib/mailpit.ts
@@ -44,9 +44,24 @@ export interface CreateMailpitClientParams {
   requestTimeoutMs?: number | undefined;
 }
 
+export interface MailpitPollingDiagnostics {
+  searchAttempts: number;
+  rawResultCount: number;
+  postSentAfterCandidateCount: number;
+  invalidOrMissingTimestampCount: number;
+  fetchedMessageCount: number;
+  extractionMissCount: number;
+  excludedValueCount: number;
+  transientRequestErrorCount: number;
+  transientRequestErrorStatuses: string[];
+  newestCandidateTimestamp: string | undefined;
+}
+
 export interface FetchMailpitValueResult {
   value: string;
   messageId: string;
+  messageCreatedAt: string | undefined;
+  pollingDiagnostics: MailpitPollingDiagnostics;
 }
 
 export interface FetchMailpitValueParams {
@@ -215,7 +230,11 @@ export async function fetchMailpitValue(
           const cachedValue = valuesByMessageId.get(message.ID);
 
           if (cachedValue !== undefined && !excludedValues.has(cachedValue)) {
-            return { value: cachedValue, messageId: message.ID };
+            return createFetchMailpitValueResult({
+              message,
+              pollingSnapshot,
+              value: cachedValue,
+            });
           }
 
           continue;
@@ -235,7 +254,7 @@ export async function fetchMailpitValue(
           } else if (excludedValues.has(value)) {
             pollingSnapshot.excludedValueCount += 1;
           } else {
-            return { value, messageId: message.ID };
+            return createFetchMailpitValueResult({ message, pollingSnapshot, value });
           }
         } catch (error: unknown) {
           if (!isTransientMailpitError({ error })) {
@@ -497,6 +516,37 @@ function createMailpitPollingSnapshot(): MailpitPollingSnapshot {
     transientRequestErrorCount: 0,
     transientRequestErrorStatuses: new Set(),
     newestCandidateTimestampMs: undefined,
+  };
+}
+
+function createFetchMailpitValueResult(params: {
+  message: MailpitMessageSummary;
+  pollingSnapshot: MailpitPollingSnapshot;
+  value: string;
+}): FetchMailpitValueResult {
+  const messageTimestampMs = getMailpitMessageTimestampMs({ message: params.message });
+  const newestCandidateTimestampMs = params.pollingSnapshot.newestCandidateTimestampMs;
+
+  return {
+    value: params.value,
+    messageId: params.message.ID,
+    messageCreatedAt:
+      messageTimestampMs === undefined ? undefined : new Date(messageTimestampMs).toISOString(),
+    pollingDiagnostics: {
+      searchAttempts: params.pollingSnapshot.searchAttempts,
+      rawResultCount: params.pollingSnapshot.rawResultCount,
+      postSentAfterCandidateCount: params.pollingSnapshot.postSentAfterCandidateCount,
+      invalidOrMissingTimestampCount: params.pollingSnapshot.invalidOrMissingTimestampCount,
+      fetchedMessageCount: params.pollingSnapshot.fetchedMessageCount,
+      extractionMissCount: params.pollingSnapshot.extractionMissCount,
+      excludedValueCount: params.pollingSnapshot.excludedValueCount,
+      transientRequestErrorCount: params.pollingSnapshot.transientRequestErrorCount,
+      transientRequestErrorStatuses: [...params.pollingSnapshot.transientRequestErrorStatuses],
+      newestCandidateTimestamp:
+        newestCandidateTimestampMs === undefined
+          ? undefined
+          : new Date(newestCandidateTimestampMs).toISOString(),
+    },
   };
 }
 


### PR DESCRIPTION
## Why

The Cognito email OTP resend test can receive a terminal `RespondToAuthChallenge` rejection while the shared helper continues waiting for a redirect that cannot happen. That adds up to 60 seconds of avoidable failure latency and leaves successful Mailpit selection provenance unavailable. There is no direct customer impact; this improves CI failure latency and makes a rare staging authentication failure diagnosable without exposing credentials or user identifiers.

## Summary

- Race the expected redirect against the monitored Cognito challenge and fail promptly on non-2xx responses or network failures.
- Preserve the existing sanitized method/host/path/status/error diagnostics and continue waiting after successful challenges.
- Return the selected Mailpit timestamp and bounded cumulative polling counts/rejection counters on successful selection.
- Add deterministic tests for success plus redirect, terminal 400 fault injection, request failure, privacy redaction, and successful Mailpit provenance.

## Validation

- `npm exec nx -- run-many -t test,build,lint -p playwright-toolkit --parallel=3 --outputStyle=static`
- `node --run verify`
- Pre-push verification hook: all checks passed

## Notes

- Closes [STAFF-2131](https://linear.app/clipboardhealth/issue/STAFF-2131/2f2d5a1b91fb-flaky-test-cognito-email-otp-login-desktop-resending-the).
- Investigation: [STAFF-2124](https://linear.app/clipboardhealth/issue/STAFF-2124/2f2d5a1b91fb-flaky-test-cognito-email-otp-login-desktop-resending-the).
- Test ID: `3cfebe2c240020a3`; Datadog attempt-to-fix ID refetched immediately before the fixing commit: `YY3ZBT`.
- The terminal `CodeMismatchException` cause remains intentionally unresolved; this change adds observability and removes known diagnostic delay without retries, timeout increases, assertion weakening, or additional Cognito calls.
- Consumer: [cbh-admin-frontend#8002](https://github.com/ClipboardHealth/cbh-admin-frontend/pull/8002), which remains draft until this package is released and its dependency lockfile can pin the immutable release.

<sub>🤖 <code>cb-ship:created v1 skill@1.0.1</code></sub>
