### PR TITLE
feat: add no-empty-boolean-call Oxlint rule

### DIFF
--- a/packages/oxlint-plugin/README.md
+++ b/packages/oxlint-plugin/README.md
@@ -10,6 +10,7 @@ ESLint.
 ## Rules
 
 - `enforce-ts-rest-in-controllers`
+- `no-empty-boolean-call`
 - `no-cross-contract-imports`
 - `require-contract-fixture-construction`
 - `require-contract-response-parse`
@@ -23,5 +24,6 @@ Use the `customRules` preset from `@clipboard-health/oxlint-config` to register 
 apply the shared controller, module, contract, and cross-contract-import scopes. The
 `contractFixtures` preset enables fixture-construction checks in tests.
 
-`require-contract-response-parse` and `require-run-validators-with-upsert` are opt-in because their
-safe adoption scope is repository-specific.
+`no-empty-boolean-call`, `require-contract-response-parse`, and
+`require-run-validators-with-upsert` are opt-in because their safe adoption scope is
+repository-specific.

--- a/packages/oxlint-plugin/src/index.test.ts
+++ b/packages/oxlint-plugin/src/index.test.ts
@@ -4,6 +4,7 @@ describe("oxlint plugin", () => {
   it("exports every Clipboard lint rule", () => {
     expect(Object.keys(rules)).toStrictEqual([
       "enforce-ts-rest-in-controllers",
+      "no-empty-boolean-call",
       "no-cross-contract-imports",
       "require-contract-fixture-construction",
       "require-contract-response-parse",

--- a/packages/oxlint-plugin/src/index.ts
+++ b/packages/oxlint-plugin/src/index.ts
@@ -1,4 +1,5 @@
 import enforceTsRestInControllers from "./lib/rules/enforce-ts-rest-in-controllers";
+import noEmptyBooleanCall from "./lib/rules/no-empty-boolean-call";
 import noCrossContractImports from "./lib/rules/no-cross-contract-imports";
 import requireContractFixtureConstruction from "./lib/rules/require-contract-fixture-construction";
 import requireContractResponseParse from "./lib/rules/require-contract-response-parse";
@@ -8,6 +9,7 @@ import requireZodImportInContracts from "./lib/rules/require-zod-import-in-contr
 
 export const rules = {
   "enforce-ts-rest-in-controllers": enforceTsRestInControllers,
+  "no-empty-boolean-call": noEmptyBooleanCall,
   "no-cross-contract-imports": noCrossContractImports,
   "require-contract-fixture-construction": requireContractFixtureConstruction,
   "require-contract-response-parse": requireContractResponseParse,

--- a/packages/oxlint-plugin/src/index.ts
+++ b/packages/oxlint-plugin/src/index.ts
@@ -1,6 +1,6 @@
 import enforceTsRestInControllers from "./lib/rules/enforce-ts-rest-in-controllers";
-import noEmptyBooleanCall from "./lib/rules/no-empty-boolean-call";
 import noCrossContractImports from "./lib/rules/no-cross-contract-imports";
+import noEmptyBooleanCall from "./lib/rules/no-empty-boolean-call";
 import requireContractFixtureConstruction from "./lib/rules/require-contract-fixture-construction";
 import requireContractResponseParse from "./lib/rules/require-contract-response-parse";
 import requireHttpModuleFactory from "./lib/rules/require-http-module-factory";

--- a/packages/oxlint-plugin/src/lib/rules/no-empty-boolean-call/index.test.ts
+++ b/packages/oxlint-plugin/src/lib/rules/no-empty-boolean-call/index.test.ts
@@ -1,0 +1,49 @@
+import { RuleTester } from "oxlint/plugins-dev";
+
+import rule from "./index";
+
+RuleTester.describe = (name, run) => {
+  describe(name, () => {
+    run();
+  });
+};
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  eslintCompat: true,
+  languageOptions: {
+    parserOptions: { lang: "ts" },
+    sourceType: "module",
+  },
+});
+
+// oxlint-disable-next-line vitest/expect-expect -- RuleTester validates declaratively
+ruleTester.run("no-empty-boolean-call", rule, {
+  valid: [
+    {
+      name: "Boolean called with an argument",
+      code: "const value = Boolean(input);",
+    },
+    {
+      name: "Boolean constructor called with an argument",
+      code: "const value = new Boolean(input);",
+    },
+    {
+      name: "Boolean method called without arguments",
+      code: "const value = object.Boolean();",
+    },
+  ],
+  invalid: [
+    {
+      name: "Boolean called without arguments",
+      code: "const value = Boolean();",
+      errors: [
+        {
+          messageId: "emptyBooleanCall",
+          line: 1,
+          column: 15,
+        },
+      ],
+    },
+  ],
+});

--- a/packages/oxlint-plugin/src/lib/rules/no-empty-boolean-call/index.ts
+++ b/packages/oxlint-plugin/src/lib/rules/no-empty-boolean-call/index.ts
@@ -1,5 +1,6 @@
 /**
  * @fileoverview Rule to disallow calling Boolean without an argument
+ * @see https://github.com/ClipboardHealth/clipboard-health/blob/a27b273938694a31897274b2baa0899783b6299f/scripts/oxlint-plugin/rules/no-restricted-syntax.mjs
  */
 import { defineRule } from "@oxlint/plugins";
 

--- a/packages/oxlint-plugin/src/lib/rules/no-empty-boolean-call/index.ts
+++ b/packages/oxlint-plugin/src/lib/rules/no-empty-boolean-call/index.ts
@@ -1,6 +1,5 @@
 /**
  * @fileoverview Rule to disallow calling Boolean without an argument
- * @see https://github.com/ClipboardHealth/clipboard-health/blob/a27b273938694a31897274b2baa0899783b6299f/scripts/oxlint-plugin/rules/no-restricted-syntax.mjs
  */
 import { defineRule } from "@oxlint/plugins";
 

--- a/packages/oxlint-plugin/src/lib/rules/no-empty-boolean-call/index.ts
+++ b/packages/oxlint-plugin/src/lib/rules/no-empty-boolean-call/index.ts
@@ -1,0 +1,33 @@
+/**
+ * @fileoverview Rule to disallow calling Boolean without an argument
+ */
+import { defineRule } from "@oxlint/plugins";
+
+const rule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow calling Boolean without an argument",
+      url: "https://github.com/ClipboardHealth/core-utils/tree/main/packages/oxlint-plugin/src/lib/rules/no-empty-boolean-call",
+    },
+    schema: [],
+    messages: {
+      emptyBooleanCall: "Avoid using Boolean() without arguments.",
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type === "Identifier" &&
+          node.callee.name === "Boolean" &&
+          node.arguments.length === 0
+        ) {
+          context.report({ node, messageId: "emptyBooleanCall" });
+        }
+      },
+    };
+  },
+});
+
+export default rule;


