### PR TITLE
fix(clearance): review cmux wrapper restore and claude-teams launch markers

### DIFF
--- a/packages/clearance/src/safehouseCmux.test.ts
+++ b/packages/clearance/src/safehouseCmux.test.ts
@@ -157,6 +157,23 @@ describe(resolveSafehouseCmuxIntegration, () => {
     expect(actual.unreviewedEnvNames).toStrictEqual([]);
   });
 
+  it("treats the cmux wrapper launch markers as reviewed", () => {
+    const actual = resolveSafehouseCmuxIntegration({
+      env: {
+        CMUX_BUNDLED_CLI_PATH: "/tmp/cmux/bin/cmux",
+      },
+      readFile: () =>
+        [
+          "CMUX_AGENT_RESTORE_LAUNCH",
+          "CMUX_AGENT_RESUME_LAUNCH",
+          "CMUX_CLAUDE_TEAMS_CMUX_BIN",
+          "CMUX_CLAUDE_TEAMS_WRAPPER_LAUNCH",
+        ].join("\n"),
+    });
+
+    expect(actual.unreviewedEnvNames).toStrictEqual([]);
+  });
+
   it("reads the bundled cmux wrapper source with the default file reader", () => {
     const tempDir = mkdtempSync(path.join(tmpdir(), "safehouse-cmux-test-"));
     try {

--- a/packages/clearance/src/safehouseCmux.ts
+++ b/packages/clearance/src/safehouseCmux.ts
@@ -22,11 +22,22 @@ export const SAFEHOUSE_CMUX_WRAPPER_LOCAL_ENV_NAMES = [
   "CMUX_AGENT_LAUNCH_CWD",
   "CMUX_AGENT_LAUNCH_EXECUTABLE",
   "CMUX_AGENT_LAUNCH_KIND",
+  // App-minted one-shot token authorizing a cmux-owned session restore. A
+  // safehouse launch is never one, and the wrapper consumes it and re-issues it
+  // across its own shim hops, so passing it in only hands over stale authority.
+  "CMUX_AGENT_RESTORE_LAUNCH",
+  // The wrapper derives this from the `--resume` id in its own argv.
+  "CMUX_AGENT_RESUME_LAUNCH",
   // Settings-merge names: shell locals plus env set inline on the wrapper's
   // own `node` merge child. None cross the sandbox boundary as ambient env.
   "CMUX_BASE_SETTINGS",
   "CMUX_CLAUDE_HOOK_CMUX_BIN",
   "CMUX_CLAUDE_PID",
+  // Marker pair `cmux claude-teams` sets when it re-enters the wrapper to bind
+  // a lead session. Forwarding it would suppress the ordinary Claude launch
+  // capture that a safehouse agent depends on.
+  "CMUX_CLAUDE_TEAMS_CMUX_BIN",
+  "CMUX_CLAUDE_TEAMS_WRAPPER_LAUNCH",
   "CMUX_FILTERED_ARGS",
   "CMUX_MERGED_SETTINGS",
   "CMUX_ORIGINAL_NODE_OPTIONS",


### PR DESCRIPTION
## Why

Every safehouse Claude launch under cmux was printing:

```
groundcrew: cmux wrapper references unreviewed env vars: CMUX_AGENT_RESTORE_LAUNCH, CMUX_AGENT_RESUME_LAUNCH, CMUX_CLAUDE_TEAMS_CMUX_BIN, CMUX_CLAUDE_TEAMS_WRAPPER_LAUNCH
groundcrew: update SAFEHOUSE_CMUX_ENV_PASS or SAFEHOUSE_CMUX_WRAPPER_LOCAL_ENV_NAMES after reviewing them.
```

cmux's Claude wrapper picked up four new `CMUX_*` names, and the drift detector correctly refused to guess what to do with them.

## Review

All four are one-shot launch markers, none of which belong in the sandbox's ambient environment:

- `CMUX_AGENT_RESTORE_LAUNCH` — app-minted token (`claude:<session-uuid>`) that authorizes a cmux-owned session restore. The wrapper consumes it before any exec so Claude and hooks never see it, and re-issues it itself across shim hops. A safehouse launch is never an app restore, so forwarding it would only hand the sandbox stale authority.
- `CMUX_AGENT_RESUME_LAUNCH` — the wrapper exports or unsets this itself based on the `--resume` id it extracts from its own argv. An inherited value is overwritten either way.
- `CMUX_CLAUDE_TEAMS_CMUX_BIN` / `CMUX_CLAUDE_TEAMS_WRAPPER_LAUNCH` — the marker pair `cmux claude-teams` sets when it deliberately re-enters the wrapper to bind a lead session. Forwarding it would suppress the ordinary Claude launch capture (`CMUX_AGENT_LAUNCH_*`) that a safehouse agent depends on.

So all four go to `SAFEHOUSE_CMUX_WRAPPER_LOCAL_ENV_NAMES`; the pass-through allowlist is unchanged.

## Verification

- `npx vitest run --root packages/clearance` — new test covers the four names; the one failure in `safehouseWrapper.test.ts` ("omits cmux Safehouse flags outside cmux") reproduces on unmodified `origin/main` and is unrelated to this change.
- Ran `resolveSafehouseCmuxIntegration` against the installed cmux Claude wrapper with the real process env: `unreviewedEnvNames` is now empty.
- `node --run verify` passes.