### PR TITLE
fix: enable platform automerge for schema packages

### DIFF
--- a/schema-packages.json
+++ b/schema-packages.json
@@ -23,13 +23,13 @@
       "prCreation": "immediate"
     },
     {
-      "description": "Automerge minor and patch schema package PRs only after Renovate observes passing checks.",
+      "description": "Automerge minor and patch schema package PRs via platform-native auto-merge after required checks pass.",
       "matchManagers": ["npm"],
       "matchPackageNames": ["/^@clipboard-health\\/(contract|flag|message)-/"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
       "automergeType": "pr",
-      "platformAutomerge": false
+      "platformAutomerge": true
     },
     {
       "description": "Leave major schema package PRs for human review.",


### PR DESCRIPTION
## Why

The shared schema-package preset disabled GitHub-native auto-merge, so Renovate had to revisit each green PR on a later run. Frequent schema releases and default-branch updates repeatedly rebased those PRs and restarted CI, delaying otherwise safe minor and patch updates. This has no direct customer-facing UI impact, but it improves the reliability and latency of schema propagation to client applications.

## Summary

- Enable platform-native auto-merge for minor and patch schema-package PRs.
- Update the rule description to reflect that GitHub merges after required checks pass.

## Validation

- `mise exec -- npm run format:check -- schema-packages.json`
- `mise exec -- node --run verify`

## Notes

The consuming repositories already allow GitHub auto-merge and run required checks under their main-branch rulesets.

Agent session: `codex resume 019ffbf7-96da-7073-85c1-62f59903264c`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.3</code></sub>
