### PR TITLE
fix(ACT-6251): correct ServiceError example in errorHandling rule

### DIFF
--- a/.rules/common/errorHandling.md
+++ b/.rules/common/errorHandling.md
@@ -7,15 +7,40 @@ description: "Returning or throwing errors: ServiceResult, ServiceError, ERROR_C
 - **Expected errors** (not found, validation failures): return `ServiceResult` (Either type) from `@clipboard-health/util-ts` instead of `try/catch`
 - **Unexpected/unrecoverable errors**: throw `ServiceError` from `@clipboard-health/util-ts`
 - Use `toError(maybeError)` from `@clipboard-health/util-ts` over hardcoded strings or type casting (`as Error`)
-- Use `ERROR_CODES` from `@clipboard-health/util-ts`, not `HttpStatus` from NestJS
+- `ServiceError` takes a message string or `{ issues, cause?, id?, source? }`. `code` and `message` describe a single issue and belong inside `issues`, not at the top level
+- Use `ERROR_CODES` from `@clipboard-health/util-ts` for an issue's `code`, not `HttpStatus` from NestJS. The HTTP status is derived from the code (`notFound` → 404); custom code strings fall back to 500, so set the issue's `status` when you need a different one
 
 ```typescript
-import { ServiceError, ERROR_CODES } from "@clipboard-health/util-ts";
+import {
+  ERROR_CODES,
+  failure,
+  ServiceError,
+  type ServiceResult,
+  success,
+  toError,
+} from "@clipboard-health/util-ts";
+
+// Expected — return
+function findShift(params: { shiftId: string }): ServiceResult<Shift> {
+  const { shiftId } = params;
+  const shift = shiftsById.get(shiftId);
+
+  return shift
+    ? success(shift)
+    : failure({ issues: [{ code: ERROR_CODES.notFound, message: `Shift ${shiftId} not found` }] });
+}
 
 // Unexpected/unrecoverable — throw
-throw new ServiceError({
-  code: "SHIFT_NOT_FOUND",
-  message: `Shift ${shiftId} not found`,
-  httpStatus: ERROR_CODES.notFound,
-});
+async function syncShift(params: { shiftId: string }): Promise<void> {
+  const { shiftId } = params;
+
+  try {
+    await shiftClient.sync(shiftId);
+  } catch (error) {
+    throw new ServiceError({
+      issues: [{ code: ERROR_CODES.internal, message: `Shift ${shiftId} sync failed` }],
+      cause: toError(error),
+    });
+  }
+}
 ```

--- a/packages/ai-rules/rules/common/errorHandling.md
+++ b/packages/ai-rules/rules/common/errorHandling.md
@@ -7,15 +7,40 @@ description: "Returning or throwing errors: ServiceResult, ServiceError, ERROR_C
 - **Expected errors** (not found, validation failures): return `ServiceResult` (Either type) from `@clipboard-health/util-ts` instead of `try/catch`
 - **Unexpected/unrecoverable errors**: throw `ServiceError` from `@clipboard-health/util-ts`
 - Use `toError(maybeError)` from `@clipboard-health/util-ts` over hardcoded strings or type casting (`as Error`)
