### PR TITLE
feat: add schema package Renovate preset (STAFF-2202)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - [Libraries](#libraries)
 - [Moved libraries](#moved-libraries)
 - [Local development commands](#local-development-commands)
+- [Shared Renovate presets](#shared-renovate-presets)
 - [Adding or porting libraries](#adding-or-porting-libraries)
 - [Contributing](#contributing)
 
@@ -77,6 +78,25 @@ npx nx migrate latest && \
   npm install && \
   npx nx migrate --runMigrations --ifExists
 ```
+
+## Shared Renovate presets
+
+Clipboard repositories can extend the default shared configuration with
+`github>ClipboardHealth/core-utils`.
+
+Repositories that should use Renovate only for published schema packages can instead extend the
+opt-in `schema-packages` preset:
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>ClipboardHealth/core-utils:schema-packages"]
+}
+```
+
+The preset manages `@clipboard-health/contract-*`, `@clipboard-health/flag-*`, and
+`@clipboard-health/message-*`. It opens pull requests for new releases, automerges minor and patch
+updates after checks pass, and leaves major updates for human review.
 
 ## Adding or porting libraries
 

--- a/schema-packages.json
+++ b/schema-packages.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Update Clipboard schema packages only, with non-major releases automerged after CI passes.",
+  "extends": ["config:best-practices", ":preserveSemverRanges"],
+  "enabledManagers": ["npm"],
+  "npmToken": "{{ secrets.NPM_TOKEN }}",
+  "lockFileMaintenance": {
+    "enabled": false
+  },
+  "packageRules": [
+    {
+      "description": "Disable npm updates by default so this preset manages schema packages only.",
+      "matchManagers": ["npm"],
+      "enabled": false
+    },
+    {
+      "description": "Create schema package PRs on the next Renovate run after publication.",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["/^@clipboard-health\\/(contract|flag|message)-/"],
+      "enabled": true,
+      "minimumReleaseAge": "0 days",
+      "schedule": ["at any time"],
+      "prCreation": "immediate"
+    },
+    {
+      "description": "Automerge minor and patch schema package PRs only after Renovate observes passing checks.",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["/^@clipboard-health\\/(contract|flag|message)-/"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": false
+    },
+    {
+      "description": "Leave major schema package PRs for human review.",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["/^@clipboard-health\\/(contract|flag|message)-/"],
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    }
+  ],
+  "prConcurrentLimit": 20,
+  "prHourlyLimit": 0
+}


### PR DESCRIPTION
## Why

Repositories consuming Clipboard schema packages need one opt-in dependency policy instead of duplicating bot configuration and automerge workflows. Centralizing that policy reduces drift and makes contract, flag, and message schema releases reach consumers predictably. There is no direct customer-facing change; the impact is dependency freshness and integration reliability.

## Summary

- Add a schema-only Renovate preset for `@clipboard-health/contract-*`, `flag-*`, and `message-*` packages.
- Open PRs for releases on the next Renovate run.
- Automerge minor and patch PRs only after Renovate observes passing checks; leave majors for review.
- Document the one-line consumer configuration.

## Validation

- `npx --yes --package renovate renovate-config-validator --strict schema-packages.json`
- `node --run verify`
- Independent `cb-review` report: ship gate passed with no findings.

## Notes

- Supports [STAFF-2202](https://linear.app/clipboardhealth/issue/STAFF-2202).
- This opt-in preset does not change repositories extending the existing default preset.
- Merge before updating mobile and admin to consume `github>ClipboardHealth/core-utils:schema-packages`.

Agent session: `codex resume 019fd8ee-78af-7f90-b9a0-5150802e823d`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.2</code></sub>
