### PR TITLE
feat: require contract response parsing (STAFF-2196)

### DIFF
--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,5 +1,6 @@
 import enforceTsRestInControllers from "./lib/rules/enforce-ts-rest-in-controllers";
 import noCrossContractImports from "./lib/rules/no-cross-contract-imports";
+import requireContractResponseParse from "./lib/rules/require-contract-response-parse";
 import requireHttpModuleFactory from "./lib/rules/require-http-module-factory";
 import requireRunValidatorsWithUpsert from "./lib/rules/require-run-validators-with-upsert";
 import requireZodImportInContracts from "./lib/rules/require-zod-import-in-contracts";
@@ -7,6 +8,7 @@ import requireZodImportInContracts from "./lib/rules/require-zod-import-in-contr
 export const rules = {
   "enforce-ts-rest-in-controllers": enforceTsRestInControllers,
   "no-cross-contract-imports": noCrossContractImports,
+  "require-contract-response-parse": requireContractResponseParse,
   "require-http-module-factory": requireHttpModuleFactory,
   "require-run-validators-with-upsert": requireRunValidatorsWithUpsert,
   "require-zod-import-in-contracts": requireZodImportInContracts,

--- a/packages/eslint-plugin/src/lib/rules/require-contract-response-parse/README.md
+++ b/packages/eslint-plugin/src/lib/rules/require-contract-response-parse/README.md
@@ -1,0 +1,42 @@
+# require-contract-response-parse
+
+Requires response-shape assertions to validate the response body with a Zod schema imported from
+an `@clipboard-health/contract-*` package. It accepts either of these forms before the assertion:
+
+```ts
+const body = parseBody(response, ExampleResponseSchema);
+const body = ExampleResponseSchema.parse(response.parsedBody);
+```
+
+The rule also reports inline permissive schemas built with `z.any()` or `z.unknown()`. Those schemas
+cannot prove that a response matches its published contract.
+
+## Migration
+
+1. Find the endpoint in its contract package and select the response schema for the asserted status
+   code. This is commonly `contract.endpoint.responses[status]` or an exported `XResponseSchema`.
+2. Parse the body before shape assertions and make subsequent assertions against the parsed value.
+3. If no response schema exists, file a contract-gap ticket and add it to the contract package. Do
+   not replace the missing contract with an inline permissive schema or an ESLint exemption.
+
+For an existing test suite, enable the rule as a warning over the full migration scope. Migrate and
+raise one directory at a time to error level. CI can suppress the warning backlog with `--quiet`, so
+every error-level directory remains blocking. Once the full scope is migrated, replace the directory
+overrides with a single error-level setting and restore the zero-warning budget.
+
+## Configuration
+
+```js
+module.exports = {
+  overrides: [
+    {
+      files: ["path/to/endpoint-tests/**/*.{ts,tsx}"],
+      rules: {
+        "@clipboard-health/require-contract-response-parse": "warn",
+      },
+    },
+  ],
+};
+```
+
+The rule has no options.

--- a/packages/eslint-plugin/src/lib/rules/require-contract-response-parse/README.md
+++ b/packages/eslint-plugin/src/lib/rules/require-contract-response-parse/README.md
@@ -5,7 +5,7 @@ an `@clipboard-health/contract-*` package. It accepts either of these forms befo
 
 ```ts
 const body = parseBody(response, ExampleResponseSchema);
-const body = ExampleResponseSchema.parse(response.parsedBody);
+// or: const body = ExampleResponseSchema.parse(response.parsedBody);
 ```
 
 The rule also reports inline permissive schemas built with `z.any()` or `z.unknown()`. Those schemas

--- a/packages/eslint-plugin/src/lib/rules/require-contract-response-parse/README.md
+++ b/packages/eslint-plugin/src/lib/rules/require-contract-response-parse/README.md
@@ -1,15 +1,17 @@
 # require-contract-response-parse
 
-Requires response-shape assertions to validate the response body with a Zod schema imported from
-an `@clipboard-health/contract-*` package. It accepts either of these forms before the assertion:
+Requires response bodies to be validated with a Zod schema imported from an
+`@clipboard-health/contract-*` package. The rule reports every unparsed `parsedBody` member access
+and `{ parsedBody }` destructuring, including reads outside assertions, unless a contract parse
+dominates the access. It accepts either of these forms before reading the body:
 
 ```ts
 const body = parseBody(response, ExampleResponseSchema);
 // or: const body = ExampleResponseSchema.parse(response.parsedBody);
 ```
 
-The rule also reports inline permissive schemas built with `z.any()` or `z.unknown()`. Those schemas
-cannot prove that a response matches its published contract.
+The rule also reports every `z.any()` or `z.unknown()` call in a linted file, even outside response
+schemas. Those permissive schemas cannot prove that a response matches its published contract.
 
 ## Migration
 

--- a/packages/eslint-plugin/src/lib/rules/require-contract-response-parse/index.test.ts
+++ b/packages/eslint-plugin/src/lib/rules/require-contract-response-parse/index.test.ts
@@ -60,6 +60,15 @@ ruleTester.run("require-contract-response-parse", rule, {
       `,
     },
     {
+      name: "contract schema can parse an inline awaited response body",
+      code: `
+        import { ExampleResponseSchema } from "@clipboard-health/contract-example";
+        it("parses an inline response", async () => {
+          ExampleResponseSchema.parse((await getResponse()).parsedBody);
+        });
+      `,
+    },
+    {
       name: "status-only assertion does not inspect response shape",
       code: `
         it("only checks status", () => {
@@ -263,6 +272,23 @@ ruleTester.run("require-contract-response-parse", rule, {
         const LooseResponseSchema = z.array(z.any());
       `,
       errors: [{ messageId: "inlineAnySchema", data: { method: "any" } }],
+    },
+    {
+      name: "default-imported z.any schema is not a contract oracle",
+      code: `
+        import z from "zod";
+        const LooseResponseSchema = z.array(z.any());
+      `,
+      errors: [{ messageId: "inlineAnySchema", data: { method: "any" } }],
+    },
+    {
+      name: "inline awaited response shape requires a contract parse",
+      code: `
+        it("asserts an inline response", async () => {
+          expect((await getResponse()).parsedBody).toEqual({});
+        });
+      `,
+      errors: [{ messageId: "missingContractParse" }],
     },
   ],
 });

--- a/packages/eslint-plugin/src/lib/rules/require-contract-response-parse/index.test.ts
+++ b/packages/eslint-plugin/src/lib/rules/require-contract-response-parse/index.test.ts
@@ -1,0 +1,268 @@
+import { TSESLint } from "@typescript-eslint/utils";
+
+import rule from "./index";
+
+// eslint-disable-next-line n/no-unpublished-require
+const parser = require.resolve("@typescript-eslint/parser");
+
+const ruleTester = new TSESLint.RuleTester({
+  parser,
+  parserOptions: {
+    ecmaVersion: 2022,
+    sourceType: "module",
+  },
+});
+
+// oxlint-disable-next-line vitest/expect-expect -- RuleTester validates declaratively
+ruleTester.run("require-contract-response-parse", rule, {
+  valid: [
+    {
+      name: "contract schema parses the response before a shape assertion",
+      code: `
+        import { ExampleResponseSchema } from "@clipboard-health/contract-example";
+        it("parses", () => {
+          const response = getResponse();
+          const body = parseBody(response, ExampleResponseSchema);
+          expect(response.parsedBody).toMatchObject(body);
+        });
+      `,
+    },
+    {
+      name: "contract schema parses parsedBody directly",
+      code: `
+        import { ExampleResponseSchema } from "@clipboard-health/contract-example";
+        it("parses", () => {
+          const response = getResponse();
+          const body = ExampleResponseSchema.parse(response.parsedBody);
+          expect(response.parsedBody.data).toEqual(body.data);
+        });
+      `,
+    },
+    {
+      name: "contract response map supplies the schema",
+      code: `
+        import { exampleContract } from "@clipboard-health/contract-example";
+        it("parses inline", () => {
+          const response = getResponse();
+          expect(parseBody(response, exampleContract.get.responses[200])).toMatchObject({});
+        });
+      `,
+    },
+    {
+      name: "TypeScript wrappers preserve contract parse evidence",
+      code: `
+        import { ExampleResponseSchema } from "@clipboard-health/contract-example";
+        it("parses a typed response", () => {
+          const response = getResponse();
+          ExampleResponseSchema.parse(response.parsedBody as unknown);
+          expect((response as Response).parsedBody.data).toEqual([]);
+        });
+      `,
+    },
+    {
+      name: "status-only assertion does not inspect response shape",
+      code: `
+        it("only checks status", () => {
+          const response = getResponse();
+          expect(response.statusCode).toBe(204);
+        });
+      `,
+    },
+    {
+      name: "unrelated any method is not a Zod schema",
+      code: `
+        const helper = { any: () => true };
+        helper.any();
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: "response shape assertion without a contract parse",
+      code: `
+        it("does not parse", () => {
+          const response = getResponse();
+          expect(response.parsedBody).toMatchObject({ data: [] });
+        });
+      `,
+      errors: [{ messageId: "missingContractParse" }],
+    },
+    {
+      name: "contract parse after the assertion",
+      code: `
+        import { ExampleResponseSchema } from "@clipboard-health/contract-example";
+        it("parses too late", () => {
+          const response = getResponse();
+          expect(response.parsedBody.data).toEqual([]);
+          parseBody(response, ExampleResponseSchema);
+        });
+      `,
+      errors: [{ messageId: "missingContractParse" }],
+    },
+    {
+      name: "local strict schema is not the contract oracle",
+      code: `
+        import { z } from "zod";
+        it("uses a local strict schema", () => {
+          const response = getResponse();
+          const LocalResponseSchema = z.object({ data: z.array(z.string()) });
+          const result = LocalResponseSchema.safeParse(response.parsedBody);
+          expect(result.success).toBe(true);
+        });
+      `,
+      errors: [{ messageId: "missingContractParse" }],
+    },
+    {
+      name: "parseBody with a local schema is not the contract oracle",
+      code: `
+        import { z } from "zod";
+        it("passes a local schema to parseBody", () => {
+          const response = getResponse();
+          const LocalResponseSchema = z.object({ data: z.array(z.string()) });
+          const body = parseBody(response, LocalResponseSchema);
+          expect(body).toMatchObject({ data: [] });
+        });
+      `,
+      errors: [{ messageId: "missingContractParse" }],
+    },
+    {
+      name: "parse evidence does not cross test functions",
+      code: `
+        import { ExampleResponseSchema } from "@clipboard-health/contract-example";
+        it("parses one response", () => {
+          const response = getResponse();
+          parseBody(response, ExampleResponseSchema);
+        });
+        it("does not let another test satisfy this one", () => {
+          const response = getResponse();
+          expect(response.parsedBody).toEqual({});
+        });
+      `,
+      errors: [{ messageId: "missingContractParse" }],
+    },
+    {
+      name: "shadowed contract import is not a contract schema",
+      code: `
+        import { ExampleResponseSchema } from "@clipboard-health/contract-example";
+        it("rejects a shadowed contract schema", (ExampleResponseSchema) => {
+          const response = getResponse();
+          parseBody(response, ExampleResponseSchema);
+          expect(response.parsedBody).toEqual({});
+        });
+      `,
+      errors: [{ messageId: "missingContractParse" }, { messageId: "missingContractParse" }],
+    },
+    {
+      name: "conditional parse does not dominate a later assertion",
+      code: `
+        import { ExampleResponseSchema } from "@clipboard-health/contract-example";
+        it("rejects conditional parse evidence", () => {
+          const response = getResponse();
+          if (shouldParse) {
+            parseBody(response, ExampleResponseSchema);
+          }
+          expect(response.parsedBody).toEqual({});
+        });
+      `,
+      errors: [{ messageId: "missingContractParse" }],
+    },
+    {
+      name: "response reassignment invalidates earlier parse evidence",
+      code: `
+        import { ExampleResponseSchema } from "@clipboard-health/contract-example";
+        it("rejects parse evidence before reassignment", () => {
+          let response = getResponse();
+          parseBody(response, ExampleResponseSchema);
+          response = getAnotherResponse();
+          expect(response.parsedBody).toEqual({});
+        });
+      `,
+      errors: [{ messageId: "missingContractParse" }],
+    },
+    {
+      name: "schema parsing a nested value does not validate the response body",
+      code: `
+        import { ExampleResponseSchema } from "@clipboard-health/contract-example";
+        it("parses only a nested value", () => {
+          const response = getResponse();
+          ExampleResponseSchema.parse(response.parsedBody.data);
+          expect(response.parsedBody).toEqual({ data: [] });
+        });
+      `,
+      errors: [{ messageId: "missingContractParse" }, { messageId: "missingContractParse" }],
+    },
+    {
+      name: "whole-response shape assertion includes parsedBody",
+      code: `
+        it("asserts the whole response", () => {
+          const response = getResponse();
+          expect(response).toMatchObject({ statusCode: 200, parsedBody: { data: [] } });
+        });
+      `,
+      errors: [{ messageId: "missingContractParse" }],
+    },
+    {
+      name: "string property path reaches parsedBody",
+      code: `
+        it("asserts a parsedBody string path", () => {
+          const response = getResponse();
+          expect(response).toHaveProperty("parsedBody.preference.distance", 100);
+        });
+      `,
+      errors: [{ messageId: "missingContractParse" }],
+    },
+    {
+      name: "array property path reaches parsedBody",
+      code: `
+        it("asserts a parsedBody array path", () => {
+          const response = getResponse();
+          expect(response).toHaveProperty(["parsedBody", "preference", "distance"], 100);
+        });
+      `,
+      errors: [{ messageId: "missingContractParse" }],
+    },
+    {
+      name: "parsedBody destructuring requires a prior contract parse",
+      code: `
+        it("destructures an unparsed response", async () => {
+          const { parsedBody } = await getResponse();
+          expect(parsedBody).toMatchObject({ data: [] });
+        });
+      `,
+      errors: [{ messageId: "missingContractParse" }],
+    },
+    {
+      name: "inline z.any schema is not a contract oracle",
+      code: `
+        import { z } from "zod";
+        it("uses an inline any schema", () => {
+          const response = getResponse();
+          const schema = z.record(z.string(), z.any());
+          schema.parse(response.parsedBody);
+          expect(response.parsedBody).toEqual({});
+        });
+      `,
+      errors: [
+        { messageId: "inlineAnySchema", data: { method: "any" } },
+        { messageId: "missingContractParse" },
+        { messageId: "missingContractParse" },
+      ],
+    },
+    {
+      name: "aliased z.unknown schema is not a contract oracle",
+      code: `
+        import { z as schema } from "zod";
+        const LooseResponseSchema = schema.array(schema.unknown());
+      `,
+      errors: [{ messageId: "inlineAnySchema", data: { method: "unknown" } }],
+    },
+    {
+      name: "namespace z.any schema is not a contract oracle",
+      code: `
+        import * as z from "zod";
+        const LooseResponseSchema = z.array(z.any());
+      `,
+      errors: [{ messageId: "inlineAnySchema", data: { method: "any" } }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/lib/rules/require-contract-response-parse/index.test.ts
+++ b/packages/eslint-plugin/src/lib/rules/require-contract-response-parse/index.test.ts
@@ -39,6 +39,17 @@ ruleTester.run("require-contract-response-parse", rule, {
       `,
     },
     {
+      name: "async contract schema parses parsedBody directly",
+      code: `
+        import { ExampleResponseSchema } from "@clipboard-health/contract-example";
+        it("parses asynchronously", async () => {
+          const response = getResponse();
+          const body = await ExampleResponseSchema.parseAsync(response.parsedBody);
+          expect(response.parsedBody.data).toEqual(body.data);
+        });
+      `,
+    },
+    {
       name: "contract response map supplies the schema",
       code: `
         import { exampleContract } from "@clipboard-health/contract-example";
@@ -65,6 +76,30 @@ ruleTester.run("require-contract-response-parse", rule, {
         import { ExampleResponseSchema } from "@clipboard-health/contract-example";
         it("parses an inline response", async () => {
           ExampleResponseSchema.parse((await getResponse()).parsedBody);
+        });
+      `,
+    },
+    {
+      name: "satisfies wrapper preserves contract parse evidence",
+      code: `
+        import { ExampleResponseSchema } from "@clipboard-health/contract-example";
+        it("parses a response with a satisfies wrapper", () => {
+          const response = getResponse();
+          parseBody(response, ExampleResponseSchema);
+          expect((response satisfies Response).parsedBody).toEqual({});
+        });
+      `,
+    },
+    {
+      name: "parse and assertion in the same control-flow branch",
+      code: `
+        import { ExampleResponseSchema } from "@clipboard-health/contract-example";
+        it("parses inside the branch", () => {
+          const response = getResponse();
+          if (shouldParse) {
+            parseBody(response, ExampleResponseSchema);
+            expect(response.parsedBody).toEqual({});
+          }
         });
       `,
     },
@@ -132,7 +167,7 @@ ruleTester.run("require-contract-response-parse", rule, {
           expect(body).toMatchObject({ data: [] });
         });
       `,
-      errors: [{ messageId: "missingContractParse" }],
+      errors: [{ messageId: "nonContractSchema" }],
     },
     {
       name: "parse evidence does not cross test functions",
@@ -159,7 +194,7 @@ ruleTester.run("require-contract-response-parse", rule, {
           expect(response.parsedBody).toEqual({});
         });
       `,
-      errors: [{ messageId: "missingContractParse" }, { messageId: "missingContractParse" }],
+      errors: [{ messageId: "nonContractSchema" }, { messageId: "missingContractParse" }],
     },
     {
       name: "conditional parse does not dominate a later assertion",
@@ -206,6 +241,26 @@ ruleTester.run("require-contract-response-parse", rule, {
         it("asserts the whole response", () => {
           const response = getResponse();
           expect(response).toMatchObject({ statusCode: 200, parsedBody: { data: [] } });
+        });
+      `,
+      errors: [{ messageId: "missingContractParse" }],
+    },
+    {
+      name: "negated whole-response shape assertion includes parsedBody",
+      code: `
+        it("asserts the whole response with not", () => {
+          const response = getResponse();
+          expect(response).not.toMatchObject({ parsedBody: { data: [] } });
+        });
+      `,
+      errors: [{ messageId: "missingContractParse" }],
+    },
+    {
+      name: "resolved whole-response shape assertion includes parsedBody",
+      code: `
+        it("asserts a resolved response", async () => {
+          const responsePromise = getResponse();
+          await expect(responsePromise).resolves.toMatchObject({ parsedBody: { data: [] } });
         });
       `,
       errors: [{ messageId: "missingContractParse" }],

--- a/packages/eslint-plugin/src/lib/rules/require-contract-response-parse/index.ts
+++ b/packages/eslint-plugin/src/lib/rules/require-contract-response-parse/index.ts
@@ -164,6 +164,7 @@ const rule = createRule({
     const zodBindings = new Set<TSESLint.Scope.Variable>();
     const functionStates = new Map<FunctionNode, FunctionState>();
     const topLevelState: FunctionState = { parses: new Map(), writes: new Map() };
+    const validatedParsedBodyAccesses = new WeakSet<TSESTree.MemberExpression>();
     const controlFlowTypes = new Set<TSESTree.Node["type"]>([
       AST_NODE_TYPES.CatchClause,
       AST_NODE_TYPES.ConditionalExpression,
@@ -344,6 +345,7 @@ const rule = createRule({
         return;
       }
 
+      validatedParsedBodyAccesses.add(access);
       const key = responseKey(access.object);
       if (key !== undefined) {
         addEvidence(stateFor(node).parses, key, node);
@@ -351,12 +353,12 @@ const rule = createRule({
     }
 
     function checkParsedBodyAccess(node: TSESTree.MemberExpression): void {
-      if (memberPropertyName(node) !== "parsedBody") {
+      if (memberPropertyName(node) !== "parsedBody" || validatedParsedBodyAccesses.has(node)) {
         return;
       }
 
       const key = responseKey(node.object);
-      if (key !== undefined && !hasContractParse(node, key)) {
+      if (key === undefined || !hasContractParse(node, key)) {
         context.report({ node, messageId: "missingContractParse" });
       }
     }
@@ -466,11 +468,12 @@ const rule = createRule({
         if (node.source.value === "zod") {
           for (const specifier of node.specifiers) {
             const importsZodNamespace = specifier.type === AST_NODE_TYPES.ImportNamespaceSpecifier;
+            const importsZodDefault = specifier.type === AST_NODE_TYPES.ImportDefaultSpecifier;
             const importsZodBinding =
               specifier.type === AST_NODE_TYPES.ImportSpecifier &&
               specifier.imported.type === AST_NODE_TYPES.Identifier &&
               specifier.imported.name === "z";
-            if (!importsZodNamespace && !importsZodBinding) {
+            if (!importsZodNamespace && !importsZodDefault && !importsZodBinding) {
               continue;
             }
 

--- a/packages/eslint-plugin/src/lib/rules/require-contract-response-parse/index.ts
+++ b/packages/eslint-plugin/src/lib/rules/require-contract-response-parse/index.ts
@@ -16,12 +16,28 @@
  * `--quiet`, making every error-level directory a blocking ratchet. Once the full scope is migrated,
  * replace the overrides with one error-level setting and restore the zero-warning budget.
  */
-import { AST_NODE_TYPES, type TSESLint, type TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ASTUtils, type TSESLint, type TSESTree } from "@typescript-eslint/utils";
 
 import { createRule } from "../../createRule";
 
 const CONTRACT_PACKAGE_PREFIX = "@clipboard-health/contract-";
 const ANY_SCHEMA_METHODS = new Set(["any", "unknown"]);
+const SCHEMA_PARSE_METHODS = new Set(["parse", "parseAsync"]);
+const MATCHER_MODIFIERS = new Set(["not", "rejects", "resolves"]);
+const CONTROL_FLOW_TYPES = new Set<TSESTree.Node["type"]>([
+  AST_NODE_TYPES.CatchClause,
+  AST_NODE_TYPES.ConditionalExpression,
+  AST_NODE_TYPES.DoWhileStatement,
+  AST_NODE_TYPES.ForInStatement,
+  AST_NODE_TYPES.ForOfStatement,
+  AST_NODE_TYPES.ForStatement,
+  AST_NODE_TYPES.IfStatement,
+  AST_NODE_TYPES.LogicalExpression,
+  AST_NODE_TYPES.SwitchCase,
+  AST_NODE_TYPES.SwitchStatement,
+  AST_NODE_TYPES.TryStatement,
+  AST_NODE_TYPES.WhileStatement,
+]);
 
 type FunctionNode =
   | TSESTree.ArrowFunctionExpression
@@ -42,6 +58,7 @@ function unwrap(node: TSESTree.Node | undefined): TSESTree.Node | undefined {
     current?.type === AST_NODE_TYPES.TSAsExpression ||
     current?.type === AST_NODE_TYPES.TSInstantiationExpression ||
     current?.type === AST_NODE_TYPES.TSNonNullExpression ||
+    current?.type === AST_NODE_TYPES.TSSatisfiesExpression ||
     current?.type === AST_NODE_TYPES.TSTypeAssertion
   ) {
     current = current.expression;
@@ -156,6 +173,8 @@ const rule = createRule({
         "Inline z.{{method}}() schemas are not contract oracles. Use the endpoint response schema from a @clipboard-health/contract-* package.",
       missingContractParse:
         "Parse this response body with its @clipboard-health/contract-* response schema before asserting its shape.",
+      nonContractSchema:
+        "This schema is not a contract oracle. Use the endpoint response schema from a @clipboard-health/contract-* package.",
     },
   },
 
@@ -165,20 +184,6 @@ const rule = createRule({
     const functionStates = new Map<FunctionNode, FunctionState>();
     const topLevelState: FunctionState = { parses: new Map(), writes: new Map() };
     const validatedParsedBodyAccesses = new WeakSet<TSESTree.MemberExpression>();
-    const controlFlowTypes = new Set<TSESTree.Node["type"]>([
-      AST_NODE_TYPES.CatchClause,
-      AST_NODE_TYPES.ConditionalExpression,
-      AST_NODE_TYPES.DoWhileStatement,
-      AST_NODE_TYPES.ForInStatement,
-      AST_NODE_TYPES.ForOfStatement,
-      AST_NODE_TYPES.ForStatement,
-      AST_NODE_TYPES.IfStatement,
-      AST_NODE_TYPES.LogicalExpression,
-      AST_NODE_TYPES.SwitchCase,
-      AST_NODE_TYPES.SwitchStatement,
-      AST_NODE_TYPES.TryStatement,
-      AST_NODE_TYPES.WhileStatement,
-    ]);
 
     function rootIdentifier(node: TSESTree.Node | undefined): TSESTree.Identifier | undefined {
       let current = unwrap(node);
@@ -207,17 +212,7 @@ const rule = createRule({
     }
 
     function findVariable(node: TSESTree.Identifier): TSESLint.Scope.Variable | undefined {
-      let scope: TSESLint.Scope.Scope | null = context.sourceCode.getScope(node);
-
-      while (scope) {
-        const variable = scope.set.get(node.name);
-        if (variable) {
-          return variable;
-        }
-        scope = scope.upper;
-      }
-
-      return undefined;
+      return ASTUtils.findVariable(context.sourceCode.getScope(node), node) ?? undefined;
     }
 
     function responseKey(node: TSESTree.Node | undefined): ResponseKey | undefined {
@@ -275,7 +270,7 @@ const rule = createRule({
       const functionNode = containingFunction(parseNode);
       while (current && current !== functionNode) {
         if (
-          controlFlowTypes.has(current.type) &&
+          CONTROL_FLOW_TYPES.has(current.type) &&
           (!isAncestor(current, assertionNode) ||
             directChild(current, parseNode) !== directChild(current, assertionNode))
         ) {
@@ -320,7 +315,7 @@ const rule = createRule({
       }
 
       if (!isContractSchema(schema)) {
-        context.report({ node: schema, messageId: "missingContractParse" });
+        context.report({ node: schema, messageId: "nonContractSchema" });
         return;
       }
 
@@ -333,7 +328,7 @@ const rule = createRule({
     function checkSchemaParse(node: TSESTree.CallExpression): void {
       if (
         node.callee.type !== AST_NODE_TYPES.MemberExpression ||
-        memberPropertyName(node.callee) !== "parse" ||
+        !SCHEMA_PARSE_METHODS.has(memberPropertyName(node.callee) ?? "") ||
         !isContractSchema(node.callee.object)
       ) {
         return;
@@ -369,9 +364,9 @@ const rule = createRule({
       }
 
       let matcherTarget = node.callee.object;
-      if (
+      while (
         matcherTarget.type === AST_NODE_TYPES.MemberExpression &&
-        memberPropertyName(matcherTarget) === "not"
+        MATCHER_MODIFIERS.has(memberPropertyName(matcherTarget) ?? "")
       ) {
         matcherTarget = matcherTarget.object;
       }

--- a/packages/eslint-plugin/src/lib/rules/require-contract-response-parse/index.ts
+++ b/packages/eslint-plugin/src/lib/rules/require-contract-response-parse/index.ts
@@ -1,0 +1,502 @@
+/**
+ * @fileoverview Require contract-package response schemas before response-shape assertions.
+ *
+ * Migration playbook:
+ * 1. Find the endpoint in its `@clipboard-health/contract-*` package and use the schema for the
+ *    asserted status code, commonly `contract.endpoint.responses[status]` or an exported
+ *    `XResponseSchema`.
+ * 2. Parse before shape assertions with `parseBody(response, schema)` or
+ *    `schema.parse(response.parsedBody)`, then assert on the parsed value.
+ * 3. If the contract package has no response schema, file a contract-gap ticket and add the schema
+ *    there. An inline permissive schema or ESLint exemption is not a contract oracle.
+ *
+ * Warn-to-error ratchet:
+ * Enable the rule as a warning across the migration scope. Migrate one directory at a time and add
+ * an error-level override for each completed directory. CI may suppress the warning backlog with
+ * `--quiet`, making every error-level directory a blocking ratchet. Once the full scope is migrated,
+ * replace the overrides with one error-level setting and restore the zero-warning budget.
+ */
+import { AST_NODE_TYPES, type TSESLint, type TSESTree } from "@typescript-eslint/utils";
+
+import { createRule } from "../../createRule";
+
+const CONTRACT_PACKAGE_PREFIX = "@clipboard-health/contract-";
+const ANY_SCHEMA_METHODS = new Set(["any", "unknown"]);
+
+type FunctionNode =
+  | TSESTree.ArrowFunctionExpression
+  | TSESTree.FunctionDeclaration
+  | TSESTree.FunctionExpression;
+type ResponseKey = TSESLint.Scope.Variable | string;
+
+interface FunctionState {
+  parses: Map<ResponseKey, TSESTree.Node[]>;
+  writes: Map<ResponseKey, TSESTree.Node[]>;
+}
+
+function unwrap(node: TSESTree.Node | undefined): TSESTree.Node | undefined {
+  let current = node;
+
+  while (
+    current?.type === AST_NODE_TYPES.ChainExpression ||
+    current?.type === AST_NODE_TYPES.TSAsExpression ||
+    current?.type === AST_NODE_TYPES.TSInstantiationExpression ||
+    current?.type === AST_NODE_TYPES.TSNonNullExpression ||
+    current?.type === AST_NODE_TYPES.TSTypeAssertion
+  ) {
+    current = current.expression;
+  }
+
+  return current;
+}
+
+function memberPropertyName(node: TSESTree.MemberExpression): string | undefined {
+  if (!node.computed && node.property.type === AST_NODE_TYPES.Identifier) {
+    return node.property.name;
+  }
+
+  if (node.computed && node.property.type === AST_NODE_TYPES.Literal) {
+    return typeof node.property.value === "string" ? node.property.value : undefined;
+  }
+
+  return undefined;
+}
+
+function containingFunction(node: TSESTree.Node): FunctionNode | undefined {
+  let current = node.parent;
+
+  while (current) {
+    if (
+      current.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+      current.type === AST_NODE_TYPES.FunctionDeclaration ||
+      current.type === AST_NODE_TYPES.FunctionExpression
+    ) {
+      return current;
+    }
+
+    current = current.parent;
+  }
+
+  return undefined;
+}
+
+function addEvidence(
+  collection: Map<ResponseKey, TSESTree.Node[]>,
+  key: ResponseKey,
+  node: TSESTree.Node,
+): void {
+  const nodes = collection.get(key) ?? [];
+  nodes.push(node);
+  collection.set(key, nodes);
+}
+
+function isAncestor(ancestor: TSESTree.Node, node: TSESTree.Node): boolean {
+  let current: TSESTree.Node | undefined = node;
+  while (current) {
+    if (current === ancestor) {
+      return true;
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
+function directChild(ancestor: TSESTree.Node, node: TSESTree.Node): TSESTree.Node | undefined {
+  let current: TSESTree.Node | undefined = node;
+  while (current?.parent && current.parent !== ancestor) {
+    current = current.parent;
+  }
+  return current?.parent === ancestor ? current : undefined;
+}
+
+function objectContainsParsedBodyProperty(node: TSESTree.Node | undefined): boolean {
+  if (node?.type !== AST_NODE_TYPES.ObjectExpression) {
+    return false;
+  }
+
+  return node.properties.some((property) => {
+    if (property.type !== AST_NODE_TYPES.Property) {
+      return false;
+    }
+
+    const propertyName =
+      property.key.type === AST_NODE_TYPES.Identifier
+        ? property.key.name
+        : property.key.type === AST_NODE_TYPES.Literal
+          ? property.key.value
+          : undefined;
+
+    return propertyName === "parsedBody" || objectContainsParsedBodyProperty(property.value);
+  });
+}
+
+function isParsedBodyPropertyPath(node: TSESTree.Node | undefined): boolean {
+  if (node?.type === AST_NODE_TYPES.Literal && typeof node.value === "string") {
+    return /^parsedBody(?:\.|\[|$)/u.test(node.value);
+  }
+
+  return (
+    node?.type === AST_NODE_TYPES.ArrayExpression &&
+    node.elements[0]?.type === AST_NODE_TYPES.Literal &&
+    node.elements[0].value === "parsedBody"
+  );
+}
+
+const rule = createRule({
+  name: "require-contract-response-parse",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Require response assertions to use contract-package schemas",
+    },
+    schema: [],
+    messages: {
+      inlineAnySchema:
+        "Inline z.{{method}}() schemas are not contract oracles. Use the endpoint response schema from a @clipboard-health/contract-* package.",
+      missingContractParse:
+        "Parse this response body with its @clipboard-health/contract-* response schema before asserting its shape.",
+    },
+  },
+
+  create(context) {
+    const contractBindings = new Set<TSESLint.Scope.Variable>();
+    const zodBindings = new Set<TSESLint.Scope.Variable>();
+    const functionStates = new Map<FunctionNode, FunctionState>();
+    const topLevelState: FunctionState = { parses: new Map(), writes: new Map() };
+    const controlFlowTypes = new Set<TSESTree.Node["type"]>([
+      AST_NODE_TYPES.CatchClause,
+      AST_NODE_TYPES.ConditionalExpression,
+      AST_NODE_TYPES.DoWhileStatement,
+      AST_NODE_TYPES.ForInStatement,
+      AST_NODE_TYPES.ForOfStatement,
+      AST_NODE_TYPES.ForStatement,
+      AST_NODE_TYPES.IfStatement,
+      AST_NODE_TYPES.LogicalExpression,
+      AST_NODE_TYPES.SwitchCase,
+      AST_NODE_TYPES.SwitchStatement,
+      AST_NODE_TYPES.TryStatement,
+      AST_NODE_TYPES.WhileStatement,
+    ]);
+
+    function rootIdentifier(node: TSESTree.Node | undefined): TSESTree.Identifier | undefined {
+      let current = unwrap(node);
+
+      while (current?.type === AST_NODE_TYPES.MemberExpression) {
+        current = unwrap(current.object);
+      }
+
+      return current?.type === AST_NODE_TYPES.Identifier ? current : undefined;
+    }
+
+    function parsedBodyAccess(
+      node: TSESTree.Node | undefined,
+    ): TSESTree.MemberExpression | undefined {
+      let current = unwrap(node);
+
+      while (current?.type === AST_NODE_TYPES.MemberExpression) {
+        if (memberPropertyName(current) === "parsedBody") {
+          return current;
+        }
+
+        current = unwrap(current.object);
+      }
+
+      return undefined;
+    }
+
+    function findVariable(node: TSESTree.Identifier): TSESLint.Scope.Variable | undefined {
+      let scope: TSESLint.Scope.Scope | null = context.sourceCode.getScope(node);
+
+      while (scope) {
+        const variable = scope.set.get(node.name);
+        if (variable) {
+          return variable;
+        }
+        scope = scope.upper;
+      }
+
+      return undefined;
+    }
+
+    function responseKey(node: TSESTree.Node | undefined): ResponseKey | undefined {
+      const current = unwrap(node);
+
+      if (current?.type === AST_NODE_TYPES.Identifier) {
+        return findVariable(current) ?? current.name;
+      }
+
+      if (current?.type === AST_NODE_TYPES.MemberExpression) {
+        return context.sourceCode.getText(current);
+      }
+
+      return undefined;
+    }
+
+    function isContractSchema(node: TSESTree.Node | undefined): boolean {
+      const identifier = rootIdentifier(node);
+      if (!identifier) {
+        return false;
+      }
+
+      const variable = findVariable(identifier);
+      return variable !== undefined && contractBindings.has(variable);
+    }
+
+    function stateFor(node: TSESTree.Node): FunctionState {
+      const functionNode = containingFunction(node);
+      if (!functionNode) {
+        return topLevelState;
+      }
+
+      const existingState = functionStates.get(functionNode);
+      if (existingState) {
+        return existingState;
+      }
+
+      const state: FunctionState = { parses: new Map(), writes: new Map() };
+      functionStates.set(functionNode, state);
+      return state;
+    }
+
+    function parseDominatesAssertion(
+      parseNode: TSESTree.Node,
+      assertionNode: TSESTree.Node,
+    ): boolean {
+      if (
+        containingFunction(parseNode) !== containingFunction(assertionNode) ||
+        parseNode.range[0] >= assertionNode.range[0]
+      ) {
+        return false;
+      }
+
+      let current = parseNode.parent;
+      const functionNode = containingFunction(parseNode);
+      while (current && current !== functionNode) {
+        if (
+          controlFlowTypes.has(current.type) &&
+          (!isAncestor(current, assertionNode) ||
+            directChild(current, parseNode) !== directChild(current, assertionNode))
+        ) {
+          return false;
+        }
+        current = current.parent;
+      }
+
+      return true;
+    }
+
+    function hasContractParse(node: TSESTree.Node, key: ResponseKey): boolean {
+      const state = stateFor(node);
+      const parses = state.parses.get(key) ?? [];
+      const writes = state.writes.get(key) ?? [];
+
+      return parses.some(
+        (parseNode) =>
+          parseDominatesAssertion(parseNode, node) &&
+          !writes.some(
+            (writeNode) =>
+              writeNode.range[0] > parseNode.range[1] && writeNode.range[0] < node.range[0],
+          ),
+      );
+    }
+
+    function recordResponseWrite(node: TSESTree.Node, expression: TSESTree.Node): void {
+      const key = responseKey(expression);
+      if (key !== undefined) {
+        addEvidence(stateFor(node).writes, key, node);
+      }
+    }
+
+    function checkParseBody(node: TSESTree.CallExpression): void {
+      if (node.callee.type !== AST_NODE_TYPES.Identifier || node.callee.name !== "parseBody") {
+        return;
+      }
+
+      const [response, schema] = node.arguments;
+      if (!response || !schema) {
+        return;
+      }
+
+      if (!isContractSchema(schema)) {
+        context.report({ node: schema, messageId: "missingContractParse" });
+        return;
+      }
+
+      const key = responseKey(response);
+      if (key !== undefined) {
+        addEvidence(stateFor(node).parses, key, node);
+      }
+    }
+
+    function checkSchemaParse(node: TSESTree.CallExpression): void {
+      if (
+        node.callee.type !== AST_NODE_TYPES.MemberExpression ||
+        memberPropertyName(node.callee) !== "parse" ||
+        !isContractSchema(node.callee.object)
+      ) {
+        return;
+      }
+
+      const argument = unwrap(node.arguments[0]);
+      const access = parsedBodyAccess(argument);
+      if (!access || argument !== access) {
+        return;
+      }
+
+      const key = responseKey(access.object);
+      if (key !== undefined) {
+        addEvidence(stateFor(node).parses, key, node);
+      }
+    }
+
+    function checkParsedBodyAccess(node: TSESTree.MemberExpression): void {
+      if (memberPropertyName(node) !== "parsedBody") {
+        return;
+      }
+
+      const key = responseKey(node.object);
+      if (key !== undefined && !hasContractParse(node, key)) {
+        context.report({ node, messageId: "missingContractParse" });
+      }
+    }
+
+    function expectCall(node: TSESTree.CallExpression): TSESTree.CallExpression | undefined {
+      if (node.callee.type !== AST_NODE_TYPES.MemberExpression) {
+        return undefined;
+      }
+
+      let matcherTarget = node.callee.object;
+      if (
+        matcherTarget.type === AST_NODE_TYPES.MemberExpression &&
+        memberPropertyName(matcherTarget) === "not"
+      ) {
+        matcherTarget = matcherTarget.object;
+      }
+
+      if (
+        matcherTarget.type !== AST_NODE_TYPES.CallExpression ||
+        matcherTarget.callee.type !== AST_NODE_TYPES.Identifier ||
+        matcherTarget.callee.name !== "expect"
+      ) {
+        return undefined;
+      }
+
+      return matcherTarget;
+    }
+
+    function checkWholeResponseAssertion(node: TSESTree.CallExpression): void {
+      const expectation = expectCall(node);
+      if (!expectation) {
+        return;
+      }
+
+      const assertsParsedBodyProperty = node.arguments.some((argument) =>
+        objectContainsParsedBodyProperty(argument),
+      );
+      const matcherName =
+        node.callee.type === AST_NODE_TYPES.MemberExpression
+          ? memberPropertyName(node.callee)
+          : undefined;
+      const assertsParsedBodyPath =
+        matcherName === "toHaveProperty" && isParsedBodyPropertyPath(node.arguments[0]);
+      if (!assertsParsedBodyProperty && !assertsParsedBodyPath) {
+        return;
+      }
+
+      const key = responseKey(expectation.arguments[0]);
+      if (key !== undefined && !hasContractParse(node, key)) {
+        context.report({ node: expectation, messageId: "missingContractParse" });
+      }
+    }
+
+    function checkParsedBodyDestructuring(node: TSESTree.VariableDeclarator): void {
+      if (node.id.type !== AST_NODE_TYPES.ObjectPattern) {
+        return;
+      }
+
+      const parsedBodyProperty = node.id.properties.find((property) => {
+        if (property.type !== AST_NODE_TYPES.Property) {
+          return false;
+        }
+
+        return (
+          (property.key.type === AST_NODE_TYPES.Identifier && property.key.name === "parsedBody") ||
+          (property.key.type === AST_NODE_TYPES.Literal && property.key.value === "parsedBody")
+        );
+      });
+      if (!parsedBodyProperty) {
+        return;
+      }
+
+      const key = responseKey(node.init ?? undefined);
+      if (key === undefined || !hasContractParse(node, key)) {
+        context.report({ node: parsedBodyProperty, messageId: "missingContractParse" });
+      }
+    }
+
+    function checkInlineAnySchema(node: TSESTree.CallExpression): void {
+      if (node.callee.type !== AST_NODE_TYPES.MemberExpression) {
+        return;
+      }
+
+      const method = memberPropertyName(node.callee);
+      const identifier = rootIdentifier(node.callee.object);
+      if (!method || !ANY_SCHEMA_METHODS.has(method) || !identifier) {
+        return;
+      }
+
+      const variable = findVariable(identifier);
+      if (variable !== undefined && zodBindings.has(variable)) {
+        context.report({ node, messageId: "inlineAnySchema", data: { method } });
+      }
+    }
+
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value.startsWith(CONTRACT_PACKAGE_PREFIX)) {
+          for (const specifier of node.specifiers) {
+            const [variable] = context.sourceCode.getDeclaredVariables(specifier);
+            if (variable) {
+              contractBindings.add(variable);
+            }
+          }
+        }
+
+        if (node.source.value === "zod") {
+          for (const specifier of node.specifiers) {
+            const importsZodNamespace = specifier.type === AST_NODE_TYPES.ImportNamespaceSpecifier;
+            const importsZodBinding =
+              specifier.type === AST_NODE_TYPES.ImportSpecifier &&
+              specifier.imported.type === AST_NODE_TYPES.Identifier &&
+              specifier.imported.name === "z";
+            if (!importsZodNamespace && !importsZodBinding) {
+              continue;
+            }
+
+            const [variable] = context.sourceCode.getDeclaredVariables(specifier);
+            if (variable) {
+              zodBindings.add(variable);
+            }
+          }
+        }
+      },
+      CallExpression(node) {
+        checkInlineAnySchema(node);
+        checkParseBody(node);
+        checkSchemaParse(node);
+        checkWholeResponseAssertion(node);
+      },
+      MemberExpression: checkParsedBodyAccess,
+      VariableDeclarator: checkParsedBodyDestructuring,
+      AssignmentExpression(node) {
+        recordResponseWrite(node, node.left);
+      },
+      UpdateExpression(node) {
+        recordResponseWrite(node, node.argument);
+      },
+    };
+  },
+});
+
+export default rule;


### PR DESCRIPTION
## Summary

- add `@clipboard-health/require-contract-response-parse` to the shared public ESLint plugin
- require response-shape assertions to use schemas imported from `@clipboard-health/contract-*` and report inline `z.any()` / `z.unknown()` schemas
- document a public-safe schema discovery, contract-gap, and warn-to-error migration playbook
- preserve scope, control-flow, reassignment, TypeScript-wrapper, and direct-expression safeguards with RuleTester coverage

## Validation

- `node --run verify`
- `nx test eslint-plugin` (25 rule cases)
- `nx build eslint-plugin`
- `nx lint eslint-plugin`
- pre-push verification passed

## Notes

- [STAFF-2196](https://linear.app/clipboardhealth/issue/STAFF-2196)
- Backend rollout remains in [clipboard-health#27743](https://github.com/ClipboardHealth/clipboard-health/pull/27743) and will consume this rule after the package release.

Agent session: `codex resume 019fd922-6adc-78f1-a1e8-8ba6d149accd`

<sub>🤖 <code>cb-ship:created v1 core@3.23.2</code></sub>