### PR TITLE
fix: tighten E2E testing guidance

### DIFF
--- a/packages/ai-rules/README.md
+++ b/packages/ai-rules/README.md
@@ -160,7 +160,7 @@ Each rule's "When to Read" text comes from the `description` field in the rule f
 | `frontend/architecture`    | Frontend architecture: feature-based file organization, where business logic lives                                      |
 | `frontend/customHooks`     | Creating React custom hooks: naming, shared state with constate                                                         |
 | `frontend/dataFetching`    | Implementing data fetching, API response fixtures, and error handling: React Query, MSW, Playwright, caching, parsedApi |
-| `frontend/e2eTesting`      | Writing E2E tests with Playwright                                                                                       |
+| `frontend/e2eTesting`      | Choosing and writing Playwright E2E tests for registered critical flows                                                 |
 | `frontend/reactComponents` | Building UI components: structure, composition, modals, bottom sheets, interactive elements, a11y, Storybook            |
 | `frontend/styling`         | Styling components with MUI sx prop: theme tokens, spacing, no CSS/SCSS                                                 |
 | `frontend/testing`         | Writing frontend tests: React Testing Library, component tests                                                          |

--- a/packages/ai-rules/rules/frontend/e2eTesting.md
+++ b/packages/ai-rules/rules/frontend/e2eTesting.md
@@ -7,8 +7,7 @@ description: "Choosing and writing Playwright E2E tests for registered critical 
 ## Core Rules
 
 - Keep the E2E suite Pareto-optimal: the smallest set of tests that protects the most critical user and business risk
