### PR TITLE
feat(oxlint-config): add frontend preset

### DIFF
--- a/packages/oxlint-config/README.md
+++ b/packages/oxlint-config/README.md
@@ -68,6 +68,7 @@ Available presets:
 - `base`
 - `contractFixtures`
 - `customRules`
+- `frontend`
 - `react`
 - `jest`
 - `vitest`
@@ -77,6 +78,33 @@ Merge behavior:
 - `plugins`, `jsPlugins`, `overrides`, and `ignorePatterns` append in order
 - `rules`, `settings`, `options`, `categories`, `env`, and `globals` merge left-to-right
 - `localConfig` always wins over preset values when keys conflict
+
+For React applications, compose `frontend` with the shared base and the repository's test runner:
+
+```ts
+import { base, createOxlintConfig, frontend, vitest } from "@clipboard-health/oxlint-config";
+import { defineConfig } from "oxlint";
+
+export default defineConfig(
+  createOxlintConfig({
+    localConfig: {
+      ignorePatterns: ["coverage/"],
+      overrides: [
+        {
+          files: ["src/**"],
+          rules: {
+            "no-console": "error",
+          },
+        },
+      ],
+    },
+    presets: [base, frontend, vitest],
+  }),
+);
+```
+
+Keep repository architecture rules, import restrictions, and additional JavaScript plugins in
+`localConfig`.
 
 ### JSON config
 
@@ -152,6 +180,7 @@ The package includes:
 - **`base.json`**: the backwards-compatible JSON preset for simple `extends` usage
 - **`vitest.json`**: extends `base.json` with the vitest plugin and rules for JSON `extends` usage
 - **`base` preset**: shared plugins, rules, and overrides exported for TypeScript composition
+- **`frontend` preset**: shared React and JSX accessibility plugins and rules
 - **`react`, `jest`, `vitest` presets**: additive plugin presets for common repo types
 - **`contractFixtures` preset**: warning-level enforcement that MSW, Playwright, and exported mock
   fixtures are parsed by producer-owned contract response schemas

