### PR TITLE
fix: update React component rule app path

### DIFF
--- a/packages/ai-rules/rules/frontend/reactComponents.md
+++ b/packages/ai-rules/rules/frontend/reactComponents.md
@@ -98,7 +98,7 @@ Register every new or updated shared UI component in Storybook before merging; i
 Before creating a new component, search for existing ones in this order:
 
 1. **MUI**: Search MUI's component library for existing components before building custom ones
-2. **App-level shared directories**: e.g., `src/appV2/lib/`, `src/lib/components/`, `src/shared/`
+2. **App-level shared directories**: e.g., `src/app/lib/`, `src/lib/components/`, `src/shared/`
 3. **Sibling features**: search for `*Card`, `*Modal`, `*Form`, `*EmptyState`, `*Page` patterns in other features
 
 If an existing component covers >70% of the need, extend it (prefer composition over boolean flags). Only create a new component when behavior is fundamentally different — document why in the PR.


### PR DESCRIPTION
## Summary

Update the frontend component-reuse rule to reference the canonical `src/app/lib/` directory. The previous `src/appV2/lib/` example caused consuming repositories to restore stale guidance whenever `@clipboard-health/ai-rules` synced during installation.

## Validation

- `node --run verify`
- `nx test ai-rules`
- `markdownlint-cli2 packages/ai-rules/rules/frontend/reactComponents.md`
- `oxfmt --check packages/ai-rules/rules/frontend/reactComponents.md`
- `git diff --check`

## Notes

After merge, the conventional `fix:` commit should trigger a patch release of `@clipboard-health/ai-rules`. Consumers can bump to that published version afterward.

Agent session: `codex resume 019fd232-5af1-7600-9f92-83b1c23df9cb`

<sub>🤖 <code>cb-ship:created v1 core@3.23.2</code></sub>
