### PR TITLE
feat: add random phone number generator (STAFF-2194)

### DIFF
--- a/packages/phone-number/README.md
+++ b/packages/phone-number/README.md
@@ -16,6 +16,16 @@ npm install @clipboard-health/phone-number
 
 ## Usage
 
+```typescript
+import { randomPhoneNumber } from "@clipboard-health/phone-number";
+
+const nationalPhoneNumber = randomPhoneNumber();
+const internationalPhoneNumber = randomPhoneNumber({ international: true });
+```
+
+`randomPhoneNumber` produces valid-looking NANP numbers for synthetic identities. The numbers are
+not reserved, so callers must suppress outbound routing.
+
 ## Local development commands
 
 See [`package.json`](./package.json) `scripts` for a list of commands.

--- a/packages/phone-number/src/index.ts
+++ b/packages/phone-number/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./lib/formatPhoneNumber";
 export * from "./lib/isValidPhoneNumber";
+export * from "./lib/randomPhoneNumber";

--- a/packages/phone-number/src/lib/randomPhoneNumber.test.ts
+++ b/packages/phone-number/src/lib/randomPhoneNumber.test.ts
@@ -1,0 +1,54 @@
+import { isValidPhoneNumber } from "libphonenumber-js";
+
+import { randomPhoneNumber } from "../index";
+
+describe("randomPhoneNumber", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("covers the full-width subscriber-number range", () => {
+    vi.spyOn(Math, "random")
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(1 - Number.EPSILON)
+      .mockReturnValueOnce(1 - Number.EPSILON);
+
+    const actual = [randomPhoneNumber(), randomPhoneNumber()];
+
+    expect(actual).toStrictEqual(["2012000000", "4759999999"]);
+    expect(actual.every((phoneNumber) => isValidPhoneNumber(phoneNumber, "US"))).toBe(true);
+  });
+
+  it("uses only area-code and exchange ranges accepted by pinned phone metadata", () => {
+    const areaCodeCount = 126;
+    const random = vi.spyOn(Math, "random");
+    const phoneNumbers = Array.from({ length: areaCodeCount }, (_, index) => {
+      random.mockReturnValueOnce(index / areaCodeCount).mockReturnValueOnce(0);
+      return randomPhoneNumber();
+    });
+
+    const areaCodes = new Set(phoneNumbers.map((phoneNumber) => phoneNumber.slice(0, 3)));
+    const hasInvalidPhoneNumber = [...areaCodes].some((areaCode) =>
+      Array.from({ length: 800 }, (_, index) => `${areaCode}${200 + index}0000`).some(
+        (phoneNumber) => !isValidPhoneNumber(phoneNumber, "US"),
+      ),
+    );
+
+    expect(areaCodes.size).toBe(areaCodeCount);
+    expect(areaCodes.has("274")).toBe(false);
+    expect(areaCodes.has("472")).toBe(false);
+    expect(areaCodes.size * 8_000_000).toBe(1_008_000_000);
+    expect(phoneNumbers.every((phoneNumber) => isValidPhoneNumber(phoneNumber, "US"))).toBe(true);
+    expect(hasInvalidPhoneNumber).toBe(false);
+  });
+
+  it("includes the US country code when requested", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    const actual = randomPhoneNumber({ international: true });
+
+    expect(actual).toBe("+12012000000");
+    expect(isValidPhoneNumber(actual)).toBe(true);
+  });
+});

