### PR TITLE
fix(ai-rules): make generated rule ownership explicit (STAFF-2222)

### DIFF
--- a/packages/ai-rules/rules/frontend/dataFetching.md
+++ b/packages/ai-rules/rules/frontend/dataFetching.md
@@ -112,3 +112,8 @@ at runtime. Do not replace the producer-owned schema with an app-local schema co
 The shared `contractFixtures` Oxlint preset reports legacy violations as warnings and local
 overrides block violations in migrated directories. Ratchet whole directories only after their
 response fixtures are migrated; do not suppress violations or downgrade a migrated directory.
+
+The source of truth for this rule is
+`packages/ai-rules/rules/frontend/dataFetching.md` in the `core-utils` repository. Do not edit
+generated `.rules` copies in consumer repositories directly; upgrade
+`@clipboard-health/ai-rules` and run `node --run sync-ai-rules` instead.


### PR DESCRIPTION
## Why

The contract-fixture guidance now lives in the correct shared source, but its original `docs(ai-rules)` classification did not produce a package version. Consumers cannot safely regenerate their `.rules` files until a new `@clipboard-health/ai-rules` release exists.

## What

- explicitly identify the `core-utils` ai-rules source path in the generated guidance
- forbid direct edits to consumer `.rules` copies
- direct consumers to upgrade the package and run `node --run sync-ai-rules`
- use the `fix(ai-rules)` release classification so Nx Release publishes a patch

## Verification

- `oxfmt --check packages/ai-rules/rules/frontend/dataFetching.md`
- ai-rules build completed successfully
- independent review: no findings, ship gate passed

Linear: STAFF-2222
