### PR TITLE
fix: retain merged Playwright tests with stdio (#836)

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,9 @@
   "knip": {
     "ignoreBinaries": [
       "op"
+    ],
+    "ignoreFiles": [
+      "packages/playwright-reporter-llm/test/e2e/blobMerge/**"
     ]
   }
 }

--- a/packages/playwright-reporter-llm/src/lib/internal/testResults.test.ts
+++ b/packages/playwright-reporter-llm/src/lib/internal/testResults.test.ts
@@ -96,13 +96,18 @@ describe(statusIndicator, () => {
 });
 
 describe(collectStdio, () => {
-  it("concatenates string and buffer chunks with ANSI stripping and capping", () => {
+  it("concatenates live and serialized chunks", () => {
     const result = {
-      stdout: [{ text: "hello " }, { buffer: Buffer.from("world").toString("base64") }],
+      stdout: [
+        "live ",
+        Buffer.from("buffer "),
+        { text: "serialized " },
+        { buffer: Buffer.from("buffer").toString("base64") },
+      ],
       stderr: [],
     } as unknown as TestResult;
 
-    expect(collectStdio(result, "stdout")).toBe("hello world");
+    expect(collectStdio(result, "stdout")).toBe("live buffer serialized buffer");
   });
 
   it("caps at 4KB", () => {

--- a/packages/playwright-reporter-llm/src/lib/internal/testResults.ts
+++ b/packages/playwright-reporter-llm/src/lib/internal/testResults.ts
@@ -9,6 +9,8 @@ import type {
 import type { FlatStep, TestError, TestStatus } from "../types";
 import { capOutput, extractFirstLine, stripAnsi } from "./textProcessing";
 
+type StdioChunk = string | Buffer | { text: string } | { buffer: string };
+
 export function buildFullTitle(test: TestCase): string {
   const parts: string[] = [];
   let current: Suite | undefined = test.parent;
@@ -106,14 +108,8 @@ export function statusIndicator(status: TestStatus): string {
 }
 
 export function collectStdio(result: TestResult, channel: "stdout" | "stderr"): string {
-  const text = (result[channel] as unknown as Array<{ text: string } | { buffer: string }>)
-    .map((chunk) => {
-      if ("text" in chunk) {
-        return chunk.text;
-      }
-      return Buffer.from(chunk.buffer, "base64").toString("utf8");
-    })
-    .join("");
+  const chunks = result[channel] as unknown as StdioChunk[];
+  const text = chunks.map(stdioChunkToString).join("");
   return capOutput(stripAnsi(text));
 }
 
@@ -142,4 +138,17 @@ export function flattenSteps(
   }
 
   return flattenedSteps;
+}
+
+function stdioChunkToString(chunk: StdioChunk): string {
+  if (typeof chunk === "string") {
+    return chunk;
+  }
+  if (Buffer.isBuffer(chunk)) {
+    return chunk.toString("utf8");
+  }
+  if ("text" in chunk) {
+    return chunk.text;
+  }
+  return Buffer.from(chunk.buffer, "base64").toString("utf8");
 }

--- a/packages/playwright-reporter-llm/test/e2e/blobMerge/fixtures/first.fixture.ts
+++ b/packages/playwright-reporter-llm/test/e2e/blobMerge/fixtures/first.fixture.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "@playwright/test";
+
+test("retains stdout from a passing test", () => {
+  // eslint-disable-next-line no-console
+  console.log("passing stdout from the first shard");
+  expect(true).toBe(true);
+});
+
+test("retains stdout from every flaky attempt", () => {
+  const retry = test.info().retry;
+  // eslint-disable-next-line no-console
+  console.log(`flaky stdout from retry ${retry}`);
+  expect(retry).toBe(1);
+});

--- a/packages/playwright-reporter-llm/test/e2e/blobMerge/fixtures/first.fixture.ts
+++ b/packages/playwright-reporter-llm/test/e2e/blobMerge/fixtures/first.fixture.ts
@@ -12,3 +12,9 @@ test("retains stdout from every flaky attempt", () => {
   console.log(`flaky stdout from retry ${retry}`);
   expect(retry).toBe(1);
 });
+
+test("retains stdout from every failed attempt", () => {
+  // eslint-disable-next-line no-console
+  console.log(`failed stdout from retry ${test.info().retry}`);
+  expect(true).toBe(false);
+});

--- a/packages/playwright-reporter-llm/test/e2e/blobMerge/fixtures/second.fixture.ts
+++ b/packages/playwright-reporter-llm/test/e2e/blobMerge/fixtures/second.fixture.ts
@@ -1,0 +1,5 @@
+import { expect, test } from "@playwright/test";
+
+test("retains a test from the second shard", () => {
+  expect("second shard").toContain("shard");
+});

--- a/packages/playwright-reporter-llm/test/e2e/blobMerge/merge.config.ts
+++ b/packages/playwright-reporter-llm/test/e2e/blobMerge/merge.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "@playwright/test";
+
+// oxlint-disable-next-line node/no-process-env
+const outputFile = process.env["PLAYWRIGHT_LLM_OUTPUT_FILE"];
+if (!outputFile) {
+  throw new Error("PLAYWRIGHT_LLM_OUTPUT_FILE is required");
+}
+
+export default defineConfig({
+  reporter: [["../../../src/index.ts", { outputFile }]],
+});

--- a/packages/playwright-reporter-llm/test/e2e/blobMerge/shard.config.ts
+++ b/packages/playwright-reporter-llm/test/e2e/blobMerge/shard.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "@playwright/test";
+
+// oxlint-disable-next-line node/no-process-env
+const outputDirectory = process.env["PLAYWRIGHT_TEST_OUTPUT_DIRECTORY"];
+if (!outputDirectory) {
+  throw new Error("PLAYWRIGHT_TEST_OUTPUT_DIRECTORY is required");
+}
+
+export default defineConfig({
+  testDir: "./fixtures",
+  testMatch: "*.fixture.ts",
+  outputDir: outputDirectory,
+  retries: 1,
+  workers: 1,
+  reporter: [["blob"]],
+});

--- a/packages/playwright-reporter-llm/test/e2e/blobMergeReporter.test.ts
+++ b/packages/playwright-reporter-llm/test/e2e/blobMergeReporter.test.ts
@@ -21,13 +21,13 @@ const MERGE_CONFIG = path.resolve(__dirname, "blobMerge/merge.config.ts");
 interface RunPlaywrightOptions {
   arguments_: string[];
   environment: NodeJS.ProcessEnv;
-  expectedOutputFile?: string;
+  expectedOutputPath?: string;
 }
 
 function runPlaywright({
   arguments_,
   environment,
-  expectedOutputFile,
+  expectedOutputPath,
 }: RunPlaywrightOptions): void {
   try {
     execFileSync(PLAYWRIGHT_CLI, arguments_, {
@@ -38,7 +38,7 @@ function runPlaywright({
     });
   } catch (error) {
     // eslint-disable-next-line security/detect-non-literal-fs-filename
-    if (!expectedOutputFile || !existsSync(expectedOutputFile)) {
+    if (!expectedOutputPath || !existsSync(expectedOutputPath)) {
       throw error;
     }
   }
@@ -83,6 +83,7 @@ describe("merged blob reports", () => {
         PLAYWRIGHT_BLOB_OUTPUT_DIR: firstBlobDirectory,
         PLAYWRIGHT_TEST_OUTPUT_DIRECTORY: path.join(temporaryDirectory, "results-1"),
       },
+      expectedOutputPath: firstBlobDirectory,
     });
     runPlaywright({
       arguments_: ["test", "--config", SHARD_CONFIG, "--shard=2/2"],
@@ -106,7 +107,7 @@ describe("merged blob reports", () => {
         ...environment,
         PLAYWRIGHT_LLM_OUTPUT_FILE: reportPath,
       },
-      expectedOutputFile: reportPath,
+      expectedOutputPath: reportPath,
     });
 
     // eslint-disable-next-line security/detect-non-literal-fs-filename
@@ -121,6 +122,9 @@ describe("merged blob reports", () => {
     const flakyTest = report.tests.find((entry) =>
       entry.title.includes("retains stdout from every flaky attempt"),
     );
+    const failedTest = report.tests.find((entry) =>
+      entry.title.includes("retains stdout from every failed attempt"),
+    );
 
     expect({
       summary: report.summary,
@@ -131,22 +135,34 @@ describe("merged blob reports", () => {
         attemptStatuses: flakyTest?.attempts.map((attempt) => attempt.status),
         attemptStdout: flakyTest?.attempts.map((attempt) => attempt.stdout),
       },
+      failedTest: {
+        status: failedTest?.status,
+        flaky: failedTest?.flaky,
+        attemptStatuses: failedTest?.attempts.map((attempt) => attempt.status),
+        attemptStdout: failedTest?.attempts.map((attempt) => attempt.stdout),
+      },
     }).toStrictEqual({
       summary: {
-        total: 3,
+        total: 4,
         passed: 2,
-        failed: 0,
+        failed: 1,
         flaky: 1,
         skipped: 0,
         timedOut: 0,
         interrupted: 0,
       },
-      testCount: 3,
+      testCount: 4,
       flakyTest: {
         status: "passed",
         flaky: true,
         attemptStatuses: ["failed", "passed"],
         attemptStdout: ["flaky stdout from retry 0\n", "flaky stdout from retry 1\n"],
+      },
+      failedTest: {
+        status: "failed",
+        flaky: false,
+        attemptStatuses: ["failed", "failed"],
+        attemptStdout: ["failed stdout from retry 0\n", "failed stdout from retry 1\n"],
       },
     });
   });

--- a/packages/playwright-reporter-llm/test/e2e/blobMergeReporter.test.ts
+++ b/packages/playwright-reporter-llm/test/e2e/blobMergeReporter.test.ts
@@ -1,0 +1,153 @@
+import { execFileSync } from "node:child_process";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type { LlmTestReport } from "../../src/lib/types";
+
+const PACKAGE_DIRECTORY = path.resolve(__dirname, "../..");
+const PLAYWRIGHT_CLI = path.resolve(PACKAGE_DIRECTORY, "../../node_modules/.bin/playwright");
+const SHARD_CONFIG = path.resolve(__dirname, "blobMerge/shard.config.ts");
+const MERGE_CONFIG = path.resolve(__dirname, "blobMerge/merge.config.ts");
+
+interface RunPlaywrightOptions {
+  arguments_: string[];
+  environment: NodeJS.ProcessEnv;
+  expectedOutputFile?: string;
+}
+
+function runPlaywright({
+  arguments_,
+  environment,
+  expectedOutputFile,
+}: RunPlaywrightOptions): void {
+  try {
+    execFileSync(PLAYWRIGHT_CLI, arguments_, {
+      cwd: PACKAGE_DIRECTORY,
+      env: environment,
+      stdio: "pipe",
+      timeout: 30_000,
+    });
+  } catch (error) {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    if (!expectedOutputFile || !existsSync(expectedOutputFile)) {
+      throw error;
+    }
+  }
+}
+
+interface CopyBlobReportOptions {
+  sourceDirectory: string;
+  targetDirectory: string;
+}
+
+function copyBlobReport({ sourceDirectory, targetDirectory }: CopyBlobReportOptions): void {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  const fileName = readdirSync(sourceDirectory).find((entry) => entry.endsWith(".zip"));
+  if (!fileName) {
+    throw new Error(`No blob report found in ${sourceDirectory}`);
+  }
+  copyFileSync(path.join(sourceDirectory, fileName), path.join(targetDirectory, fileName));
+}
+
+describe("merged blob reports", () => {
+  let temporaryDirectory: string;
+  let report: LlmTestReport;
+
+  beforeAll(() => {
+    temporaryDirectory = mkdtempSync(path.join(tmpdir(), "llm-reporter-blob-merge-"));
+    const firstBlobDirectory = path.join(temporaryDirectory, "blob-1");
+    const secondBlobDirectory = path.join(temporaryDirectory, "blob-2");
+    const mergedBlobDirectory = path.join(temporaryDirectory, "merged-blobs");
+    const reportPath = path.join(temporaryDirectory, "llm-report.json");
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    mkdirSync(mergedBlobDirectory);
+
+    const environment = Object.fromEntries(
+      // oxlint-disable-next-line node/no-process-env
+      Object.entries(process.env).filter(([key]) => !key.startsWith("JEST")),
+    );
+
+    runPlaywright({
+      arguments_: ["test", "--config", SHARD_CONFIG, "--shard=1/2"],
+      environment: {
+        ...environment,
+        PLAYWRIGHT_BLOB_OUTPUT_DIR: firstBlobDirectory,
+        PLAYWRIGHT_TEST_OUTPUT_DIRECTORY: path.join(temporaryDirectory, "results-1"),
+      },
+    });
+    runPlaywright({
+      arguments_: ["test", "--config", SHARD_CONFIG, "--shard=2/2"],
+      environment: {
+        ...environment,
+        PLAYWRIGHT_BLOB_OUTPUT_DIR: secondBlobDirectory,
+        PLAYWRIGHT_TEST_OUTPUT_DIRECTORY: path.join(temporaryDirectory, "results-2"),
+      },
+    });
+    copyBlobReport({
+      sourceDirectory: firstBlobDirectory,
+      targetDirectory: mergedBlobDirectory,
+    });
+    copyBlobReport({
+      sourceDirectory: secondBlobDirectory,
+      targetDirectory: mergedBlobDirectory,
+    });
+    runPlaywright({
+      arguments_: ["merge-reports", "--config", MERGE_CONFIG, mergedBlobDirectory],
+      environment: {
+        ...environment,
+        PLAYWRIGHT_LLM_OUTPUT_FILE: reportPath,
+      },
+      expectedOutputFile: reportPath,
+    });
+
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    report = JSON.parse(readFileSync(reportPath, "utf8")) as LlmTestReport;
+  }, 60_000);
+
+  afterAll(() => {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  it("retains tests and attempts that emit stdio", () => {
+    const flakyTest = report.tests.find((entry) =>
+      entry.title.includes("retains stdout from every flaky attempt"),
+    );
+
+    expect({
+      summary: report.summary,
+      testCount: report.tests.length,
+      flakyTest: {
+        status: flakyTest?.status,
+        flaky: flakyTest?.flaky,
+        attemptStatuses: flakyTest?.attempts.map((attempt) => attempt.status),
+        attemptStdout: flakyTest?.attempts.map((attempt) => attempt.stdout),
+      },
+    }).toStrictEqual({
+      summary: {
+        total: 3,
+        passed: 2,
+        failed: 0,
+        flaky: 1,
+        skipped: 0,
+        timedOut: 0,
+        interrupted: 0,
+      },
+      testCount: 3,
+      flakyTest: {
+        status: "passed",
+        flaky: true,
+        attemptStatuses: ["failed", "passed"],
+        attemptStdout: ["flaky stdout from retry 0\n", "flaky stdout from retry 1\n"],
+      },
+    });
+  });
+});

--- a/packages/playwright-reporter-llm/test/e2e/blobMergeReporter.test.ts
+++ b/packages/playwright-reporter-llm/test/e2e/blobMergeReporter.test.ts
@@ -112,7 +112,7 @@ describe("merged blob reports", () => {
 
     // eslint-disable-next-line security/detect-non-literal-fs-filename
     report = JSON.parse(readFileSync(reportPath, "utf8")) as LlmTestReport;
-  }, 60_000);
+  }, 100_000);
 
   afterAll(() => {
     rmSync(temporaryDirectory, { recursive: true, force: true });


### PR DESCRIPTION
## Why

Playwright blob-report replay serializes stdout and stderr chunks as primitive strings, but the LLM reporter only accepted serialized object wrappers. The resulting `TypeError` aborted `onTestEnd`, silently omitted affected tests, and produced incorrect schema-v3 summary counts. There is no direct customer impact; the impact is unreliable CI diagnostics and automated failure analysis.

## Summary

- Normalize live and blob-serialized Playwright stdio chunk shapes before building test attempts.
- Preserve failed and flaky tests that emit stdout across merged shards.
- Add an end-to-end two-shard blob merge regression covering failed/flaky attempts and summary counts.

## Validation

- `mise exec -- npm exec nx -- run-many -t test lint build -p playwright-reporter-llm --outputStyle=stream-without-prefixes --skipRemoteCache --skipNxCache`
- `mise exec -- node --run verify`
- `cb-review --effort low --report`: no findings; Ship gate: pass; requirements met.

## Notes

Closes #836.

Agent session: `codex resume 019ff636-88c0-78b0-a9f8-2ef7657a5a0a`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.2</code></sub>