--- a/packages/phone-number/src/lib/randomPhoneNumber.ts
+++ b/packages/phone-number/src/lib/randomPhoneNumber.ts
@@ -1,0 +1,173 @@
+export interface RandomPhoneNumberOptions {
+  /** Whether to include the US country code in the number. */
+  international?: boolean;
+}
+
+const VALID_TEST_PHONE_AREA_CODES = [
+  "201",
+  "202",
+  "203",
+  "205",
+  "206",
+  "207",
+  "208",
+  "209",
+  "210",
+  "212",
+  "213",
+  "214",
+  "215",
+  "216",
+  "217",
+  "218",
+  "219",
+  "220",
+  "223",
+  "224",
+  "225",
+  "227",
+  "228",
+  "229",
+  "231",
+  "234",
+  "235",
+  "239",
+  "240",
+  "248",
+  "251",
+  "252",
+  "253",
+  "254",
+  "256",
+  "260",
+  "262",
+  "267",
+  "269",
+  "270",
+  "272",
+  "276",
+  "279",
+  "281",
+  "283",
+  "301",
+  "302",
+  "303",
+  "304",
+  "305",
+  "307",
+  "308",
+  "309",
+  "310",
+  "312",
+  "313",
+  "314",
+  "315",
+  "316",
+  "317",
+  "318",
+  "319",
+  "320",
+  "321",
+  "323",
+  "324",
+  "325",
+  "326",
+  "327",
+  "329",
+  "330",
+  "331",
+  "332",
+  "334",
+  "336",
+  "337",
+  "339",
+  "341",
+  "346",
+  "347",
+  "350",
+  "351",
+  "352",
+  "353",
+  "360",
+  "361",
+  "363",
+  "364",
+  "369",
+  "380",
+  "385",
+  "386",
+  "401",
+  "402",
+  "404",
+  "405",
+  "406",
+  "407",
+  "408",
+  "409",
+  "410",
+  "412",
+  "413",
+  "414",
+  "415",
+  "417",
+  "419",
+  "423",
+  "424",
+  "425",
+  "430",
+  "432",
+  "434",
+  "435",
+  "440",
+  "442",
+  "443",
+  "445",
+  "447",
+  "448",
+  "458",
+  "463",
+  "464",
+  "469",
+  "470",
+  "475",
+] as const;
+
+const MINIMUM_SUBSCRIBER_NUMBER = 2_000_000;
+const MAXIMUM_SUBSCRIBER_NUMBER = 9_999_999;
+
+/**
+ * Creates a random US phone number accepted by pinned libphonenumber-js metadata.
+ *
+ * The 126 area codes × 8,000,000 full-width subscriber numbers provide
+ * 1,008,000,000 possible values. These are not reserved NANP test numbers;
+ * callers creating synthetic identities must suppress outbound routing.
+ */
+export function randomPhoneNumber(options: RandomPhoneNumberOptions = {}): string {
+  const { international = false } = options;
+  const prefix = international ? "+1" : "";
+  const areaCode = randomAreaCode();
+  const subscriberNumber = randomInteger({
+    minimum: MINIMUM_SUBSCRIBER_NUMBER,
+    maximum: MAXIMUM_SUBSCRIBER_NUMBER,
+  });
+
+  return `${prefix}${areaCode}${subscriberNumber}`;
+}
+
+interface RandomIntegerParams {
+  minimum: number;
+  maximum: number;
+}
+
+function randomInteger({ minimum, maximum }: RandomIntegerParams): number {
+  const minimumInteger = Math.ceil(minimum);
+  const maximumInteger = Math.floor(maximum);
+
+  return Math.floor(Math.random() * (maximumInteger - minimumInteger + 1)) + minimumInteger;
+}
+
+function randomAreaCode(): string {
+  const index = randomInteger({ minimum: 0, maximum: VALID_TEST_PHONE_AREA_CODES.length - 1 });
+
+  return VALID_TEST_PHONE_AREA_CODES.slice(index, index + 1).join("");
+}


### PR DESCRIPTION
## Why

Production code needs the shared synthetic phone-number generator, but its current home in `@clipboard-health/testing` makes consumers pull a testing package into the runtime dependency graph. Publishing it from the production-safe `@clipboard-health/phone-number` package gives runtime callers a focused dependency. There is no direct customer-facing change.

## Summary

- add `randomPhoneNumber` to the public `@clipboard-health/phone-number` API
- preserve the existing 1.008 billion-number keyspace with national and international formats
- validate every supported area-code/exchange combination against pinned `libphonenumber-js` metadata
- document that generated numbers are not reserved and outbound routing must remain suppressed

## Validation

- `npm exec nx run-many -- --projects=phone-number --targets=test,lint,build --configuration=ci --skip-nx-cache`
- `node --run verify`
- package coverage: 100% statements, branches, functions, and lines
- independent `cb-review --effort low`: no findings; ship gate passed

## Notes

This is the release-producing first phase of STAFF-2194. After the new package version is published, follow-up changes will migrate `ClipboardHealth/clipboard-health#27772` to this API and make `cbh-core/packages/testing` delegate to it for compatibility.

<sub>🤖 <code>cb-ship:created v1 skill@1.0.2</code></sub>