### PR DESCRIPTION
## Why

Tldr: `no-empty-boolean-call` rule doesn't exist on oxlint, it's been manually ported on `clipboard-health`: As I'm migrating `documents-service-backend` I figured I'd move the rule to the shared package.  
This rule doesn't seem to do much though, any competent review from humans or AI would flag this as a bad behaviour, so I'm not sure if we want to simply remove the rule altogether.

Now, why does the oxlint package use eslint for its own linting? 🙃

Agent blurb follows.

---

Repositories migrating from ESLint need to preserve the existing prohibition on calling `Boolean()` without an argument. Oxlint has no built-in equivalent, and keeping repository-local copies would make the rule harder to maintain consistently. This has no direct customer impact; it centralizes lint policy and reduces migration maintenance.

## Summary

- add the opt-in `no-empty-boolean-call` Oxlint rule
- export and document the rule from `@clipboard-health/oxlint-plugin`
- cover valid calls, invalid empty calls, and the package export

## Validation

- `node --run verify`
- `npm exec vitest -- run --config packages/oxlint-plugin/vitest.config.ts` (121 tests passed)
- package build and negative-fixture verification (7 fixtures passed)

## Notes

The rule is intentionally opt-in so upgrading the shared preset does not introduce a new lint failure across existing consumers.

Reference implementation: [`clipboard-health/scripts/oxlint-plugin/rules/no-restricted-syntax.mjs`](https://github.com/ClipboardHealth/clipboard-health/blob/a27b273938694a31897274b2baa0899783b6299f/scripts/oxlint-plugin/rules/no-restricted-syntax.mjs)

Agent session: `codex resume 01a01b2d-9abc-7171-bed3-d8bc9261bf12`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.0</code></sub>
