### PR TITLE
fix: parse Playwright responses before navigation

### DIFF
--- a/packages/playwright-toolkit/README.md
+++ b/packages/playwright-toolkit/README.md
@@ -2,7 +2,7 @@
 
 Shared anti-flake primitives for Clipboard Health Playwright suites.
 
-The package owns retry policy, APM correlation, shared admin-token caching, deployed-asset checks, Mailpit polling, Cognito login diagnostics, and setup retry classification. Consuming repositories keep only configuration and domain-specific matching.
+The package owns retry policy, APM correlation, shared admin-token caching, deployed-asset checks, JSON response lifetime capture, Mailpit polling, Cognito login diagnostics, and setup retry classification. Consuming repositories keep only configuration and domain-specific matching.
 
 ## Install
 
@@ -21,6 +21,7 @@ npm install --save-dev @clipboard-health/playwright-toolkit
 | Copy-pasted traceparent page fixture    | `createTraceparentFixtures()`                                                            |
 | Admin token promise cache and file lock | `generateAdminAuthToken()` or `getOrCreateAdminAuthToken()`                              |
 | Deployed frontend/mobile asset loops    | `verifyDeployedAssets()` and `waitForDeployedAssets()`                                   |
+| Deferred Playwright JSON response reads | `waitForParsedJsonResponse()`                                                            |
 | Mailpit search/fetch loops              | `createMailpitClient()`, `fetchMagicLinkFromMailpit()`, `fetchEmailOtpCodeFromMailpit()` |
 | Cognito OTP redirect debugging          | `fillOtpAndWaitForCognitoRedirect()`                                                     |
 | Setup HTTP and identity retry checks    | `classifySetupRetry()` and `isRetryableHttpStatus()`                                     |
