### PR TITLE
fix(oxlint-config): keep file limits repository-local

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -21,6 +21,7 @@
     }
   },
   "rules": {
+    "max-lines": ["error", { "max": 2000 }],
     "oxc/no-barrel-file": "off",
 
     // Temporarily disabled globally until issue gets fixed, should then move to test-only disable

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -21,7 +21,6 @@
     }
   },
   "rules": {
-    "max-lines": ["error", { "max": 2000 }],
     "oxc/no-barrel-file": "off",
 
     // Temporarily disabled globally until issue gets fixed, should then move to test-only disable
@@ -36,6 +35,18 @@
     "typescript/unbound-method": "off"
   },
   "overrides": [
+    {
+      "files": [
+        "packages/embedex/src/lib/embed.test.ts",
+        "packages/notifications/src/lib/notificationClient.test.ts",
+        "packages/playwright-flake-linter/src/lib/playwrightFlakeLinter.ts",
+        "packages/playwright-reporter-llm/src/lib/reporter.test.ts",
+        "packages/playwright-toolkit/src/lib/adminAuthToken.ts"
+      ],
+      "rules": {
+        "max-lines": ["error", { "max": 2000 }]
+      }
+    },
     {
       "files": [
         "**/bin/**/*.ts",

--- a/packages/oxlint-config/src/base.json
+++ b/packages/oxlint-config/src/base.json
@@ -45,7 +45,7 @@
     "init-declarations": "off",
     "max-classes-per-file": "off",
     "max-depth": "off",
-    "max-lines": ["error", { "max": 1000 }],
+    "max-lines": "off",
     "max-lines-per-function": "off",
     "max-params": "off",
     "max-statements": "off",

--- a/packages/oxlint-config/src/base.json
+++ b/packages/oxlint-config/src/base.json
@@ -45,7 +45,7 @@
     "init-declarations": "off",
     "max-classes-per-file": "off",
     "max-depth": "off",
-    "max-lines": "off",
+    "max-lines": ["error", { "max": 1000 }],
     "max-lines-per-function": "off",
     "max-params": "off",
     "max-statements": "off",

--- a/packages/oxlint-config/src/index.test.ts
+++ b/packages/oxlint-config/src/index.test.ts
@@ -70,6 +70,7 @@ describe("oxlint-config", () => {
         "unicorn/no-null": "off",
         "no-underscore-dangle": "off",
       });
+      expect(base.rules).toHaveProperty("max-lines", "off");
     });
 
     it("exports additive plugin presets", () => {
@@ -185,7 +186,6 @@ describe("oxlint-config", () => {
       expect(jestPreset).toStrictEqual({
         plugins: ["jest"],
         rules: {
-          "max-lines": ["error", { max: 2000 }],
           "jest/max-expects": "off",
           "jest/max-nested-describe": "off",
           "jest/no-confusing-set-timeout": "off",
@@ -201,7 +201,6 @@ describe("oxlint-config", () => {
       expect(vitest).toStrictEqual({
         plugins: ["vitest"],
         rules: {
-          "max-lines": ["error", { max: 2000 }],
           "vitest/consistent-test-filename": [
             "error",
             { pattern: String.raw`.*\.(test|spec)\.[tj]sx?$` },

--- a/packages/oxlint-config/src/index.test.ts
+++ b/packages/oxlint-config/src/index.test.ts
@@ -70,7 +70,6 @@ describe("oxlint-config", () => {
         "unicorn/no-null": "off",
         "no-underscore-dangle": "off",
       });
-      expect(base.rules).toHaveProperty("max-lines", "off");
     });
 
     it("exports additive plugin presets", () => {

--- a/packages/oxlint-config/src/internal/presets.ts
+++ b/packages/oxlint-config/src/internal/presets.ts
@@ -6,7 +6,6 @@ import type { AllowWarnDeny, DummyRule, DummyRuleMap, OxlintConfig, OxlintOverri
 import type { OxlintPreset } from "./types";
 
 const JEST_RULES: DummyRuleMap = {
-  "max-lines": ["error", { max: 2000 }],
   "jest/max-expects": "off",
   "jest/max-nested-describe": "off",
   // False-positive explosion: flags spec files that contain no setTimeout call at all

--- a/packages/oxlint-config/src/vitest.json
+++ b/packages/oxlint-config/src/vitest.json
@@ -2,7 +2,6 @@
   "extends": ["./base.json"],
   "plugins": ["eslint", "typescript", "unicorn", "oxc", "import", "node", "promise", "vitest"],
   "rules": {
-    "max-lines": ["error", { "max": 2000 }],
     "vitest/consistent-test-filename": ["error", { "pattern": ".*\\.(test|spec)\\.[tj]sx?$" }],
     "vitest/expect-expect": [
       "error",


### PR DESCRIPTION
## Summary
- keep the base preset's existing 1,000-line limit unchanged
- remove the generic 2,000-line override from the Jest and Vitest presets
- add repository-local 2,000-line exceptions only for the five existing core-utils files above the base limit

`max-lines` is not test-runner policy. New core-utils files retain the shared 1,000-line base limit, while existing oversized files keep the behavior they had before this change. Admin and mobile can choose their own repository policy without Jest and Vitest silently changing it.

## Validation
- `npm exec nx test oxlint-config -- --reporter=verbose`
- `node --run verify`