### PR TITLE
feat: share contract fixture enforcement

### DIFF
--- a/.knip.jsonc
+++ b/.knip.jsonc
@@ -56,6 +56,9 @@
     "packages/notifications": {
       "entry": ["examples/**/*.ts", "src/index.ts"],
     },
+    "packages/oxlint-config": {
+      "ignoreDependencies": ["@clipboard-health/eslint-plugin"],
+    },
     "packages/rules-engine": {
       "entry": ["examples/**/*.ts", "src/index.ts"],
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -33212,6 +33212,9 @@
       "name": "@clipboard-health/oxlint-config",
       "version": "1.14.3",
       "license": "MIT",
+      "dependencies": {
+        "@clipboard-health/eslint-plugin": "2.8.0"
+      },
       "peerDependencies": {
         "oxlint": ">=1.68.0",
         "oxlint-tsgolint": ">=0.21.1"

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -5,6 +5,7 @@ Clipboard's [ESLint](https://eslint.org/) plugin.
 ## Table of contents <!-- omit from toc -->
 
 - [Install](#install)
+- [Contract fixture construction](#contract-fixture-construction)
 - [Local development commands](#local-development-commands)
 
 ## Install
@@ -33,6 +34,17 @@ module.exports = {
   root: true,
 };
 ```
+
+## Contract fixture construction
+
+`require-contract-fixture-construction` requires MSW and Playwright response fixtures to be
+constructed through response schemas imported from `@clipboard-health/contract-*` packages. It
+also checks exported fixtures in `testUtils/mocks` modules and rejects fixtures mutated after they
+were parsed.
+
+Prefer the `contractFixtures` preset from `@clipboard-health/oxlint-config`. Repositories migrating
+an existing fixture backlog should enable the preset's warning baseline, then add local error-level
+overrides for each migrated directory.
 
 ## Local development commands
 

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,5 +1,6 @@
 import enforceTsRestInControllers from "./lib/rules/enforce-ts-rest-in-controllers";
 import noCrossContractImports from "./lib/rules/no-cross-contract-imports";
+import requireContractFixtureConstruction from "./lib/rules/require-contract-fixture-construction";
 import requireContractResponseParse from "./lib/rules/require-contract-response-parse";
 import requireHttpModuleFactory from "./lib/rules/require-http-module-factory";
 import requireRunValidatorsWithUpsert from "./lib/rules/require-run-validators-with-upsert";
@@ -8,6 +9,7 @@ import requireZodImportInContracts from "./lib/rules/require-zod-import-in-contr
 export const rules = {
   "enforce-ts-rest-in-controllers": enforceTsRestInControllers,
   "no-cross-contract-imports": noCrossContractImports,
+  "require-contract-fixture-construction": requireContractFixtureConstruction,
   "require-contract-response-parse": requireContractResponseParse,
   "require-http-module-factory": requireHttpModuleFactory,
   "require-run-validators-with-upsert": requireRunValidatorsWithUpsert,

--- a/packages/eslint-plugin/src/lib/rules/require-contract-fixture-construction/index.test.ts
+++ b/packages/eslint-plugin/src/lib/rules/require-contract-fixture-construction/index.test.ts
@@ -137,6 +137,20 @@ ruleTester.run("require-contract-fixture-construction", rule, {
       errors: [{ messageId: "parsePayload" }],
     },
     {
+      name: "rejects direct and indirect exports mutated later in the module",
+      filename: mocksFile,
+      code: `
+        import { FeatureResponseSchema } from "@clipboard-health/contract-feature";
+        export const mockDirect = FeatureResponseSchema.parse({ items: [] });
+        mockDirect.items.push({ id: "drift" });
+
+        const mockIndirect = FeatureResponseSchema.parse({ items: [] });
+        export { mockIndirect };
+        mockIndirect.items.push({ id: "drift" });
+      `,
+      errors: [{ messageId: "parseMock" }, { messageId: "parseMock" }],
+    },
+    {
       name: "propagates mutation through aliases",
       filename: handlersFile,
       code: `

--- a/packages/eslint-plugin/src/lib/rules/require-contract-fixture-construction/index.test.ts
+++ b/packages/eslint-plugin/src/lib/rules/require-contract-fixture-construction/index.test.ts
@@ -1,0 +1,213 @@
+import { TSESLint } from "@typescript-eslint/utils";
+
+import rule from "./index";
+
+// eslint-disable-next-line n/no-unpublished-require
+const parser = require.resolve("@typescript-eslint/parser");
+
+const ruleTester = new TSESLint.RuleTester({
+  parser,
+  parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+});
+
+const mocksFile = "/repo/src/app/Feature/api/testUtils/mocks.ts";
+const handlersFile = "/repo/src/app/Feature/api/test-utils/handlers.ts";
+const playwrightFile = "/repo/playwright/e2e/feature.spec.ts";
+
+// oxlint-disable-next-line vitest/expect-expect -- RuleTester validates declaratively
+ruleTester.run("require-contract-fixture-construction", rule, {
+  valid: [
+    {
+      name: "accepts an exported fixture parsed by an imported response schema",
+      filename: mocksFile,
+      code: `
+        import { FeatureResponseSchema } from "@clipboard-health/contract-feature";
+        export const mockFeature = FeatureResponseSchema.parse({ id: "feature" });
+      `,
+    },
+    {
+      name: "accepts a response-map schema through a forward-declared builder",
+      filename: mocksFile,
+      code: `
+        import { featureContract } from "@clipboard-health/contract-feature";
+        import { createContractFixtureBuilder as createFixture } from "@clipboard-health/testing-core";
+        export const mockFeature = buildFeature();
+        const buildFeature = createFixture({
+          schema: featureContract.get.responses[200],
+          defaults: { id: "feature" },
+        });
+      `,
+    },
+    {
+      name: "accepts fixtures imported from an enforced sibling mocks module",
+      filename: handlersFile,
+      code: `
+        import { mockFeature } from "./mocks";
+        export const handler = rest.get("/feature", (_request, response, ctx) =>
+          response(ctx.json(mockFeature))
+        );
+      `,
+    },
+    {
+      name: "accepts aliased HttpResponse and parsed payloads",
+      filename: handlersFile,
+      code: `
+        import { FeatureResponseSchema } from "@clipboard-health/contract-feature";
+        import { HttpResponse as Response } from "msw";
+        const payload = FeatureResponseSchema.parse({ id: "feature" });
+        export const handler = http.get("/feature", () => Response.json(payload));
+      `,
+    },
+    {
+      name: "accepts a parsed fixture after read-only inspection",
+      filename: handlersFile,
+      code: `
+        import { FeatureResponseSchema } from "@clipboard-health/contract-feature";
+        const payload = FeatureResponseSchema.parse({ id: "feature" });
+        expect(payload).toMatchObject({ id: "feature" });
+        observe(payload);
+        context.json(payload);
+      `,
+    },
+    {
+      name: "ignores unrelated json and fulfill methods",
+      filename: handlersFile,
+      code: `
+        logger.json({ freehand: true });
+        promise.fulfill({ json: { freehand: true } });
+      `,
+    },
+    {
+      name: "accepts parsed Playwright shorthand and spread payloads",
+      filename: playwrightFile,
+      code: `
+        import { FeatureResponseSchema } from "@clipboard-health/contract-feature";
+        const json = FeatureResponseSchema.parse({ id: "feature" });
+        const base = { status: 200, json };
+        await route.fulfill({ ...base, headers: {} });
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: "rejects a freehand exported mock",
+      filename: mocksFile,
+      code: `export const mockFeature = { id: "feature" };`,
+      errors: [{ messageId: "parseMock" }],
+    },
+    {
+      name: "rejects a local schema copy",
+      filename: mocksFile,
+      code: `
+        import { z } from "zod";
+        const LocalResponseSchema = z.object({ id: z.string() });
+        export const mockFeature = LocalResponseSchema.parse({ id: "feature" });
+      `,
+      errors: [{ messageId: "parseMock" }],
+    },
+    {
+      name: "rejects request and nested contract schemas",
+      filename: mocksFile,
+      code: `
+        import { featureContract } from "@clipboard-health/contract-feature";
+        export const mockRequest = featureContract.get.body.parse({ id: "feature" });
+        export const mockNested = featureContract.get.responses[200].shape.data.parse([]);
+      `,
+      errors: [{ messageId: "parseMock" }, { messageId: "parseMock" }],
+    },
+    {
+      name: "rejects a shadowed contract schema",
+      filename: handlersFile,
+      code: `
+        import { FeatureResponseSchema } from "@clipboard-health/contract-feature";
+        export const handler = (FeatureResponseSchema) =>
+          context.json(FeatureResponseSchema.parse({ id: "feature" }));
+      `,
+      errors: [{ messageId: "parsePayload" }],
+    },
+    {
+      name: "rejects parsed fixtures mutated before MSW observes them",
+      filename: handlersFile,
+      code: `
+        import { FeatureResponseSchema } from "@clipboard-health/contract-feature";
+        const payload = FeatureResponseSchema.parse({ items: [] });
+        payload.items.push({ id: "drift" });
+        context.json(payload);
+      `,
+      errors: [{ messageId: "parsePayload" }],
+    },
+    {
+      name: "propagates mutation through aliases",
+      filename: handlersFile,
+      code: `
+        import { FeatureResponseSchema } from "@clipboard-health/contract-feature";
+        const payload = FeatureResponseSchema.parse({ items: [] });
+        const alias = payload.items;
+        alias.push({ id: "drift" });
+        context.json(payload);
+      `,
+      errors: [{ messageId: "parsePayload" }],
+    },
+    {
+      name: "propagates mutations through destructured aliases",
+      filename: handlersFile,
+      code: `
+        import { FeatureResponseSchema } from "@clipboard-health/contract-feature";
+        const payload = FeatureResponseSchema.parse({ items: [] });
+        const { items } = payload;
+        items.push({ id: "drift" });
+        context.json(payload);
+      `,
+      errors: [{ messageId: "parsePayload" }],
+    },
+    {
+      name: "rejects freehand MSW response forms",
+      filename: handlersFile,
+      code: `
+        import { HttpResponse } from "msw";
+        context.json({ first: true });
+        ctx.json({ second: true });
+        HttpResponse.json({ third: true });
+      `,
+      errors: [
+        { messageId: "parsePayload" },
+        { messageId: "parsePayload" },
+        { messageId: "parsePayload" },
+      ],
+    },
+    {
+      name: "rejects Playwright options aliases, shorthand, and serialized bodies",
+      filename: playwrightFile,
+      code: `
+        const json = { first: true };
+        const firstOptions = { json };
+        await route.fulfill(firstOptions);
+        const body = JSON.stringify({ second: true });
+        await apiRoute.fulfill({ body });
+      `,
+      errors: [{ messageId: "parsePayload" }, { messageId: "parsePayload" }],
+    },
+    {
+      name: "rejects Playwright route aliases with freehand payloads",
+      filename: playwrightFile,
+      code: `await r.fulfill({ json: { freehand: true } });`,
+      errors: [{ messageId: "parsePayload" }],
+    },
+    {
+      name: "fails closed on unresolved Playwright spreads",
+      filename: playwrightFile,
+      code: `
+        import { FeatureResponseSchema } from "@clipboard-health/contract-feature";
+        const parsed = FeatureResponseSchema.parse({ id: "feature" });
+        await route.fulfill({ json: parsed, ...unknownOptions });
+      `,
+      errors: [{ messageId: "parsePayload" }],
+    },
+    {
+      name: "rejects exported fixture builders returning freehand values",
+      filename: mocksFile,
+      code: `export function makeFixture() { return { id: "feature" }; }`,
+      errors: [{ messageId: "parseMock" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/lib/rules/require-contract-fixture-construction/index.ts
+++ b/packages/eslint-plugin/src/lib/rules/require-contract-fixture-construction/index.ts
@@ -1,0 +1,750 @@
+import { AST_NODE_TYPES, ASTUtils, type TSESLint, type TSESTree } from "@typescript-eslint/utils";
+
+import { createRule } from "../../createRule";
+
+const CONTRACT_PACKAGE_PREFIX = "@clipboard-health/contract-";
+const MOCKS_FILE_PATTERN = /\/(?:testUtils|test-utils)\/mocks\.[cm]?[jt]sx?$/u;
+const MOCK_NAME_PATTERN = /mock/iu;
+const MUTATING_METHOD_NAMES = new Set([
+  "add",
+  "clear",
+  "copyWithin",
+  "delete",
+  "fill",
+  "pop",
+  "push",
+  "reverse",
+  "set",
+  "shift",
+  "sort",
+  "splice",
+  "unshift",
+]);
+const OBJECT_MUTATOR_NAMES = new Set([
+  "assign",
+  "defineProperties",
+  "defineProperty",
+  "setPrototypeOf",
+]);
+
+type Expression = TSESTree.Expression;
+type FunctionNode =
+  | TSESTree.ArrowFunctionExpression
+  | TSESTree.FunctionDeclaration
+  | TSESTree.FunctionExpression;
+
+interface Candidate {
+  node: Expression;
+  observationPosition: number;
+}
+
+interface IndirectExport {
+  exportedName: string;
+  local: TSESTree.Identifier;
+}
+
+interface PayloadMap {
+  body?: Expression;
+  json?: Expression;
+  unknown?: Expression;
+}
+
+function unwrap(node: TSESTree.Node | undefined): TSESTree.Node | undefined {
+  let current = node;
+
+  while (
+    current?.type === AST_NODE_TYPES.ChainExpression ||
+    current?.type === AST_NODE_TYPES.TSAsExpression ||
+    current?.type === AST_NODE_TYPES.TSInstantiationExpression ||
+    current?.type === AST_NODE_TYPES.TSNonNullExpression ||
+    current?.type === AST_NODE_TYPES.TSSatisfiesExpression ||
+    current?.type === AST_NODE_TYPES.TSTypeAssertion
+  ) {
+    current = current.expression;
+  }
+
+  return current;
+}
+
+function propertyName(node: TSESTree.MemberExpression | TSESTree.Property): string | undefined {
+  const property = node.type === AST_NODE_TYPES.MemberExpression ? node.property : node.key;
+  const computed = node.computed;
+  if (!computed && property.type === AST_NODE_TYPES.Identifier) {
+    return property.name;
+  }
+  if (computed && property.type === AST_NODE_TYPES.Literal && typeof property.value === "string") {
+    return property.value;
+  }
+  return undefined;
+}
+
+function isExpression(node: TSESTree.Node | null | undefined): node is Expression {
+  return (
+    node !== null &&
+    node !== undefined &&
+    node.type !== AST_NODE_TYPES.SpreadElement &&
+    node.type !== AST_NODE_TYPES.JSXElement &&
+    node.type !== AST_NODE_TYPES.JSXFragment
+  );
+}
+
+function rootIdentifier(node: TSESTree.Node | undefined): TSESTree.Identifier | undefined {
+  let current = unwrap(node);
+  while (current?.type === AST_NODE_TYPES.MemberExpression) {
+    current = unwrap(current.object);
+  }
+  return current?.type === AST_NODE_TYPES.Identifier ? current : undefined;
+}
+
+function objectProperty(
+  object: TSESTree.ObjectExpression,
+  name: string,
+): TSESTree.Property | undefined {
+  return object.properties.find(
+    (entry): entry is TSESTree.Property =>
+      entry.type === AST_NODE_TYPES.Property && propertyName(entry) === name,
+  );
+}
+
+function isRouteFulfillCall(node: TSESTree.CallExpression, allowAnyReceiver: boolean): boolean {
+  return (
+    node.callee.type === AST_NODE_TYPES.MemberExpression &&
+    propertyName(node.callee) === "fulfill" &&
+    node.callee.object.type === AST_NODE_TYPES.Identifier &&
+    (allowAnyReceiver || /route$/iu.test(node.callee.object.name))
+  );
+}
+
+function isFixtureValue(name: string, node: TSESTree.Node | undefined): boolean {
+  const current = unwrap(node);
+  return (
+    MOCK_NAME_PATTERN.test(name) ||
+    current?.type === AST_NODE_TYPES.ArrayExpression ||
+    current?.type === AST_NODE_TYPES.ObjectExpression
+  );
+}
+
+function importName(specifier: TSESTree.ImportClause): string {
+  if (specifier.type === AST_NODE_TYPES.ImportSpecifier) {
+    return specifier.imported.type === AST_NODE_TYPES.Identifier
+      ? specifier.imported.name
+      : specifier.imported.value;
+  }
+  return specifier.type === AST_NODE_TYPES.ImportNamespaceSpecifier ? "*" : "default";
+}
+
+const rule = createRule({
+  name: "require-contract-fixture-construction",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Require response fixtures to be constructed by producer-owned contracts",
+    },
+    schema: [],
+    messages: {
+      parseMock:
+        "Construct exported response fixtures with a producer-owned contract response schema.",
+      parsePayload:
+        "Construct JSON response fixtures with a producer-owned contract response schema before passing them to the test transport.",
+    },
+  },
+  create(context) {
+    const filename = context.filename.replaceAll("\\", "/");
+    const isMocksFile = MOCKS_FILE_PATTERN.test(filename);
+    const isPlaywrightFile = filename.includes("/playwright/");
+    const isTestUtilsFile = /\/(?:testUtils|test-utils)\//u.test(filename);
+    const contractImports = new Map<TSESLint.Scope.Variable, string>();
+    const fixtureBuilderFactoryImports = new Set<TSESLint.Scope.Variable>();
+    const oneShotBuilderImports = new Set<TSESLint.Scope.Variable>();
+    const httpResponseImports = new Set<TSESLint.Scope.Variable>();
+    const trustedFixtureImports = new Set<TSESLint.Scope.Variable>();
+    const variableInitializers = new Map<TSESLint.Scope.Variable, Expression>();
+    const fixtureBuilders = new Set<TSESLint.Scope.Variable>();
+    const mutations = new Map<TSESLint.Scope.Variable, number[]>();
+    const aliasTargets = new Map<TSESLint.Scope.Variable, TSESLint.Scope.Variable>();
+    const candidates: Candidate[] = [];
+    const directFixtureCandidates: Candidate[] = [];
+    const functionReturns = new Map<FunctionNode, Expression[]>();
+    const functionStack: FunctionNode[] = [];
+    const exportedFunctions = new Set<FunctionNode>();
+    const indirectExports: IndirectExport[] = [];
+
+    function variableFor(identifier: TSESTree.Identifier): TSESLint.Scope.Variable | undefined {
+      return (
+        ASTUtils.findVariable(context.sourceCode.getScope(identifier), identifier) ?? undefined
+      );
+    }
+
+    function declaredVariable(node: TSESTree.Node): TSESLint.Scope.Variable | undefined {
+      return context.sourceCode.getDeclaredVariables(node)[0];
+    }
+
+    function recordMutation(node: TSESTree.Node | undefined, position: number): void {
+      const identifier = rootIdentifier(node);
+      if (!identifier) {
+        return;
+      }
+      const variable = variableFor(identifier);
+      if (!variable) {
+        return;
+      }
+      const positions = mutations.get(variable) ?? [];
+      positions.push(position);
+      mutations.set(variable, positions);
+    }
+
+    function wasMutated(variable: TSESLint.Scope.Variable, observationPosition: number): boolean {
+      return mutations.get(variable)?.some((position) => position < observationPosition) === true;
+    }
+
+    function isContractRoot(identifier: TSESTree.Identifier): boolean {
+      const variable = variableFor(identifier);
+      return variable !== undefined && contractImports.has(variable);
+    }
+
+    function isContractResponseSchema(
+      node: TSESTree.Node | undefined,
+      seen = new Set<TSESLint.Scope.Variable>(),
+    ): boolean {
+      const current = unwrap(node);
+      if (!current) {
+        return false;
+      }
+
+      if (current.type === AST_NODE_TYPES.Identifier) {
+        const variable = variableFor(current);
+        if (!variable) {
+          return false;
+        }
+        const importedName = contractImports.get(variable);
+        if (importedName !== undefined) {
+          return importedName.endsWith("ResponseSchema");
+        }
+        if (seen.has(variable)) {
+          return false;
+        }
+        seen.add(variable);
+        return isContractResponseSchema(variableInitializers.get(variable), seen);
+      }
+
+      if (current.type !== AST_NODE_TYPES.MemberExpression) {
+        return false;
+      }
+
+      const selectedFromResponses =
+        current.computed &&
+        current.object.type === AST_NODE_TYPES.MemberExpression &&
+        propertyName(current.object) === "responses";
+      if (selectedFromResponses) {
+        const root = rootIdentifier(current);
+        return root !== undefined && isContractRoot(root);
+      }
+
+      const selectedNamedSchema = propertyName(current)?.endsWith("ResponseSchema") === true;
+      if (selectedNamedSchema) {
+        const root = rootIdentifier(current);
+        return root !== undefined && isContractRoot(root);
+      }
+
+      return false;
+    }
+
+    function hasContractSchemaOption(call: TSESTree.CallExpression): boolean {
+      const [options] = call.arguments;
+      const current = unwrap(options);
+      if (current?.type !== AST_NODE_TYPES.ObjectExpression) {
+        return false;
+      }
+      const schema = objectProperty(current, "schema");
+      return (
+        schema !== undefined && isExpression(schema.value) && isContractResponseSchema(schema.value)
+      );
+    }
+
+    function isOneShotBuilderCall(node: TSESTree.Node | undefined): boolean {
+      const current = unwrap(node);
+      if (
+        current?.type !== AST_NODE_TYPES.CallExpression ||
+        current.callee.type !== AST_NODE_TYPES.Identifier
+      ) {
+        return false;
+      }
+      const variable = variableFor(current.callee);
+      return (
+        variable !== undefined &&
+        oneShotBuilderImports.has(variable) &&
+        hasContractSchemaOption(current)
+      );
+    }
+
+    function isFixtureBuilderFactoryCall(node: TSESTree.Node | undefined): boolean {
+      const current = unwrap(node);
+      if (
+        current?.type !== AST_NODE_TYPES.CallExpression ||
+        current.callee.type !== AST_NODE_TYPES.Identifier
+      ) {
+        return false;
+      }
+      const variable = variableFor(current.callee);
+      return (
+        variable !== undefined &&
+        fixtureBuilderFactoryImports.has(variable) &&
+        hasContractSchemaOption(current)
+      );
+    }
+
+    function isContractParseCall(node: TSESTree.Node | undefined): boolean {
+      const current = unwrap(node);
+      return (
+        current?.type === AST_NODE_TYPES.CallExpression &&
+        current.callee.type === AST_NODE_TYPES.MemberExpression &&
+        propertyName(current.callee) === "parse" &&
+        isContractResponseSchema(current.callee.object)
+      );
+    }
+
+    function isContractConstructed(
+      node: TSESTree.Node | undefined,
+      observationPosition: number,
+      seen = new Set<TSESLint.Scope.Variable>(),
+    ): boolean {
+      const current = unwrap(node);
+      if (!current) {
+        return false;
+      }
+      if (isContractParseCall(current) || isOneShotBuilderCall(current)) {
+        return true;
+      }
+      if (
+        current.type === AST_NODE_TYPES.CallExpression &&
+        current.callee.type === AST_NODE_TYPES.Identifier
+      ) {
+        const variable = variableFor(current.callee);
+        if (variable !== undefined && fixtureBuilders.has(variable)) {
+          return true;
+        }
+      }
+      if (current.type !== AST_NODE_TYPES.Identifier) {
+        return false;
+      }
+      const variable = variableFor(current);
+      if (!variable || seen.has(variable) || wasMutated(variable, observationPosition)) {
+        return false;
+      }
+      if (trustedFixtureImports.has(variable)) {
+        return true;
+      }
+      const initializer = variableInitializers.get(variable);
+      if (!initializer) {
+        return false;
+      }
+      seen.add(variable);
+      return isContractConstructed(initializer, observationPosition, seen);
+    }
+
+    function resolveObject(
+      node: TSESTree.Node | undefined,
+      observationPosition: number,
+      seen = new Set<TSESLint.Scope.Variable>(),
+    ): TSESTree.ObjectExpression | undefined {
+      const current = unwrap(node);
+      if (current?.type === AST_NODE_TYPES.ObjectExpression) {
+        return current;
+      }
+      if (current?.type !== AST_NODE_TYPES.Identifier) {
+        return undefined;
+      }
+      const variable = variableFor(current);
+      if (!variable || seen.has(variable) || wasMutated(variable, observationPosition)) {
+        return undefined;
+      }
+      const initializer = variableInitializers.get(variable);
+      if (!initializer) {
+        return undefined;
+      }
+      seen.add(variable);
+      return resolveObject(initializer, observationPosition, seen);
+    }
+
+    function jsonStringifyPayload(
+      node: TSESTree.Node | undefined,
+      seen = new Set<TSESLint.Scope.Variable>(),
+    ): Expression | undefined {
+      const current = unwrap(node);
+      if (
+        current?.type === AST_NODE_TYPES.CallExpression &&
+        current.callee.type === AST_NODE_TYPES.MemberExpression &&
+        current.callee.object.type === AST_NODE_TYPES.Identifier &&
+        current.callee.object.name === "JSON" &&
+        propertyName(current.callee) === "stringify"
+      ) {
+        const [payload] = current.arguments;
+        return isExpression(payload) ? payload : undefined;
+      }
+      if (current?.type !== AST_NODE_TYPES.Identifier) {
+        return undefined;
+      }
+      const variable = variableFor(current);
+      if (!variable || seen.has(variable)) {
+        return undefined;
+      }
+      seen.add(variable);
+      return jsonStringifyPayload(variableInitializers.get(variable), seen);
+    }
+
+    function playwrightPayloads(
+      node: TSESTree.Node | undefined,
+      observationPosition: number,
+      seen = new Set<TSESLint.Scope.Variable>(),
+    ): PayloadMap {
+      const options = resolveObject(node, observationPosition, seen);
+      if (!options) {
+        return isExpression(unwrap(node)) ? { unknown: unwrap(node) as Expression } : {};
+      }
+
+      const payloads: PayloadMap = {};
+      for (const entry of options.properties) {
+        if (entry.type === AST_NODE_TYPES.SpreadElement) {
+          const spread = playwrightPayloads(entry.argument, observationPosition, new Set(seen));
+          if (spread.unknown) {
+            return { unknown: spread.unknown };
+          }
+          if (spread.body !== undefined) {
+            payloads.body = spread.body;
+          }
+          if (spread.json !== undefined) {
+            payloads.json = spread.json;
+          }
+          continue;
+        }
+        const name = propertyName(entry);
+        if (name === undefined && entry.computed && isExpression(entry.value)) {
+          return { unknown: entry.value };
+        }
+        if (!isExpression(entry.value)) {
+          continue;
+        }
+        if (name === "json") {
+          payloads.json = entry.value;
+        } else if (name === "body") {
+          const serialized = jsonStringifyPayload(entry.value);
+          if (serialized) {
+            payloads.body = serialized;
+          }
+        }
+      }
+      return payloads;
+    }
+
+    function isMswJsonCall(node: TSESTree.CallExpression): boolean {
+      if (
+        node.callee.type !== AST_NODE_TYPES.MemberExpression ||
+        propertyName(node.callee) !== "json" ||
+        node.callee.object.type !== AST_NODE_TYPES.Identifier
+      ) {
+        return false;
+      }
+      if (node.callee.object.name === "ctx" || node.callee.object.name === "context") {
+        return true;
+      }
+      const variable = variableFor(node.callee.object);
+      return variable !== undefined && httpResponseImports.has(variable);
+    }
+
+    function addCandidate(node: TSESTree.Node | undefined, observationPosition: number): void {
+      if (isExpression(node)) {
+        candidates.push({ node, observationPosition });
+      }
+    }
+
+    function addDirectFixture(node: TSESTree.Node | null | undefined): void {
+      if (isExpression(node)) {
+        directFixtureCandidates.push({ node, observationPosition: node.range[0] });
+      }
+    }
+
+    function registerBuilderVariables(): void {
+      let changed = true;
+      while (changed) {
+        changed = false;
+        for (const [variable, initializer] of variableInitializers) {
+          if (!fixtureBuilders.has(variable) && isFixtureBuilderFactoryCall(initializer)) {
+            fixtureBuilders.add(variable);
+            changed = true;
+          }
+        }
+      }
+    }
+
+    function propagateAliasMutations(): void {
+      let changed = true;
+      while (changed) {
+        changed = false;
+        for (const [alias, target] of aliasTargets) {
+          const aliasMutations = mutations.get(alias) ?? [];
+          const targetMutations = mutations.get(target) ?? [];
+          for (const position of aliasMutations) {
+            if (!targetMutations.includes(position)) {
+              targetMutations.push(position);
+              changed = true;
+            }
+          }
+          if (targetMutations.length > 0) {
+            mutations.set(target, targetMutations);
+          }
+        }
+      }
+    }
+
+    function reportDirectFixtures(): void {
+      for (const candidate of directFixtureCandidates) {
+        if (!isContractConstructed(candidate.node, candidate.observationPosition)) {
+          context.report({ node: candidate.node, messageId: "parseMock" });
+        }
+      }
+    }
+
+    function reportExportedFunctions(): void {
+      for (const functionNode of exportedFunctions) {
+        for (const returnValue of functionReturns.get(functionNode) ?? []) {
+          if (!isContractConstructed(returnValue, returnValue.range[0])) {
+            context.report({ node: returnValue, messageId: "parseMock" });
+          }
+        }
+      }
+    }
+
+    function reportIndirectExports(): void {
+      for (const { exportedName, local } of indirectExports) {
+        const variable = variableFor(local);
+        if (!variable) {
+          continue;
+        }
+        const initializer = variableInitializers.get(variable);
+        const current = unwrap(initializer);
+        if (
+          current?.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+          current?.type === AST_NODE_TYPES.FunctionExpression
+        ) {
+          for (const returnValue of functionReturns.get(current) ?? []) {
+            if (!isContractConstructed(returnValue, returnValue.range[0])) {
+              context.report({ node: returnValue, messageId: "parseMock" });
+            }
+          }
+        } else if (
+          isFixtureValue(exportedName, initializer) &&
+          !isContractConstructed(initializer, initializer?.range[0] ?? local.range[0])
+        ) {
+          context.report({ node: initializer ?? local, messageId: "parseMock" });
+        }
+      }
+    }
+
+    function reportTransportCandidates(): void {
+      for (const candidate of candidates) {
+        if (!isContractConstructed(candidate.node, candidate.observationPosition)) {
+          context.report({ node: candidate.node, messageId: "parsePayload" });
+        }
+      }
+    }
+
+    return {
+      ImportDeclaration(node) {
+        const source = node.source.value;
+        for (const specifier of node.specifiers) {
+          const variable = declaredVariable(specifier);
+          if (!variable) {
+            continue;
+          }
+          const importedName = importName(specifier);
+          if (source.startsWith(CONTRACT_PACKAGE_PREFIX)) {
+            contractImports.set(variable, importedName);
+          }
+          if (
+            (source === "@clipboard-health/testing-core" ||
+              /(?:^|\/)test(?:Utils|-utils)\/createContractFixtureBuilder$/u.test(source)) &&
+            importedName === "createContractFixtureBuilder"
+          ) {
+            fixtureBuilderFactoryImports.add(variable);
+          }
+          if (
+            (source === "@clipboard-health/testing-core" ||
+              /(?:^|\/)test(?:Utils|-utils)\/buildContractFixture$/u.test(source)) &&
+            importedName === "buildContractFixture"
+          ) {
+            oneShotBuilderImports.add(variable);
+          }
+          if (source === "msw" && importedName === "HttpResponse") {
+            httpResponseImports.add(variable);
+          }
+          if (
+            /(?:^|\/)test(?:Utils|-utils)\/mocks$/u.test(source) ||
+            (isTestUtilsFile && /^\.\/mocks$/u.test(source))
+          ) {
+            trustedFixtureImports.add(variable);
+          }
+        }
+      },
+      VariableDeclarator(node) {
+        if (!isExpression(node.init)) {
+          return;
+        }
+        if (node.id.type !== AST_NODE_TYPES.Identifier) {
+          const aliasIdentifier = rootIdentifier(node.init);
+          const target = aliasIdentifier ? variableFor(aliasIdentifier) : undefined;
+          if (target) {
+            for (const variable of context.sourceCode.getDeclaredVariables(node)) {
+              aliasTargets.set(variable, target);
+            }
+          }
+          return;
+        }
+        const variable = declaredVariable(node);
+        if (!variable) {
+          return;
+        }
+        variableInitializers.set(variable, node.init);
+        const aliasIdentifier = rootIdentifier(node.init);
+        const target = aliasIdentifier ? variableFor(aliasIdentifier) : undefined;
+        if (target && target !== variable) {
+          aliasTargets.set(variable, target);
+        }
+      },
+      FunctionDeclaration(node) {
+        functionReturns.set(node, []);
+        functionStack.push(node);
+        if (node.parent.type === AST_NODE_TYPES.ExportNamedDeclaration && isMocksFile) {
+          exportedFunctions.add(node);
+        }
+      },
+      "FunctionDeclaration:exit"() {
+        functionStack.pop();
+      },
+      FunctionExpression(node) {
+        functionReturns.set(node, []);
+        functionStack.push(node);
+      },
+      "FunctionExpression:exit"() {
+        functionStack.pop();
+      },
+      ArrowFunctionExpression(node) {
+        functionReturns.set(
+          node,
+          node.body.type === AST_NODE_TYPES.BlockStatement ? [] : [node.body],
+        );
+        functionStack.push(node);
+      },
+      "ArrowFunctionExpression:exit"() {
+        functionStack.pop();
+      },
+      ReturnStatement(node) {
+        const current = functionStack.at(-1);
+        if (current && isExpression(node.argument)) {
+          functionReturns.get(current)?.push(node.argument);
+        }
+      },
+      ExportNamedDeclaration(node) {
+        if (!isMocksFile) {
+          return;
+        }
+        for (const specifier of node.specifiers) {
+          if (
+            specifier.type === AST_NODE_TYPES.ExportSpecifier &&
+            specifier.local.type === AST_NODE_TYPES.Identifier
+          ) {
+            indirectExports.push({
+              exportedName:
+                specifier.exported.type === AST_NODE_TYPES.Identifier
+                  ? specifier.exported.name
+                  : specifier.exported.value,
+              local: specifier.local,
+            });
+          }
+        }
+        if (node.declaration?.type !== AST_NODE_TYPES.VariableDeclaration) {
+          return;
+        }
+        for (const declaration of node.declaration.declarations) {
+          if (
+            declaration.id.type !== AST_NODE_TYPES.Identifier ||
+            !isExpression(declaration.init)
+          ) {
+            addDirectFixture(declaration.init);
+            continue;
+          }
+          const initializer = unwrap(declaration.init);
+          if (
+            initializer?.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+            initializer?.type === AST_NODE_TYPES.FunctionExpression
+          ) {
+            exportedFunctions.add(initializer);
+          } else if (isFixtureValue(declaration.id.name, declaration.init)) {
+            addDirectFixture(declaration.init);
+          }
+        }
+      },
+      ExportDefaultDeclaration(node) {
+        if (!isMocksFile) {
+          return;
+        }
+        if (node.declaration.type === AST_NODE_TYPES.Identifier) {
+          indirectExports.push({ exportedName: node.declaration.name, local: node.declaration });
+        } else if (isExpression(node.declaration)) {
+          const current = unwrap(node.declaration);
+          if (
+            current?.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+            current?.type === AST_NODE_TYPES.FunctionExpression
+          ) {
+            exportedFunctions.add(current);
+          } else {
+            addDirectFixture(node.declaration);
+          }
+        }
+      },
+      AssignmentExpression(node) {
+        recordMutation(node.left, node.range[0]);
+      },
+      UpdateExpression(node) {
+        recordMutation(node.argument, node.range[0]);
+      },
+      UnaryExpression(node) {
+        if (node.operator === "delete") {
+          recordMutation(node.argument, node.range[0]);
+        }
+      },
+      CallExpression(node) {
+        if (isMswJsonCall(node)) {
+          addCandidate(node.arguments[0], node.range[0]);
+        }
+        if (isRouteFulfillCall(node, isPlaywrightFile)) {
+          const payloads = playwrightPayloads(node.arguments[0], node.range[0]);
+          addCandidate(payloads.unknown ?? payloads.json ?? payloads.body, node.range[0]);
+        }
+
+        if (node.callee.type === AST_NODE_TYPES.MemberExpression) {
+          const method = propertyName(node.callee);
+          if (
+            node.callee.object.type === AST_NODE_TYPES.Identifier &&
+            node.callee.object.name === "Object" &&
+            OBJECT_MUTATOR_NAMES.has(method ?? "")
+          ) {
+            recordMutation(node.arguments[0], node.range[0]);
+          } else if (MUTATING_METHOD_NAMES.has(method ?? "")) {
+            recordMutation(node.callee.object, node.range[0]);
+          }
+        }
+      },
+      "Program:exit"() {
+        registerBuilderVariables();
+        propagateAliasMutations();
+        reportDirectFixtures();
+        reportExportedFunctions();
+        reportIndirectExports();
+        reportTransportCandidates();
+      },
+    };
+  },
+});
+
+export default rule;

--- a/packages/eslint-plugin/src/lib/rules/require-contract-fixture-construction/index.ts
+++ b/packages/eslint-plugin/src/lib/rules/require-contract-fixture-construction/index.ts
@@ -460,7 +460,10 @@ const rule = createRule({
 
     function addDirectFixture(node: TSESTree.Node | null | undefined): void {
       if (isExpression(node)) {
-        directFixtureCandidates.push({ node, observationPosition: node.range[0] });
+        directFixtureCandidates.push({
+          node,
+          observationPosition: Number.MAX_SAFE_INTEGER,
+        });
       }
     }
 
@@ -534,7 +537,7 @@ const rule = createRule({
           }
         } else if (
           isFixtureValue(exportedName, initializer) &&
-          !isContractConstructed(initializer, initializer?.range[0] ?? local.range[0])
+          !isContractConstructed(local, Number.MAX_SAFE_INTEGER)
         ) {
           context.report({ node: initializer ?? local, messageId: "parseMock" });
         }
@@ -680,7 +683,7 @@ const rule = createRule({
           ) {
             exportedFunctions.add(initializer);
           } else if (isFixtureValue(declaration.id.name, declaration.init)) {
-            addDirectFixture(declaration.init);
+            addDirectFixture(declaration.id);
           }
         }
       },

--- a/packages/oxlint-config/README.md
+++ b/packages/oxlint-config/README.md
@@ -151,6 +151,8 @@ The package includes:
 - **`vitest.json`**: extends `base.json` with the vitest plugin and rules for JSON `extends` usage
 - **`base` preset**: shared plugins, rules, and overrides exported for TypeScript composition
 - **`react`, `jest`, `vitest` presets**: additive plugin presets for common repo types
+- **`contractFixtures` preset**: warning-level enforcement that MSW, Playwright, and exported mock
+  fixtures are parsed by producer-owned contract response schemas
 - **`createOxlintConfig`**: helper for composing presets with repo-local config
 
 ## Intentionally disabled rules

--- a/packages/oxlint-config/README.md
+++ b/packages/oxlint-config/README.md
@@ -66,6 +66,7 @@ export default defineConfig(
 Available presets:
 
 - `base`
+- `contractFixtures`
 - `react`
 - `jest`
 - `vitest`

--- a/packages/oxlint-config/package.json
+++ b/packages/oxlint-config/package.json
@@ -19,6 +19,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "@clipboard-health/eslint-plugin": "2.8.0"
+  },
   "peerDependencies": {
     "oxlint": ">=1.68.0",
     "oxlint-tsgolint": ">=0.21.1"

--- a/packages/oxlint-config/src/index.test.ts
+++ b/packages/oxlint-config/src/index.test.ts
@@ -1,5 +1,6 @@
 import {
   base,
+  contractFixtures,
   createOxlintConfig,
   jest as jestPreset,
   type OxlintPreset,
@@ -69,6 +70,28 @@ describe("oxlint-config", () => {
     });
 
     it("exports additive plugin presets", () => {
+      expect(contractFixtures).toStrictEqual({
+        jsPlugins: [
+          {
+            name: "contract-fixtures",
+            specifier: "@clipboard-health/eslint-plugin",
+          },
+        ],
+        overrides: [
+          {
+            files: [
+              "**/{testUtils,test-utils}/{handlers,mocks}*.{cjs,cts,js,jsx,mjs,mts,ts,tsx}",
+              "**/testHandlers.{cjs,cts,js,jsx,mjs,mts,ts,tsx}",
+              "**/*.{spec,test}.{cjs,cts,js,jsx,mjs,mts,ts,tsx}",
+              "playwright/**/*.{cjs,cts,js,jsx,mjs,mts,ts,tsx}",
+            ],
+            rules: {
+              "contract-fixtures/require-contract-fixture-construction": "warn",
+            },
+          },
+        ],
+      });
+
       expect(react).toStrictEqual({
         plugins: ["react"],
       });

--- a/packages/oxlint-config/src/index.ts
+++ b/packages/oxlint-config/src/index.ts
@@ -1,3 +1,3 @@
 export { createOxlintConfig } from "./internal/createOxlintConfig";
-export { base, jest, react, vitest } from "./internal/presets";
+export { base, contractFixtures, jest, react, vitest } from "./internal/presets";
 export type { CreateOxlintConfigRequest, OxlintPreset } from "./internal/types";

--- a/packages/oxlint-config/src/internal/presets.ts
+++ b/packages/oxlint-config/src/internal/presets.ts
@@ -66,6 +66,27 @@ export const jest: OxlintPreset = {
   rules: JEST_RULES,
 };
 export const vitest: OxlintPreset = createVitestPreset();
+export const contractFixtures: OxlintPreset = {
+  jsPlugins: [
+    {
+      name: "contract-fixtures",
+      specifier: "@clipboard-health/eslint-plugin",
+    },
+  ],
+  overrides: [
+    {
+      files: [
+        "**/{testUtils,test-utils}/{handlers,mocks}*.{cjs,cts,js,jsx,mjs,mts,ts,tsx}",
+        "**/testHandlers.{cjs,cts,js,jsx,mjs,mts,ts,tsx}",
+        "**/*.{spec,test}.{cjs,cts,js,jsx,mjs,mts,ts,tsx}",
+        "playwright/**/*.{cjs,cts,js,jsx,mjs,mts,ts,tsx}",
+      ],
+      rules: {
+        "contract-fixtures/require-contract-fixture-construction": "warn",
+      },
+    },
+  ],
+};
 
 function createBasePreset(): OxlintPreset {
   const parsedBaseJson = loadBaseJson();

--- a/packages/oxlint-config/tsconfig.lib.json
+++ b/packages/oxlint-config/tsconfig.lib.json
@@ -11,5 +11,10 @@
     "tsBuildInfoFile": "../../.nx/tsbuildinfo/packages/oxlint-config/tsconfig.lib.tsbuildinfo"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.json"],
-  "exclude": ["vitest.config.ts", "src/**/*.test.ts", "src/**/*.test.tsx"]
+  "exclude": ["vitest.config.ts", "src/**/*.test.ts", "src/**/*.test.tsx"],
+  "references": [
+    {
+      "path": "../eslint-plugin/tsconfig.lib.json"
+    }
+  ]
 }

--- a/packages/testing-core/README.md
+++ b/packages/testing-core/README.md
@@ -6,6 +6,7 @@ TypeScript-friendly testing utilities.
 
 - [Install](#install)
 - [Usage](#usage)
+  - [Contract fixtures](#contract-fixtures)
   - [Type narrowing `expect` helpers](#type-narrowing-expect-helpers)
 - [Local development commands](#local-development-commands)
 
@@ -16,6 +17,36 @@ npm install @clipboard-health/testing-core
 ```
 
 ## Usage
+
+### Contract fixtures
+
+Parse API response fixtures through their producer-owned Zod contract so drift fails when the
+fixture is constructed. Use `buildContractFixture` for one-off fixtures:
+
+```ts
+import { FeatureResponseSchema } from "@clipboard-health/contract-feature";
+import { buildContractFixture } from "@clipboard-health/testing-core";
+
+export const mockFeature = buildContractFixture({
+  schema: FeatureResponseSchema,
+  fixture: { id: "feature-id" },
+});
+```
+
+Use `createContractFixtureBuilder` for fixture families with shallow overrides:
+
+```ts
+import { createContractFixtureBuilder } from "@clipboard-health/testing-core";
+
+const buildFeature = createContractFixtureBuilder({
+  schema: FeatureResponseSchema,
+  defaults: { id: "default-id", name: "Default" },
+});
+
+export const mockRenamedFeature = buildFeature({ name: "Renamed" });
+```
+
+Both helpers accept schema input and return schema output, including Zod transforms.
 
 ### Type narrowing `expect` helpers
 

--- a/packages/testing-core/src/index.ts
+++ b/packages/testing-core/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./lib/contractFixtures";
 export * from "./lib/expectToBeDefined";
 export * from "./lib/expectToBeFailure";
 export * from "./lib/expectToBeLeft";

--- a/packages/testing-core/src/lib/contractFixtures.test.ts
+++ b/packages/testing-core/src/lib/contractFixtures.test.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+
+import { buildContractFixture, createContractFixtureBuilder } from "./contractFixtures";
+
+const responseSchema = z.object({
+  createdAt: z.string().transform((value) => new Date(value)),
+  data: z.object({ id: z.string().min(1), count: z.number() }),
+});
+
+describe("contract fixtures", () => {
+  it("builds one-shot fixtures from schema input to schema output", () => {
+    const actual = buildContractFixture({
+      schema: responseSchema,
+      fixture: {
+        createdAt: "2026-08-13T12:00:00.000Z",
+        data: { id: "fixture-id", count: 1 },
+      },
+    });
+
+    expect(actual).toEqual({
+      createdAt: new Date("2026-08-13T12:00:00.000Z"),
+      data: { id: "fixture-id", count: 1 },
+    });
+  });
+
+  it("builds reusable fixture families with shallow overrides", () => {
+    const buildResponse = createContractFixtureBuilder({
+      schema: responseSchema,
+      defaults: {
+        createdAt: "2026-08-13T12:00:00.000Z",
+        data: { id: "default-id", count: 1 },
+      },
+    });
+
+    expect(buildResponse({ data: { id: "override-id", count: 2 } })).toEqual({
+      createdAt: new Date("2026-08-13T12:00:00.000Z"),
+      data: { id: "override-id", count: 2 },
+    });
+  });
+
+  it("throws a ZodError when a fixture drifts", () => {
+    expect(() =>
+      buildContractFixture({
+        schema: responseSchema,
+        fixture: {
+          createdAt: "2026-08-13T12:00:00.000Z",
+          data: {
+            id: "fixture-id",
+            // @ts-expect-error Deliberately prove runtime parsing rejects untyped drift.
+            count: "not-a-number",
+          },
+        },
+      }),
+    ).toThrow(z.ZodError);
+  });
+});

--- a/packages/testing-core/src/lib/contractFixtures.ts
+++ b/packages/testing-core/src/lib/contractFixtures.ts
@@ -1,0 +1,26 @@
+import type { z } from "zod";
+
+interface BuildContractFixtureRequest<Input, Output> {
+  fixture: Input;
+  schema: z.ZodType<Output, z.ZodTypeDef, Input>;
+}
+
+interface CreateContractFixtureBuilderRequest<Input, Output> {
+  defaults: Input;
+  schema: z.ZodType<Output, z.ZodTypeDef, Input>;
+}
+
+export function buildContractFixture<Input, Output>({
+  fixture,
+  schema,
+}: BuildContractFixtureRequest<Input, Output>): Output {
+  return schema.parse(fixture);
+}
+
+export function createContractFixtureBuilder<Input, Output>({
+  defaults,
+  schema,
+}: CreateContractFixtureBuilderRequest<Input, Output>): (overrides?: Partial<Input>) => Output {
+  return (overrides = {}): Output =>
+    buildContractFixture({ fixture: { ...defaults, ...overrides }, schema });
+}

--- a/packages/testing-core/src/lib/contractFixtures.ts
+++ b/packages/testing-core/src/lib/contractFixtures.ts
@@ -5,7 +5,7 @@ interface BuildContractFixtureRequest<Input, Output> {
   schema: z.ZodType<Output, z.ZodTypeDef, Input>;
 }
 
-interface CreateContractFixtureBuilderRequest<Input, Output> {
+interface CreateContractFixtureBuilderRequest<Input extends object, Output> {
   defaults: Input;
   schema: z.ZodType<Output, z.ZodTypeDef, Input>;
 }
@@ -17,7 +17,7 @@ export function buildContractFixture<Input, Output>({
   return schema.parse(fixture);
 }
 
-export function createContractFixtureBuilder<Input, Output>({
+export function createContractFixtureBuilder<Input extends object, Output>({
   defaults,
   schema,
 }: CreateContractFixtureBuilderRequest<Input, Output>): (overrides?: Partial<Input>) => Output {


### PR DESCRIPTION
## Summary

- add Zod-backed `buildContractFixture` and `createContractFixtureBuilder` helpers to `@clipboard-health/testing-core`
- add an Oxlint-compatible contract-fixture enforcement rule and a reusable warning-level preset
- document the public APIs and cover MSW, exported mocks, Playwright payloads, provenance, aliases, and mutation cases

## Validation

- `NX_CLOUD=false mise exec -- node --run verify`
- `NX_CLOUD=false mise exec -- npm exec nx run-many -- --targets=build,test --projects=eslint-plugin,oxlint-config,testing-core --parallel=3 --output-style=static`
- packaged Oxlint JavaScript-plugin smoke test

[STAFF-2222](https://linear.app/clipboardhealth/issue/STAFF-2222)