### PR TITLE
fix: preserve browser lifecycle HTTP status (STAFF-2238)

### DIFF
--- a/packages/playwright-reporter-llm/src/lib/clientLifecycleContract.test.ts
+++ b/packages/playwright-reporter-llm/src/lib/clientLifecycleContract.test.ts
@@ -11,6 +11,28 @@ import {
 } from "./internal/testHelpers";
 
 describe("browser lifecycle attachment contract", () => {
+  it("round trips an HTTP response status when present", () => {
+    const input = {
+      ...createBrowserLifecycleCompletedFixture({ requestNumber: 1 }),
+      httpStatus: 503,
+    };
+
+    const encoded = encodeBrowserLifecycleAttachment({ records: [input] });
+    const actual = parseBrowserLifecycleAttachment({ content: encoded.body });
+
+    expect(actual?.records[0]).toMatchObject({ httpStatus: 503 });
+  });
+
+  it("keeps the HTTP response status absent when omitted", () => {
+    const input = createBrowserLifecycleCompletedFixture({ requestNumber: 1 });
+
+    const encoded = encodeBrowserLifecycleAttachment({ records: [input] });
+    const actual = parseBrowserLifecycleAttachment({ content: encoded.body });
+
+    expect(encoded.attachment.records[0]).not.toHaveProperty("httpStatus");
+    expect(actual?.records[0]).not.toHaveProperty("httpStatus");
+  });
+
   it("round trips the 48-record failing shape within the shared byte cap", () => {
     const input = createBrowserLifecycle48RecordFixture();
 

--- a/packages/playwright-reporter-llm/src/lib/clientLifecycleContract.ts
+++ b/packages/playwright-reporter-llm/src/lib/clientLifecycleContract.ts
@@ -80,6 +80,7 @@ export interface BrowserLifecycleRecord {
   traceId?: string;
   spanId?: string;
   apiGatewayRequestId?: string;
+  httpStatus?: number;
   protocol?: string;
   connection?: BrowserLifecycleConnection;
   encodedBytes?: BrowserLifecycleEncodedBytes;
@@ -233,6 +234,11 @@ function sanitizeRecord(value: unknown): BrowserLifecycleRecord | undefined {
   copyTraceIdentifiers({ source: record, target: sanitized });
   copyConnection({ source: record, target: sanitized });
   copyEncodedBytes({ source: record, target: sanitized });
+
+  const httpStatus = sanitizeLifecycleNonNegativeNumber(record["httpStatus"]);
+  if (httpStatus !== undefined) {
+    sanitized.httpStatus = httpStatus;
+  }
 
   const protocol = sanitizeLifecycleProtocol(record["protocol"]);
   if (protocol) {


### PR DESCRIPTION
## Why

Browser lifecycle attachments currently lose the HTTP response status at the shared contract boundary. That makes a completed request with a 503 response indistinguishable from one with a 200 response and blocks cbh-admin-frontend from restoring the diagnostic field.

## Summary

- Add optional `httpStatus: number` to `BrowserLifecycleRecord`.
- Preserve sanitized status values through encoding and parsing while tolerating older attachments without the field.
- Keep the existing attachment byte and record limits unchanged.
- Rely on the existing `main` release workflow to version and publish `@clipboard-health/playwright-reporter-llm` after merge.

## Validation

- `npm exec nx -- test playwright-reporter-llm --reporter=dot --maxWorkers=1` (233 tests passed)
- `npm exec nx -- run-many --projects=playwright-reporter-llm --targets=build,lint`
- `node --run verify`

## Notes

Closes staff-2238

- [STAFF-2238](https://linear.app/clipboardhealth/issue/STAFF-2238/add-optional-http-response-status-to-the-browserlifecyclerecord-contract)
- Consumer follow-up: [STAFF-2221](https://linear.app/clipboardhealth/issue/STAFF-2221/restore-http-status-on-browser-network-lifecycle-records)

Agent session: `codex resume 019fd8eb-939a-7963-acbb-f334527fa678`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.2</code></sub>