### PR TITLE
fix: include Oxlint plugin runtime (STAFF-2222)

### DIFF
--- a/.knip.jsonc
+++ b/.knip.jsonc
@@ -57,7 +57,7 @@
       "entry": ["examples/**/*.ts", "src/index.ts"],
     },
     "packages/oxlint-config": {
-      "ignoreDependencies": ["@clipboard-health/eslint-plugin"],
+      "ignoreDependencies": ["@clipboard-health/eslint-plugin", "eslint"],
     },
     "packages/rules-engine": {
       "entry": ["examples/**/*.ts", "src/index.ts"],

--- a/packages/oxlint-config/package.json
+++ b/packages/oxlint-config/package.json
@@ -20,7 +20,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@clipboard-health/eslint-plugin": "2.9.0"
+    "@clipboard-health/eslint-plugin": "2.9.0",
+    "eslint": "8.57.1"
   },
   "peerDependencies": {
     "oxlint": ">=1.68.0",


### PR DESCRIPTION
## Summary

- declare ESLint as a runtime dependency of the shared Oxlint preset
- keep Knip aware that Oxlint loads it indirectly through the JS plugin

This makes the contract-fixture preset installable in Oxlint-only consumers such as cbh-admin-frontend.

## Verification

- `npx nx run oxlint-config:test`
- `npx nx run oxlint-config:build`
- `npx nx run oxlint-config:lint`
- `npm run knip`
- pre-push verification