--- a/packages/oxlint-config/src/index.test.ts
+++ b/packages/oxlint-config/src/index.test.ts
@@ -3,6 +3,7 @@ import {
   contractFixtures,
   createOxlintConfig,
   customRules,
+  frontend,
   jest as jestPreset,
   type OxlintPreset,
   react,
@@ -130,6 +131,42 @@ describe("oxlint-config", () => {
 
       expect(react).toStrictEqual({
         plugins: ["react"],
+      });
+
+      expect(frontend).toStrictEqual({
+        plugins: ["react", "jsx-a11y"],
+        rules: {
+          "jsx-a11y/anchor-has-content": "error",
+          "jsx-a11y/aria-props": "error",
+          "jsx-a11y/aria-proptypes": "error",
+          "jsx-a11y/aria-role": "error",
+          "jsx-a11y/aria-unsupported-elements": "error",
+          "jsx-a11y/control-has-associated-label": "error",
+          "jsx-a11y/heading-has-content": "error",
+          "jsx-a11y/iframe-has-title": "error",
+          "jsx-a11y/img-redundant-alt": "error",
+          "jsx-a11y/interactive-supports-focus": "error",
+          "jsx-a11y/no-access-key": "error",
+          "jsx-a11y/no-distracting-elements": "error",
+          "jsx-a11y/no-redundant-roles": "error",
+          "jsx-a11y/prefer-tag-over-role": "off",
+          "jsx-a11y/role-has-required-aria-props": "error",
+          "jsx-a11y/role-supports-aria-props": "error",
+          "jsx-a11y/scope": "error",
+          "react/exhaustive-deps": "warn",
+          "react/jsx-filename-extension": ["warn", { extensions: [".tsx", ".jsx"] }],
+          "react/jsx-no-comment-textnodes": "error",
+          "react/jsx-no-duplicate-props": "error",
+          "react/jsx-no-undef": "error",
+          "react/jsx-pascal-case": ["error", { allowAllCaps: true }],
+          "react/no-danger-with-children": "error",
+          "react/no-did-update-set-state": "error",
+          "react/no-direct-mutation-state": "error",
+          "react/no-is-mounted": "error",
+          "react/require-render-return": "error",
+          "react/rules-of-hooks": "error",
+          "react/style-prop-object": "error",
+        },
       });
 
       expect(jestPreset).toStrictEqual({

--- a/packages/oxlint-config/src/index.ts
+++ b/packages/oxlint-config/src/index.ts
@@ -1,3 +1,11 @@
 export { createOxlintConfig } from "./internal/createOxlintConfig";
-export { base, contractFixtures, customRules, jest, react, vitest } from "./internal/presets";
+export {
+  base,
+  contractFixtures,
+  customRules,
+  frontend,
+  jest,
+  react,
+  vitest,
+} from "./internal/presets";
 export type { CreateOxlintConfigRequest, OxlintPreset } from "./internal/types";

--- a/packages/oxlint-config/src/internal/presets.ts
+++ b/packages/oxlint-config/src/internal/presets.ts
@@ -21,6 +21,39 @@ const JEST_RULES: DummyRuleMap = {
   "jest/valid-title": ["error", { ignoreTypeOfDescribeName: true }],
 } as const;
 
+const FRONTEND_RULES: DummyRuleMap = {
+  "jsx-a11y/anchor-has-content": "error",
+  "jsx-a11y/aria-props": "error",
+  "jsx-a11y/aria-proptypes": "error",
+  "jsx-a11y/aria-role": "error",
+  "jsx-a11y/aria-unsupported-elements": "error",
+  "jsx-a11y/control-has-associated-label": "error",
+  "jsx-a11y/heading-has-content": "error",
+  "jsx-a11y/iframe-has-title": "error",
+  "jsx-a11y/img-redundant-alt": "error",
+  "jsx-a11y/interactive-supports-focus": "error",
+  "jsx-a11y/no-access-key": "error",
+  "jsx-a11y/no-distracting-elements": "error",
+  "jsx-a11y/no-redundant-roles": "error",
+  "jsx-a11y/prefer-tag-over-role": "off",
+  "jsx-a11y/role-has-required-aria-props": "error",
+  "jsx-a11y/role-supports-aria-props": "error",
+  "jsx-a11y/scope": "error",
+  "react/exhaustive-deps": "warn",
+  "react/jsx-filename-extension": ["warn", { extensions: [".tsx", ".jsx"] }],
+  "react/jsx-no-comment-textnodes": "error",
+  "react/jsx-no-duplicate-props": "error",
+  "react/jsx-no-undef": "error",
+  "react/jsx-pascal-case": ["error", { allowAllCaps: true }],
+  "react/no-danger-with-children": "error",
+  "react/no-did-update-set-state": "error",
+  "react/no-direct-mutation-state": "error",
+  "react/no-is-mounted": "error",
+  "react/require-render-return": "error",
+  "react/rules-of-hooks": "error",
+  "react/style-prop-object": "error",
+} as const;
+
 // See https://oxc.rs/docs/guide/usage/linter/plugins.html#supported-plugins
 const OXLINT_PLUGIN_NAMES = {
   eslint: "eslint",
@@ -60,6 +93,10 @@ interface BaseJsonConfig {
 export const base = createBasePreset();
 export const react: OxlintPreset = {
   plugins: ["react"],
+};
+export const frontend: OxlintPreset = {
+  plugins: ["react", "jsx-a11y"],
+  rules: FRONTEND_RULES,
 };
 export const jest: OxlintPreset = {
   plugins: ["jest"],


### PR DESCRIPTION
## Summary

- add a shared frontend Oxlint preset for React and JSX accessibility
- export the preset through the package API
- document composition with the existing base and Vitest presets
- keep React Doctor and repository-specific rules out of this change

## Validation

- `npm exec nx test oxlint-config -- --reporter=verbose`
- `npm exec nx lint oxlint-config`
- `npm exec nx build oxlint-config`
- `npx oxfmt --check packages/oxlint-config`
- `node --run verify`