@@ -86,6 +87,31 @@ operation: async ({ signal }) =>
     signal,
   });
 ```
+
+## JSON response lifetime
+
+Playwright response bodies can become unreadable after a document navigation. Use
+`waitForParsedJsonResponse` when a page action both waits for a JSON response and crosses a
+navigation boundary. The helper parses each candidate inside the `waitForResponse` predicate and
+returns only the parsed value, so callers cannot accidentally retain a lazy `Response` handle.
+
+```typescript
+const workerResponsePromise = waitForParsedJsonResponse({
+  page,
+  timeoutMs: 30_000,
+  isCandidate: ({ response }) =>
+    response.ok() && new URL(response.url()).pathname === "/api/worker",
+  parseCandidate: ({ body }) => workerResponseSchema.parse(body),
+});
+
+await page.reload({ waitUntil: "domcontentloaded" });
+
+const workerResponse = await workerResponsePromise;
+```
+
+Return `undefined` from `parseCandidate` when the URL-level candidate is valid but its body is not
+the response the test needs. Parsing errors propagate immediately. Keep repository-specific URL,
+method, resource-type, and schema matching in the consumer.
 
 ## Per-test traceparent fixture
 

--- a/packages/playwright-toolkit/src/index.ts
+++ b/packages/playwright-toolkit/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./lib/adminAuthToken";
 export * from "./lib/cognitoDiagnostics";
 export * from "./lib/deployedAssets";
+export * from "./lib/jsonResponse";
 export * from "./lib/mailpit";
 export * from "./lib/retry";
 export * from "./lib/setupRetry";

--- a/packages/playwright-toolkit/src/lib/jsonResponse.test.ts
+++ b/packages/playwright-toolkit/src/lib/jsonResponse.test.ts
@@ -1,0 +1,148 @@
+import type { Page, Response } from "@playwright/test";
+
+import { waitForParsedJsonResponse } from "../index";
+
+interface MockResponseParams {
+  body: unknown;
+  isReadable?: boolean;
+  url?: string;
+}
+
+interface MockResponse {
+  response: Response;
+  setReadable(isReadable: boolean): void;
+}
+
+interface VersionResponse {
+  version: string;
+}
+
+const VERSION_TWO_RESPONSE = { version: "V2" };
+const VERSION_THREE_RESPONSE = { version: "V3" };
+const PARSED_VERSION_RESPONSES = new Map<unknown, VersionResponse>([
+  [VERSION_THREE_RESPONSE, VERSION_THREE_RESPONSE],
+]);
+
+function parseVersionThreeCandidate(params: { body: unknown }): VersionResponse | undefined {
+  return PARSED_VERSION_RESPONSES.get(params.body);
+}
+
+function createMockResponse(params: MockResponseParams): MockResponse {
+  let isReadable = params.isReadable ?? true;
+  const response = {
+    json: vi.fn(async () => {
+      if (!isReadable) {
+        throw new Error("Response body is no longer readable");
+      }
+
+      return await Promise.resolve(params.body);
+    }),
+    url: vi.fn(() => params.url ?? "https://api.example.test/workers"),
+  } as unknown as Response;
+
+  return {
+    response,
+    setReadable(nextIsReadable) {
+      isReadable = nextIsReadable;
+    },
+  };
+}
+
+function createMockPage(params: { afterMatch?: () => void; responses: Response[] }): Page {
+  return {
+    waitForResponse: vi.fn(async (predicate: Parameters<Page["waitForResponse"]>[0]) => {
+      if (typeof predicate !== "function") {
+        throw new TypeError("Expected a response predicate");
+      }
+
+      for (const response of params.responses) {
+        // eslint-disable-next-line no-await-in-loop -- Mock responses arrive in observed order.
+        if (await predicate(response)) {
+          params.afterMatch?.();
+          return response;
+        }
+      }
+
+      throw new Error("Timeout waiting for response");
+    }),
+  } as unknown as Page;
+}
+
+describe("waitForParsedJsonResponse", () => {
+  it("parses the matched body before the response lifetime ends", async () => {
+    const mockResponse = createMockResponse({ body: VERSION_THREE_RESPONSE });
+    const page = createMockPage({
+      afterMatch: () => {
+        mockResponse.setReadable(false);
+      },
+      responses: [mockResponse.response],
+    });
+
+    const actual = await waitForParsedJsonResponse<{ version: string }>({
+      isCandidate: ({ response }) => response.url().endsWith("/workers"),
+      page,
+      parseCandidate: parseVersionThreeCandidate,
+      timeoutMs: 1000,
+    });
+
+    expect(actual).toEqual({ version: "V3" });
+    expect(mockResponse.response.json).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips non-candidates and parsed values that are not a match", async () => {
+    const unrelatedResponse = createMockResponse({
+      body: VERSION_THREE_RESPONSE,
+      url: "https://api.example.test/agreements",
+    });
+    const staleResponse = createMockResponse({ body: VERSION_TWO_RESPONSE });
+    const freshResponse = createMockResponse({ body: VERSION_THREE_RESPONSE });
+
+    const actual = await waitForParsedJsonResponse<{ version: string }>({
+      isCandidate: ({ response }) => response.url().endsWith("/workers"),
+      page: createMockPage({
+        responses: [unrelatedResponse.response, staleResponse.response, freshResponse.response],
+      }),
+      parseCandidate: parseVersionThreeCandidate,
+      timeoutMs: 1000,
+    });
+
+    expect(actual).toEqual({ version: "V3" });
+    expect(unrelatedResponse.response.json).not.toHaveBeenCalled();
+    expect(staleResponse.response.json).toHaveBeenCalledTimes(1);
+    expect(freshResponse.response.json).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces parser failures", async () => {
+    const mockResponse = createMockResponse({ body: { version: "invalid" } });
+
+    await expect(
+      waitForParsedJsonResponse({
+        isCandidate: () => true,
+        page: createMockPage({ responses: [mockResponse.response] }),
+        parseCandidate: () => {
+          throw new Error("Invalid worker response");
+        },
+        timeoutMs: 1000,
+      }),
+    ).rejects.toThrow("Invalid worker response");
+  });
+
+  it("fails if Playwright returns without capturing a parsed body", async () => {
+    const mockResponse = createMockResponse({ body: { version: "V3" } });
+    const page = {
+      waitForResponse: vi.fn(async () => await Promise.resolve(mockResponse.response)),
+    } as unknown as Page;
+
+    await expect(
+      waitForParsedJsonResponse({
+        isCandidate: () => true,
+        page,
+        parseCandidate: ({ body }) => body,
+        timeoutMs: 321,
+      }),
+    ).rejects.toThrow(
+      "Expected the matched JSON response body to be captured while it was readable.",
+    );
+    expect(page.waitForResponse).toHaveBeenCalledWith(expect.any(Function), { timeout: 321 });
+  });
+});

--- a/packages/playwright-toolkit/src/lib/jsonResponse.test.ts
+++ b/packages/playwright-toolkit/src/lib/jsonResponse.test.ts
@@ -89,6 +89,19 @@ describe("waitForParsedJsonResponse", () => {
     expect(page.waitForResponse).toHaveBeenCalledWith(expect.any(Function), { timeout: 1000 });
   });
 
+  it("accepts null as a parsed JSON response", async () => {
+    const mockResponse = createMockResponse({ body: null });
+
+    const actual = await waitForParsedJsonResponse<null>({
+      isCandidate: () => true,
+      page: createMockPage({ responses: [mockResponse.response] }),
+      parseCandidate: () => null,
+      timeoutMs: 1000,
+    });
+
+    expect(actual).toBeNull();
+  });
+
   it("skips non-candidates and parsed values that are not a match", async () => {
     const unrelatedResponse = createMockResponse({
       body: VERSION_THREE_RESPONSE,

--- a/packages/playwright-toolkit/src/lib/jsonResponse.test.ts
+++ b/packages/playwright-toolkit/src/lib/jsonResponse.test.ts
@@ -4,7 +4,6 @@ import { waitForParsedJsonResponse } from "../index";
 
 interface MockResponseParams {
   body: unknown;
-  isReadable?: boolean;
   url?: string;
 }
 
@@ -28,7 +27,7 @@ function parseVersionThreeCandidate(params: { body: unknown }): VersionResponse 
 }
 
 function createMockResponse(params: MockResponseParams): MockResponse {
-  let isReadable = params.isReadable ?? true;
+  let isReadable = true;
   const response = {
     json: vi.fn(async () => {
       if (!isReadable) {
@@ -87,6 +86,7 @@ describe("waitForParsedJsonResponse", () => {
 
     expect(actual).toEqual({ version: "V3" });
     expect(mockResponse.response.json).toHaveBeenCalledTimes(1);
+    expect(page.waitForResponse).toHaveBeenCalledWith(expect.any(Function), { timeout: 1000 });
   });
 
   it("skips non-candidates and parsed values that are not a match", async () => {
@@ -125,24 +125,5 @@ describe("waitForParsedJsonResponse", () => {
         timeoutMs: 1000,
       }),
     ).rejects.toThrow("Invalid worker response");
-  });
-
-  it("fails if Playwright returns without capturing a parsed body", async () => {
-    const mockResponse = createMockResponse({ body: { version: "V3" } });
-    const page = {
-      waitForResponse: vi.fn(async () => await Promise.resolve(mockResponse.response)),
-    } as unknown as Page;
-
-    await expect(
-      waitForParsedJsonResponse({
-        isCandidate: () => true,
-        page,
-        parseCandidate: ({ body }) => body,
-        timeoutMs: 321,
-      }),
-    ).rejects.toThrow(
-      "Expected the matched JSON response body to be captured while it was readable.",
-    );
-    expect(page.waitForResponse).toHaveBeenCalledWith(expect.any(Function), { timeout: 321 });
   });
 });

--- a/packages/playwright-toolkit/src/lib/jsonResponse.ts
+++ b/packages/playwright-toolkit/src/lib/jsonResponse.ts
@@ -8,6 +8,10 @@ export interface WaitForParsedJsonResponseParams<T> {
   timeoutMs: number;
 }
 
+interface ParsedCandidate<T> {
+  value: T;
+}
+
 /**
  * Waits for a matching JSON response and parses its body while Playwright's
  * document-scoped response resource is still readable. Return `undefined`
@@ -17,7 +21,7 @@ export async function waitForParsedJsonResponse<T>(
   params: WaitForParsedJsonResponseParams<T>,
 ): Promise<T> {
   const { isCandidate, page, parseCandidate, timeoutMs } = params;
-  const parsedCandidates = new WeakMap<Response, T>();
+  const parsedCandidates = new WeakMap<Response, ParsedCandidate<T>>();
 
   const response = await page.waitForResponse(
     async (candidateResponse) => {
@@ -29,11 +33,12 @@ export async function waitForParsedJsonResponse<T>(
         body: await candidateResponse.json(),
         response: candidateResponse,
       });
-      if (!isDefined(parsedCandidate)) {
+      // JSON null is a valid parsed value; only undefined means "keep waiting".
+      if (parsedCandidate === undefined) {
         return false;
       }
 
-      parsedCandidates.set(candidateResponse, parsedCandidate);
+      parsedCandidates.set(candidateResponse, { value: parsedCandidate });
       return true;
     },
     { timeout: timeoutMs },
@@ -46,5 +51,5 @@ export async function waitForParsedJsonResponse<T>(
     );
   }
 
-  return parsedResponse;
+  return parsedResponse.value;
 }

--- a/packages/playwright-toolkit/src/lib/jsonResponse.ts
+++ b/packages/playwright-toolkit/src/lib/jsonResponse.ts
@@ -1,0 +1,50 @@
+import { isDefined } from "@clipboard-health/util-ts";
+import type { Page, Response } from "@playwright/test";
+
+export interface WaitForParsedJsonResponseParams<T> {
+  isCandidate: (params: { response: Response }) => boolean;
+  page: Page;
+  parseCandidate: (params: { body: unknown; response: Response }) => T | undefined;
+  timeoutMs: number;
+}
+
+/**
+ * Waits for a matching JSON response and parses its body while Playwright's
+ * document-scoped response resource is still readable. Return `undefined`
+ * from `parseCandidate` to keep waiting for another candidate response.
+ */
+export async function waitForParsedJsonResponse<T>(
+  params: WaitForParsedJsonResponseParams<T>,
+): Promise<T> {
+  const { isCandidate, page, parseCandidate, timeoutMs } = params;
+  const parsedCandidates = new WeakMap<Response, T>();
+
+  const response = await page.waitForResponse(
+    async (candidateResponse) => {
+      if (!isCandidate({ response: candidateResponse })) {
+        return false;
+      }
+
+      const parsedCandidate = parseCandidate({
+        body: await candidateResponse.json(),
+        response: candidateResponse,
+      });
+      if (!isDefined(parsedCandidate)) {
+        return false;
+      }
+
+      parsedCandidates.set(candidateResponse, parsedCandidate);
+      return true;
+    },
+    { timeout: timeoutMs },
+  );
+  const parsedResponse = parsedCandidates.get(response);
+
+  if (!isDefined(parsedResponse)) {
+    throw new Error(
+      "Expected the matched JSON response body to be captured while it was readable.",
+    );
+  }
+
+  return parsedResponse;
+}


### PR DESCRIPTION
## Why

Playwright response bodies are lazy, document-scoped resources. A test that retains a `Response` across a reload or navigation can fail with `Network.getResponseBody: No resource with given identifier found`, even after the request succeeded. Mobile fixed one occurrence locally, but the same unsafe pattern remains in both frontend repositories. A shared primitive prevents the remaining tests from reintroducing that lifetime bug. There is no direct customer-facing behavior change; this reduces end-to-end test flakiness and merge-queue noise.

## Summary

- export `waitForParsedJsonResponse` from `@clipboard-health/playwright-toolkit`
- parse and associate JSON bodies with the matched response inside Playwright's response predicate
- document the navigation-safe calling pattern and keep URL/schema matching in consumers
- cover response lifetime, candidate filtering, and parser failures through the public package export

## Validation

- `npm exec -- nx test playwright-toolkit`
- `npm exec -- nx lint playwright-toolkit`
- `npm exec -- nx build playwright-toolkit`
- `node --run verify`
- `npm pack --dry-run --json ./dist/packages/playwright-toolkit` (confirmed `jsonResponse.js` and `jsonResponse.d.ts` are included)

## Notes

- The toolkit is currently published at 1.3.2. After this PR merges, the main workflow must publish the next patch before consumer dependency changes can merge.
- After publication, update mobile and admin in separate PRs. Mobile should replace its local helper export and migrate the two navigation readbacks in `listCardClaim.spec.ts`, the reload readback in `timekeeping.spec.ts`, and its existing IC Agreement call sites. Admin should migrate the reload readback in `dailyView.spec.ts`.
- Do not point either consumer at this branch or an unpublished package version.

Agent session: `codex resume 01a02518-b41a-7e02-84cf-17ea34030b4c`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.3</code></sub>
