### PR TITLE
fix(ai-rules): remove Firebase from service test fakes list

### DIFF
--- a/packages/ai-rules/rules/backend/serviceTests.md
+++ b/packages/ai-rules/rules/backend/serviceTests.md
@@ -4,7 +4,7 @@ description: "Writing service tests: test data, background jobs, bug handling, m
 
 # Service Tests (Primary Testing Approach)
 
-Test the public contract (REST endpoints, events) with real local dependencies (Postgres, Mongo, Redis). Fake slow/external services (LaunchDarkly, Firebase, Stripe, Zendesk) and other microservices with fakes; fake the event bus.
+Test the public contract (REST endpoints, events) with real local dependencies (Postgres, Mongo, Redis). Fake slow/external services (LaunchDarkly, Stripe, Zendesk) and other microservices with fakes; fake the event bus.
 
 Backend test files use the `.spec.ts` suffix (not `.test.ts`) and sit next to the file they cover.
 


### PR DESCRIPTION
## Summary

Firebase Auth is dead at Clipboard Health (`@clipboard-health/auth-guard` v21 dropped Firebase support and backend-main no longer depends on `firebase-admin`). This repo's `@clipboard-health/ai-rules` package is the upstream source that ~26 repos vendor via `postinstall` sync into `.rules/`, so listing Firebase as a service to fake in service tests keeps propagating the assumption that it's still a live auth path.

This removes Firebase from the "fake slow/external services" list in `serviceTests.md`, keeping LaunchDarkly, Stripe, and Zendesk.

[DEVOP-6679](https://linear.app/clipboardhealth/issue/DEVOP-6679/remove-all-firebase-auth-references-across-clipboardhealth-repos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)