-- Use `ERROR_CODES` from `@clipboard-health/util-ts`, not `HttpStatus` from NestJS
+- `ServiceError` takes a message string or `{ issues, cause?, id?, source? }`. `code` and `message` describe a single issue and belong inside `issues`, not at the top level
+- Use `ERROR_CODES` from `@clipboard-health/util-ts` for an issue's `code`, not `HttpStatus` from NestJS. The HTTP status is derived from the code (`notFound` → 404); custom code strings fall back to 500, so set the issue's `status` when you need a different one
 
 ```typescript
-import { ServiceError, ERROR_CODES } from "@clipboard-health/util-ts";
+import {
+  ERROR_CODES,
+  failure,
+  ServiceError,
+  type ServiceResult,
+  success,
+  toError,
+} from "@clipboard-health/util-ts";
+
+// Expected — return
+function findShift(params: { shiftId: string }): ServiceResult<Shift> {
+  const { shiftId } = params;
+  const shift = shiftsById.get(shiftId);
+
+  return shift
+    ? success(shift)
+    : failure({ issues: [{ code: ERROR_CODES.notFound, message: `Shift ${shiftId} not found` }] });
+}
 
 // Unexpected/unrecoverable — throw
-throw new ServiceError({
-  code: "SHIFT_NOT_FOUND",
-  message: `Shift ${shiftId} not found`,
-  httpStatus: ERROR_CODES.notFound,
-});
+async function syncShift(params: { shiftId: string }): Promise<void> {
+  const { shiftId } = params;
+
+  try {
+    await shiftClient.sync(shiftId);
+  } catch (error) {
+    throw new ServiceError({
+      issues: [{ code: ERROR_CODES.internal, message: `Shift ${shiftId} sync failed` }],
+      cause: toError(error),
+    });
+  }
+}
 ```


### PR DESCRIPTION
Summary
  ===

  What changes were made?
  ---
  - Rewrote the `ServiceError` example in `packages/ai-rules/rules/common/errorHandling.md` to the real
  `ServiceErrorParams` shape: `code` and `message` now live inside `issues[]`, and the HTTP status is derived from the
  code instead of being passed as `httpStatus`.
  - Added the missing `ServiceResult` half of the example (`success` / `failure`), so the "expected errors — return"
  bullet finally has a worked example.
  - Extended the `ERROR_CODES` bullet: the status is derived from the code (`notFound` → 404), and custom code strings
  fall back to 500, so an issue's `status` is the way to override that.
  - Added a bullet stating the constructor's accepted shapes (message string, or `{ issues, cause?, id?, source? }`).
  - Regenerated the repo's own `.rules/common/errorHandling.md` copy via `node --run sync-ai-rules`.
  - Both example branches were compiled against `packages/util-ts` under the repo's strictest tsconfig; the old
  snippet reproduces `TS2353` and the new one typechecks clean.

  Why were these changes made
  ---
  - ACT-6251: every engineer or agent following `.rules/common/errorHandling.md` wrote a `ServiceError` call that does
  not compile. `ServiceErrorParams` accepts a message string or `{ issues, cause?, id?, source? }` — there is no
  top-level `code`, `message`, or `httpStatus`.
  - The drift was found the hard way while implementing ACT-6243 in worker-app-bff: the rule was followed as written,
  the build broke, and the real signature had to be recovered from `node_modules`. The cost is small per occurrence
  but paid by every reader, and agents are hit hardest since they follow the rule literally.
  - A rule that does not compile also quietly teaches readers to distrust the other examples, so the rest of
  `.rules/**/*.md` was swept against the current package signatures — contract-core's schema helpers, testing-core's
  `createContractFixtureBuilder`, the notifications trigger request, and the util-ts nullish helpers all still match.
  This was the only drifted example.
  - Committed as `fix:` so the `@clipboard-health/ai-rules` release publishes; consuming repos pick it up on their
  next `sync-ai-rules` and need no change of their own.

  Notes
  ===

  Checklist :heavy_check_mark:
  ---
  - [ ] I have added tests that prove my fix is effective or that my feature works.
  - [ ] I have added necessary documentation (if appropriate).

  Screenshots/Video :camera:
  ---
  - No UI changes — documentation-only change to a shared AI rule. Validation was `node --run verify` (all 8 checks
  green: architecture, cpd, embed, format, knip, lint, markdown-lint, syncpack), the `ai-rules` test suite, cspell on
  the changed files, and a real `tsc` typecheck of both the old (fails, TS2353) and new (clean) example snippets
  against `packages/util-ts`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/clipboardhealth/core-utils/pull/869" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->