-- Map every test to a flow in [`criticalFlows.json`](https://github.com/ClipboardHealth/groundtruth/blob/main/registry/criticalFlows.json); record its `id` in the test title or an adjacent comment
-- Cover one representative path per distinct cross-system risk; put variants and edge cases at a lower test seam
+- Record the mapped critical flow's `id` in the test title or an adjacent comment
 - Each test sets up its own data (no shared state between tests)
 - Mock feature flags and third-party services
 - Use user-centric locators in priority order: `getByRole`, `getByLabel`, `getByPlaceholder`, `getByText`; use `getByTestId` only as a last resort—avoid CSS/XPath selectors

--- a/packages/ai-rules/rules/frontend/e2eTesting.md
+++ b/packages/ai-rules/rules/frontend/e2eTesting.md
@@ -26,7 +26,7 @@ await expect(page.getByText("Submit")).toBeAttached();
 
 Before adding an E2E test:
 
-1. Identify the exact `criticalFlows.json` entry for the behavior. A flow absent from the registry belongs at a lower test seam.
+1. Identify the exact [`criticalFlows.json`](https://github.com/ClipboardHealth/groundtruth/blob/main/registry/criticalFlows.json) entry for the behavior. A flow absent from the registry belongs at a lower test seam.
 2. Identify the distinct browser-to-service failure this test detects beyond existing E2E coverage. Multi-page navigation alone is insufficient.
 3. Use the lowest seam that can detect the failure: unit tests for logic and variants, component tests for user-visible behavior, and contract tests for API compatibility.
 4. Add the E2E test only when all three checks pass and coverage requires the end-to-end system. Otherwise follow the [frontend testing priority](testing.md#philosophy).

--- a/packages/ai-rules/rules/frontend/e2eTesting.md
+++ b/packages/ai-rules/rules/frontend/e2eTesting.md
@@ -1,12 +1,14 @@
 ---
-description: "Writing E2E tests with Playwright"
+description: "Choosing and writing Playwright E2E tests for registered critical flows"
 ---
 
 # E2E Testing (Playwright)
 
 ## Core Rules
 
-- Test critical user flows only—not exhaustive scenarios; when in doubt, write a component test instead
+- Keep the E2E suite Pareto-optimal: the smallest set of tests that protects the most critical user and business risk
+- Map every test to a flow in [`criticalFlows.json`](https://github.com/ClipboardHealth/groundtruth/blob/main/registry/criticalFlows.json); record its `id` in the test title or an adjacent comment
+- Cover one representative path per distinct cross-system risk; put variants and edge cases at a lower test seam
 - Each test sets up its own data (no shared state between tests)
 - Mock feature flags and third-party services
 - Use user-centric locators in priority order: `getByRole`, `getByLabel`, `getByPlaceholder`, `getByText`; use `getByTestId` only as a last resort—avoid CSS/XPath selectors
@@ -21,13 +23,14 @@ await expect(page.getByText("Submit")).toBeVisible();
 await expect(page.getByText("Submit")).toBeAttached();
 ```
 
-## E2E vs Component Test Decision
+## E2E Admission Gate
 
 Before adding an E2E test:
 
-1. Check if existing E2E tests already cover the API calls and flows being tested — avoid duplicating coverage
-2. Confirm the flow is a core user journey (auth, payments, onboarding, multi-page navigation) — non-core flows belong in component tests even if they call backend APIs or touch API contracts
-3. Verify the test requires real cross-service integration or multi-page navigation — if it can be asserted with `render()` + `screen.getByRole()` or mocked API responses, write a component test instead
+1. Identify the exact `criticalFlows.json` entry for the behavior. A flow absent from the registry belongs at a lower test seam.
+2. Identify the distinct browser-to-service failure this test detects beyond existing E2E coverage. Multi-page navigation alone is insufficient.
+3. Use the lowest seam that can detect the failure: unit tests for logic and variants, component tests for user-visible behavior, and contract tests for API compatibility.
+4. Add the E2E test only when all three checks pass and coverage requires the end-to-end system. Otherwise follow the [frontend testing priority](testing.md#philosophy).
 
 ## Avoid
 

--- a/packages/ai-rules/rules/frontend/testing.md
+++ b/packages/ai-rules/rules/frontend/testing.md
@@ -12,7 +12,7 @@ Most tests must be unit, component, or contract tests. Test components together 
 
 **Priority:** Static (TS/ESLint) → Unit, component, and contract → E2E (registered critical flows only)
 
-Contract tests and API-backed component tests use the producer-owned `@clipboard-health/contract-*` package published by the backend repository. Build responses through its schemas as specified in [Contract-Derived Response Fixtures](dataFetching.md#contract-derived-response-fixtures).
+For contract tests and API-backed component tests, follow [Contract-Derived Response Fixtures](dataFetching.md#contract-derived-response-fixtures).
 
 ## Page-Level Tests
 

--- a/packages/ai-rules/rules/frontend/testing.md
+++ b/packages/ai-rules/rules/frontend/testing.md
@@ -8,9 +8,11 @@ Vitest and `@testing-library/react`, with MSW for API mocking. Test files use th
 
 ## Philosophy
 
-Focus on integration tests—test how components work together as users experience them.
+Most tests must be unit, component, or contract tests. Test components together as users experience them; isolate pure logic only when that is the clearest public seam.
 
-**Priority:** Static (TS/ESLint) → Integration → Unit (pure utilities only) → E2E (critical flows only)
+**Priority:** Static (TS/ESLint) → Unit, component, and contract → E2E (registered critical flows only)
+
+Contract tests and API-backed component tests use the producer-owned `@clipboard-health/contract-*` package published by the backend repository. Build responses through its schemas as specified in [Contract-Derived Response Fixtures](dataFetching.md#contract-derived-response-fixtures).
 
 ## Page-Level Tests
 

--- a/packages/ai-rules/rules/frontend/testing.md
+++ b/packages/ai-rules/rules/frontend/testing.md
@@ -8,9 +8,9 @@ Vitest and `@testing-library/react`, with MSW for API mocking. Test files use th
 
 ## Philosophy
 
-Most tests must be unit, component, or contract tests. Test components together as users experience them; isolate pure logic only when that is the clearest public seam.
+Test components together as users experience them; isolate pure logic only when that is the clearest public seam.
 
-**Priority:** Static (TS/ESLint) → Unit, component, and contract → E2E (registered critical flows only)
+**Priority:** Static (TS/ESLint) → Unit, component, and contract (most tests) → E2E (registered critical flows only)
 
 For contract tests and API-backed component tests, follow [Contract-Derived Response Fixtures](dataFetching.md#contract-derived-response-fixtures).
 


### PR DESCRIPTION
## Why

The existing test-selection guidance described E2E candidates with examples, but did not make Clipboard's critical-flow registry the admission boundary. That leaves room for expensive E2E coverage to grow around non-core scenarios. There is no direct customer-facing change; the developer impact is a smaller, more reliable E2E portfolio with most coverage at faster seams.

## Summary

- Define a Pareto-optimal E2E suite and require traceability to the authoritative `criticalFlows.json` registry.
- Admit E2E coverage only for distinct browser-to-service risks that require the end-to-end system.
- Make unit, component, and contract tests the default majority, with a pointer to the existing producer-owned contract fixture guidance.
- Regenerate the ai-rules README index for the sharper E2E retrieval trigger.

## Validation

- `npm exec nx run-many -- --targets=build,lint,test --projects=ai-rules --skip-nx-cache`
- `node --run verify`
- Pre-push hook: `node --run verify`
- `cb-review --effort low --report`: ship gate pass; external `id` evidence resolved against the live critical-flow schema.

## Notes

- Source of truth: https://github.com/ClipboardHealth/groundtruth/blob/main/registry/criticalFlows.json
- Context-engineering reference: https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models

Agent session: `codex resume 01a01280-ef82-7860-b194-ef55107b5af2`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.3</code></sub>
