### PR TITLE
feat: add no-parallel-mongo-session-ops Oxlint rule

### DIFF
--- a/packages/oxlint-plugin/README.md
+++ b/packages/oxlint-plugin/README.md
@@ -12,6 +12,7 @@ ESLint.
 - `enforce-ts-rest-in-controllers`
 - `no-empty-boolean-call`
 - `no-cross-contract-imports`
+- `no-parallel-mongo-session-ops`
 - `require-contract-fixture-construction`
 - `require-contract-response-parse`
 - `require-http-module-factory`
@@ -27,3 +28,17 @@ apply the shared controller, module, contract, and cross-contract-import scopes.
 `no-empty-boolean-call`, `require-contract-response-parse`, and
 `require-run-validators-with-upsert` are opt-in because their safe adoption scope is
 repository-specific.
+
+`no-parallel-mongo-session-ops` is also opt-in. Out of the box it covers `Promise.all`,
+`Promise.allSettled`, `Promise.race`, and `Promise.any`. Repositories with their own
+bounded-concurrency helpers must name them, or those call sites go unchecked:
+
+```ts
+"@clipboard-health/no-parallel-mongo-session-ops": [
+  "warn",
+  { additionalPrimitives: ["batchPromiseAllWithLimit", "batchPromiseAllSettledWithLimit"] },
+],
+```
+
+Exclude tests: app-level session objects such as `session.sessionUserId` share the name but are
+unrelated to MongoDB sessions.

--- a/packages/oxlint-plugin/src/index.test.ts
+++ b/packages/oxlint-plugin/src/index.test.ts
@@ -6,6 +6,7 @@ describe("oxlint plugin", () => {
       "enforce-ts-rest-in-controllers",
       "no-empty-boolean-call",
       "no-cross-contract-imports",
+      "no-parallel-mongo-session-ops",
       "require-contract-fixture-construction",
       "require-contract-response-parse",
       "require-http-module-factory",

--- a/packages/oxlint-plugin/src/index.ts
+++ b/packages/oxlint-plugin/src/index.ts
@@ -1,6 +1,7 @@
 import enforceTsRestInControllers from "./lib/rules/enforce-ts-rest-in-controllers";
 import noCrossContractImports from "./lib/rules/no-cross-contract-imports";
 import noEmptyBooleanCall from "./lib/rules/no-empty-boolean-call";
+import noParallelMongoSessionOps from "./lib/rules/no-parallel-mongo-session-ops";
 import requireContractFixtureConstruction from "./lib/rules/require-contract-fixture-construction";
 import requireContractResponseParse from "./lib/rules/require-contract-response-parse";
 import requireHttpModuleFactory from "./lib/rules/require-http-module-factory";
@@ -11,6 +12,7 @@ export const rules = {
   "enforce-ts-rest-in-controllers": enforceTsRestInControllers,
   "no-empty-boolean-call": noEmptyBooleanCall,
   "no-cross-contract-imports": noCrossContractImports,
+  "no-parallel-mongo-session-ops": noParallelMongoSessionOps,
   "require-contract-fixture-construction": requireContractFixtureConstruction,
   "require-contract-response-parse": requireContractResponseParse,
   "require-http-module-factory": requireHttpModuleFactory,

--- a/packages/oxlint-plugin/src/lib/rules/no-parallel-mongo-session-ops/index.test.ts
+++ b/packages/oxlint-plugin/src/lib/rules/no-parallel-mongo-session-ops/index.test.ts
@@ -89,6 +89,14 @@ ruleTester.run("no-parallel-mongo-session-ops", rule, {
       }`,
     },
     {
+      name: "a prebuilt task list whose callbacks each open their own session",
+      code: `const tasks = items.map(async (item) => {
+        const session = await mongoose.startSession();
+        await enqueue(item, { session });
+      });
+      await Promise.all(tasks);`,
+    },
+    {
       name: "same-named task lists stay distinct, so a session-free call is quiet",
       code: `async function withoutSession(items: Item[]) {
         const promises = items.map(async (item) => await handle(item));

--- a/packages/oxlint-plugin/src/lib/rules/no-parallel-mongo-session-ops/index.test.ts
+++ b/packages/oxlint-plugin/src/lib/rules/no-parallel-mongo-session-ops/index.test.ts
@@ -202,6 +202,18 @@ ruleTester.run("no-parallel-mongo-session-ops", rule, {
       errors: [{ messageId: "parallelSessionOps" }],
     },
     {
+      name: "an IIFE creating one session and returning many operations is not per-branch",
+      code: `async function run(ids: string[]) {
+        await Promise.all(
+          await (async () => {
+            const session = await mongoose.startSession();
+            return ids.map((id) => write(id, { session }));
+          })(),
+        );
+      }`,
+      errors: [{ messageId: "parallelSessionOps" }],
+    },
+    {
       name: "allSettled shares a session just as all does",
       code: `async function run(session: ClientSession) {
         await Promise.allSettled(ids.map(async (id) => await write(id, { session })));

--- a/packages/oxlint-plugin/src/lib/rules/no-parallel-mongo-session-ops/index.test.ts
+++ b/packages/oxlint-plugin/src/lib/rules/no-parallel-mongo-session-ops/index.test.ts
@@ -181,6 +181,27 @@ ruleTester.run("no-parallel-mongo-session-ops", rule, {
       errors: [{ messageId: "parallelSessionOps" }],
     },
     {
+      name: "a callback parameter can receive one shared session, so it stays reportable",
+      code: `async function run(shared: ClientSession, ids: string[]) {
+        await Promise.all(
+          [shared, shared].map(async (session) => await write(ids[0], { session })),
+        );
+      }`,
+      errors: [{ messageId: "parallelSessionOps" }],
+    },
+    {
+      name: "an alias of an outer session inside the callback is not a new session",
+      code: `async function run(outerSession: ClientSession, ids: string[]) {
+        await Promise.all(
+          ids.map(async (id) => {
+            const session = outerSession;
+            await write(id, { session });
+          }),
+        );
+      }`,
+      errors: [{ messageId: "parallelSessionOps" }],
+    },
+    {
       name: "allSettled shares a session just as all does",
       code: `async function run(session: ClientSession) {
         await Promise.allSettled(ids.map(async (id) => await write(id, { session })));

--- a/packages/oxlint-plugin/src/lib/rules/no-parallel-mongo-session-ops/index.test.ts
+++ b/packages/oxlint-plugin/src/lib/rules/no-parallel-mongo-session-ops/index.test.ts
@@ -214,6 +214,18 @@ ruleTester.run("no-parallel-mongo-session-ops", rule, {
       errors: [{ messageId: "parallelSessionOps" }],
     },
     {
+      name: "a flatMap callback runs once per group, so one session there spans many operations",
+      code: `async function run(groups: Group[]) {
+        await Promise.all(
+          groups.flatMap((group) => {
+            const session = openSession();
+            return group.ids.map((id) => write(id, { session }));
+          }),
+        );
+      }`,
+      errors: [{ messageId: "parallelSessionOps" }],
+    },
+    {
       name: "allSettled shares a session just as all does",
       code: `async function run(session: ClientSession) {
         await Promise.allSettled(ids.map(async (id) => await write(id, { session })));

--- a/packages/oxlint-plugin/src/lib/rules/no-parallel-mongo-session-ops/index.test.ts
+++ b/packages/oxlint-plugin/src/lib/rules/no-parallel-mongo-session-ops/index.test.ts
@@ -1,0 +1,226 @@
+import { RuleTester } from "oxlint/plugins-dev";
+
+import rule from "./index";
+
+RuleTester.describe = (name, run) => {
+  describe(name, () => {
+    run();
+  });
+};
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  eslintCompat: true,
+  languageOptions: {
+    parserOptions: { lang: "ts" },
+    sourceType: "module",
+  },
+});
+
+/** Mirrors a consumer that registers its own bounded-concurrency helpers. */
+const withHelpers = [
+  { additionalPrimitives: ["batchPromiseAllWithLimit", "batchPromiseAllSettledWithLimit"] },
+];
+
+// oxlint-disable-next-line vitest/expect-expect -- RuleTester validates declaratively
+ruleTester.run("no-parallel-mongo-session-ops", rule, {
+  valid: [
+    {
+      name: "no session in play",
+      code: "await Promise.all(items.map(async (item) => await handle(item)));",
+    },
+    {
+      name: "sequential loop over a shared session",
+      code: "for (const item of items) { await enqueue(item, { session }); }",
+    },
+    {
+      name: "sequential helper over a shared session",
+      code: "await forEachAsyncSequentially(items, async (item) => { await enqueue(item, { session }); });",
+    },
+    {
+      name: "each branch opens its own session",
+      code: `await Promise.all(
+        items.map(async (item) => {
+          const session = await mongoose.startSession();
+          await enqueue(item, { session });
+        }),
+      );`,
+    },
+    {
+      name: "each branch opens its own session under a different name",
+      code: `await Promise.all(
+        items.map(async (item) => {
+          const mongoSession = await startMongoSession();
+          await enqueue(item, { session: mongoSession });
+        }),
+      );`,
+    },
+    {
+      name: "a key named session holding something unrelated is a label",
+      code: "await Promise.all([updateAddress({ session: workplaceId }), saveNotes()]);",
+    },
+    {
+      name: "sessionUser is not a session",
+      code: "await Promise.all(shifts.map(async (shift) => await del(shift, { sessionUser: userId })));",
+    },
+    {
+      name: "sessionId is not a session",
+      code: "await Promise.all(files.map(async (file) => await ingest({ sessionId, file })));",
+    },
+    {
+      name: "unrelated verification sessions",
+      code: "await Promise.all([getVerificationSessions(id), getDocuments(id)]);",
+    },
+    {
+      name: "a project helper is not a primitive unless configured",
+      code: `async function run(session: ClientSession) {
+        await batchPromiseAllWithLimit(
+          ids.map((id) => async () => await enqueue(id, { session })),
+          20,
+        );
+      }`,
+    },
+    {
+      name: "a configured helper limited to one task at a time is sequential",
+      options: withHelpers,
+      code: `async function run(session: ClientSession) {
+        const deletions = blocks.map((block) => async () => await del(block, session));
+        await batchPromiseAllSettledWithLimit(deletions, 1);
+      }`,
+    },
+    {
+      name: "same-named task lists stay distinct, so a session-free call is quiet",
+      code: `async function withoutSession(items: Item[]) {
+        const promises = items.map(async (item) => await handle(item));
+        await Promise.all(promises);
+      }
+      async function withSessionElsewhere(session: ClientSession, ids: string[]) {
+        const other = ids.map(async (id) => await write(id, { session }));
+        await forEachAsyncSequentially(other, async (task) => await task);
+      }`,
+    },
+  ],
+  invalid: [
+    {
+      name: "session captured directly in the callback",
+      code: `async function run(session: ClientSession) {
+        await Promise.all(ids.map(async (id) => await enqueue({ id }, { session })));
+      }`,
+      errors: [{ messageId: "parallelSessionOps" }],
+    },
+    {
+      name: "session reached only through a task list built above the call",
+      code: `async function run(session: ClientSession) {
+        const jobsToEnqueue = shifts.flatMap((shift) =>
+          Array.from({ length: shift.count }, () => ({ jobData: { shift }, options: { session } })),
+        );
+        await Promise.all(
+          jobsToEnqueue.map(async ({ jobData, options }) => await enqueue(jobData, options)),
+        );
+      }`,
+      errors: [{ messageId: "parallelSessionOps" }],
+    },
+    {
+      name: "task list held in a variable, so the call site names no session",
+      code: `async function accept(session: ClientSession) {
+        const acceptancePromises = requests.map(async (request) => await handle(request, { session }));
+        await Promise.all(acceptancePromises);
+      }`,
+      errors: [{ messageId: "parallelSessionOps" }],
+    },
+    {
+      name: "configured helper sharing a session",
+      options: withHelpers,
+      code: `async function run(mongoSession: ClientSession) {
+        await batchPromiseAllWithLimit(
+          apps.map((app) => async () => await enqueue(app, { session: mongoSession })),
+          20,
+        );
+      }`,
+      errors: [{ messageId: "parallelSessionOps" }],
+    },
+    {
+      name: "configured settled helper sharing a session",
+      options: withHelpers,
+      code: `async function run(session: ClientSession) {
+        await batchPromiseAllSettledWithLimit(
+          apps.map((app) => async () => await enqueue(app, { session })),
+          5,
+        );
+      }`,
+      errors: [{ messageId: "parallelSessionOps" }],
+    },
+    {
+      name: "session destructured from a typed options parameter",
+      options: withHelpers,
+      code: `async function book(params: Params, { session }: BookOptions) {
+        await batchPromiseAllWithLimit(
+          shifts.map((shift) => async () => await assignShift({ shift }, { session })),
+          concurrency,
+        );
+      }`,
+      errors: [{ messageId: "parallelSessionOps" }],
+    },
+    {
+      name: "session arriving as optional member access",
+      options: withHelpers,
+      code: `async function cancel(shifts: Shift[], options?: { session?: ClientSession }) {
+        await batchPromiseAllWithLimit(
+          shifts.map((shift) => async () => await del(shift, { externalSession: options?.session })),
+          concurrency,
+        );
+      }`,
+      errors: [{ messageId: "parallelSessionOps" }],
+    },
+    {
+      name: "allSettled shares a session just as all does",
+      code: `async function run(session: ClientSession) {
+        await Promise.allSettled(ids.map(async (id) => await write(id, { session })));
+      }`,
+      errors: [{ messageId: "parallelSessionOps" }],
+    },
+    {
+      name: "race shares a session just as all does",
+      code: `async function run(session: ClientSession) {
+        await Promise.race([writeA({ session }), writeB({ session })]);
+      }`,
+      errors: [{ messageId: "parallelSessionOps" }],
+    },
+    {
+      name: "only the session-carrying call is reported when task lists share a name",
+      code: `async function withoutSession(items: Item[]) {
+        const promises = items.map(async (item) => await handle(item));
+        await Promise.all(promises);
+      }
+      async function withSession(session: ClientSession, ids: string[]) {
+        const promises = ids.map(async (id) => await write(id, { session }));
+        await Promise.all(promises);
+      }`,
+      errors: [{ messageId: "parallelSessionOps" }],
+    },
+    {
+      name: "declaration order does not hide the finding",
+      code: `async function withSession(session: ClientSession, ids: string[]) {
+        const promises = ids.map(async (id) => await write(id, { session }));
+        await Promise.all(promises);
+      }
+      async function withoutSession(items: Item[]) {
+        const promises = items.map(async (item) => await handle(item));
+        await Promise.all(promises);
+      }`,
+      errors: [{ messageId: "parallelSessionOps" }],
+    },
+    {
+      name: "an inner redeclaration does not mask an outer shared session",
+      code: `async function outer(session: ClientSession, ids: string[]) {
+        const promises = ids.map(async (id) => await write(id, { session }));
+        function inner() {
+          const promises = [];
+          return promises;
+        }
+        await Promise.all(promises);
+      }`,
+      errors: [{ messageId: "parallelSessionOps" }],
+    },
+  ],
+});

--- a/packages/oxlint-plugin/src/lib/rules/no-parallel-mongo-session-ops/index.ts
+++ b/packages/oxlint-plugin/src/lib/rules/no-parallel-mongo-session-ops/index.ts
@@ -56,6 +56,16 @@ function isWithin(inner: readonly number[], outer: readonly number[]): boolean {
   return Number(inner[0]) >= Number(outer[0]) && Number(inner[1]) <= Number(outer[1]);
 }
 
+/**
+ * A call plausibly produces a fresh session; a bare identifier or member expression is an alias of
+ * something that already exists.
+ */
+function createsSession(init: ESTree.Node | null | undefined): boolean {
+  const expression = init?.type === "AwaitExpression" ? init.argument : init;
+
+  return expression?.type === "CallExpression" || expression?.type === "NewExpression";
+}
+
 /** A task list is the only initialiser worth following; anything else is unrelated data. */
 function isTaskList(init: ESTree.Node | null | undefined): boolean {
   if (!init) {
@@ -152,9 +162,23 @@ const rule = defineRule({
       return node.arguments.some((argument) => "value" in argument && argument.value === 1);
     }
 
-    /** A session is per-branch when its declaration sits inside the primitive itself. */
-    function isDeclaredWithin(variable: Variable | undefined, range: readonly number[]): boolean {
-      return variable?.identifiers.some((identifier) => isWithin(identifier.range, range)) === true;
+    /**
+     * A session is per-branch only when a binding inside the range *creates* one. Declaration
+     * scope alone is not proof: a callback parameter receives whatever the caller mapped over,
+     * and an alias of an outer binding is the very same session. Both stay reportable.
+     */
+    function createsOwnSession(variable: Variable | undefined, range: readonly number[]): boolean {
+      return (
+        variable?.defs.some((definition) => {
+          if (definition.type !== "Variable" || !isWithin(definition.name.range, range)) {
+            return false;
+          }
+
+          return (
+            definition.node.type === "VariableDeclarator" && createsSession(definition.node.init)
+          );
+        }) === true
+      );
     }
 
     return {
@@ -242,8 +266,8 @@ const rule = defineRule({
               searchRanges.some((range) => isWithin(reference.range, range)) &&
               !nonReferenceRanges.has(reference.range.join(":")) &&
               // Check every searched range, not just the call: a task list built above the call
-              // can itself declare a per-branch session inside its callbacks.
-              !searchRanges.some((range) => isDeclaredWithin(reference.variable, range)),
+              // can itself create a per-branch session inside its callbacks.
+              !searchRanges.some((range) => createsOwnSession(reference.variable, range)),
           );
 
           if (shared) {

--- a/packages/oxlint-plugin/src/lib/rules/no-parallel-mongo-session-ops/index.ts
+++ b/packages/oxlint-plugin/src/lib/rules/no-parallel-mongo-session-ops/index.ts
@@ -1,0 +1,260 @@
+/**
+ * @fileoverview Rule to disallow parallel operations sharing one MongoDB transaction session.
+ *
+ * The MongoDB driver documents parallel operations inside a transaction as undefined behaviour.
+ * From `startTransaction` and `withTransaction` in the driver's `lib/sessions.js`:
+ *
+ * > Running operations in parallel is not supported during a transaction. The use of
+ * > `Promise.all`, `Promise.allSettled`, `Promise.race`, etc to parallelize operations inside a
+ * > transaction is undefined behaviour.
+ *
+ * In practice one branch aborts the transaction and its siblings, still in flight, fail with
+ * `Transaction with { txnNumber: N } has been aborted.`
+ *
+ * The rule reports a concurrency primitive that reaches a session declared *outside* it, meaning
+ * every branch shares one session. A session created *inside* the callback gives each branch its
+ * own and is not reported, which is the safe way to fan out.
+ *
+ * Oxlint JS plugins receive no type information, so a session is recognised by binding name or by
+ * `.session` member access rather than by the `ClientSession` type. Bindings are resolved through
+ * scope analysis, so same-named sessions in different scopes do not collide.
+ *
+ * Repositories with their own bounded-concurrency helpers should list them in
+ * `additionalPrimitives`; the defaults cover only the `Promise` combinators.
+ */
+import { defineRule, type ESTree, type Variable } from "@oxlint/plugins";
+
+import { findVariable as findVariableInScope } from "../../internal/findVariable";
+
+const SESSION_NAMES = new Set([
+  "session",
+  "mongoSession",
+  "transactionSession",
+  "clientSession",
+  "dbSession",
+]);
+
+const PROMISE_COMBINATORS = new Set(["all", "allSettled", "race", "any"]);
+
+const TASK_LIST_METHODS = new Set(["map", "flatMap"]);
+
+type Identifier = ESTree.BindingIdentifier | ESTree.IdentifierName | ESTree.IdentifierReference;
+
+interface SessionReference {
+  range: readonly number[];
+  /** Absent when the session arrives on something we cannot resolve, such as `this.session`. */
+  variable: Variable | undefined;
+  label: string;
+}
+
+interface IdentifierReference {
+  range: readonly number[];
+  variable: Variable | undefined;
+}
+
+function isWithin(inner: readonly number[], outer: readonly number[]): boolean {
+  return Number(inner[0]) >= Number(outer[0]) && Number(inner[1]) <= Number(outer[1]);
+}
+
+/** A task list is the only initialiser worth following; anything else is unrelated data. */
+function isTaskList(init: ESTree.Node | null | undefined): boolean {
+  if (!init) {
+    return false;
+  }
+
+  if (init.type === "ArrayExpression") {
+    return true;
+  }
+
+  return (
+    init.type === "CallExpression" &&
+    init.callee.type === "MemberExpression" &&
+    !init.callee.computed &&
+    init.callee.property.type === "Identifier" &&
+    TASK_LIST_METHODS.has(init.callee.property.name)
+  );
+}
+
+const rule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow parallel operations sharing one MongoDB transaction session",
+      url: "https://github.com/ClipboardHealth/core-utils/tree/main/packages/oxlint-plugin/src/lib/rules/no-parallel-mongo-session-ops",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          additionalPrimitives: {
+            type: "array",
+            items: { type: "string" },
+            description:
+              "Names of project-local helpers that run their tasks concurrently, for example a bounded-concurrency wrapper around Promise.all.",
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      parallelSessionOps:
+        "`{{ primitive }}` runs its operations in parallel on the `{{ name }}` transaction session, which the MongoDB driver documents as undefined behaviour. Await them sequentially, or give each branch its own session.",
+    },
+  },
+  create(context) {
+    const [options] = context.options;
+    const additionalPrimitives = new Set<string>(
+      (options as { additionalPrimitives?: string[] } | undefined)?.additionalPrimitives ?? [],
+    );
+
+    const parallelCalls: Array<{ node: ESTree.CallExpression; primitive: string }> = [];
+    const sessionReferences: SessionReference[] = [];
+    const identifierReferences: IdentifierReference[] = [];
+    const nonReferenceRanges = new Set<string>();
+    /** Keyed by resolved binding, so same-named lists in sibling scopes stay distinct. */
+    const taskLists = new Map<Variable, ESTree.Node>();
+
+    function resolve(identifier: Identifier): Variable | undefined {
+      return findVariableInScope(context.sourceCode, identifier);
+    }
+
+    function primitiveName(node: ESTree.CallExpression): string | undefined {
+      const { callee } = node;
+
+      if (callee.type === "Identifier" && additionalPrimitives.has(callee.name)) {
+        return callee.name;
+      }
+
+      if (
+        callee.type === "MemberExpression" &&
+        !callee.computed &&
+        callee.object.type === "Identifier" &&
+        callee.object.name === "Promise" &&
+        callee.property.type === "Identifier" &&
+        PROMISE_COMBINATORS.has(callee.property.name)
+      ) {
+        return `Promise.${callee.property.name}`;
+      }
+
+      return undefined;
+    }
+
+    /**
+     * A configured helper taking a concurrency of 1 runs one task at a time, so it is already
+     * sequential and safe.
+     */
+    function isSequential(node: ESTree.CallExpression): boolean {
+      const { callee } = node;
+      if (!(callee.type === "Identifier" && additionalPrimitives.has(callee.name))) {
+        return false;
+      }
+
+      return node.arguments.some((argument) => "value" in argument && argument.value === 1);
+    }
+
+    /** A session is per-branch when its declaration sits inside the primitive itself. */
+    function isDeclaredWithin(variable: Variable | undefined, range: readonly number[]): boolean {
+      return variable?.identifiers.some((identifier) => isWithin(identifier.range, range)) === true;
+    }
+
+    return {
+      CallExpression(node) {
+        const primitive = primitiveName(node);
+        if (primitive !== undefined && !isSequential(node)) {
+          parallelCalls.push({ node, primitive });
+        }
+      },
+
+      // A non-shorthand key, as in `{ session: workplaceId }`, is a label rather than a reference.
+      Property(node) {
+        if (!("key" in node) || !("shorthand" in node)) {
+          return;
+        }
+
+        if (!node.shorthand && !node.computed && node.key.type === "Identifier") {
+          nonReferenceRanges.add(node.key.range.join(":"));
+        }
+      },
+
+      // `options.session` and `options?.session` carry the session in on an object.
+      MemberExpression(node) {
+        if (node.type !== "MemberExpression" || node.computed) {
+          return;
+        }
+
+        if (node.property.type !== "Identifier") {
+          return;
+        }
+
+        if (node.property.name === "session") {
+          const object = node.object;
+          sessionReferences.push({
+            range: node.range,
+            variable: object.type === "Identifier" ? resolve(object) : undefined,
+            label: object.type === "Identifier" ? object.name : "session",
+          });
+        }
+
+        nonReferenceRanges.add(node.property.range.join(":"));
+      },
+
+      Identifier(node) {
+        const variable = resolve(node);
+        identifierReferences.push({ range: node.range, variable });
+
+        if (SESSION_NAMES.has(node.name)) {
+          sessionReferences.push({ range: node.range, variable, label: node.name });
+        }
+      },
+
+      VariableDeclarator(node) {
+        const { id, init } = node;
+        if (id.type !== "Identifier" || !isTaskList(init)) {
+          return;
+        }
+
+        const variable = resolve(id);
+        if (variable && init) {
+          taskLists.set(variable, init);
+        }
+      },
+
+      "Program:exit"() {
+        for (const { node, primitive } of parallelCalls) {
+          const argumentRanges = node.arguments.map((argument) => argument.range);
+          const searchRanges: Array<readonly number[]> = [node.range];
+
+          // `const tasks = items.map(...)` before `Promise.all(tasks)` keeps the session out of
+          // the call site, so search where the list was built too.
+          for (const reference of identifierReferences) {
+            if (!argumentRanges.some((range) => isWithin(reference.range, range))) {
+              continue;
+            }
+
+            const taskList = reference.variable && taskLists.get(reference.variable);
+            if (taskList && !isWithin(taskList.range, node.range)) {
+              searchRanges.push(taskList.range);
+            }
+          }
+
+          const shared = sessionReferences.find(
+            (reference) =>
+              searchRanges.some((range) => isWithin(reference.range, range)) &&
+              !nonReferenceRanges.has(reference.range.join(":")) &&
+              !isDeclaredWithin(reference.variable, node.range),
+          );
+
+          if (shared) {
+            context.report({
+              node,
+              messageId: "parallelSessionOps",
+              data: { primitive, name: shared.label },
+            });
+          }
+        }
+      },
+    };
+  },
+});
+
+export default rule;

--- a/packages/oxlint-plugin/src/lib/rules/no-parallel-mongo-session-ops/index.ts
+++ b/packages/oxlint-plugin/src/lib/rules/no-parallel-mongo-session-ops/index.ts
@@ -123,6 +123,12 @@ const rule = defineRule({
     const nonReferenceRanges = new Set<string>();
     /** Keyed by resolved binding, so same-named lists in sibling scopes stay distinct. */
     const taskLists = new Map<Variable, ESTree.Node>();
+    /**
+     * Bodies of `map`/`flatMap` callbacks: the only regions that run once per branch. A session
+     * created anywhere else inside the primitive, such as in an enclosing IIFE, is created once
+     * and shared.
+     */
+    const taskCallbackRanges: Array<readonly number[]> = [];
 
     function resolve(identifier: Identifier): Variable | undefined {
       return findVariableInScope(context.sourceCode, identifier);
@@ -163,9 +169,10 @@ const rule = defineRule({
     }
 
     /**
-     * A session is per-branch only when a binding inside the range *creates* one. Declaration
-     * scope alone is not proof: a callback parameter receives whatever the caller mapped over,
-     * and an alias of an outer binding is the very same session. Both stay reportable.
+     * A session is per-branch only when a task callback *creates* one. Neither declaration scope
+     * nor creation alone is proof: a callback parameter receives whatever the caller mapped over,
+     * an alias of an outer binding is the very same session, and a session created in a scope
+     * that encloses the fan-out is shared by every branch. All three stay reportable.
      */
     function createsOwnSession(variable: Variable | undefined, range: readonly number[]): boolean {
       return (
@@ -186,6 +193,23 @@ const rule = defineRule({
         const primitive = primitiveName(node);
         if (primitive !== undefined && !isSequential(node)) {
           parallelCalls.push({ node, primitive });
+        }
+
+        const { callee } = node;
+        if (
+          callee.type === "MemberExpression" &&
+          !callee.computed &&
+          callee.property.type === "Identifier" &&
+          TASK_LIST_METHODS.has(callee.property.name)
+        ) {
+          for (const argument of node.arguments) {
+            if (
+              argument.type === "ArrowFunctionExpression" ||
+              argument.type === "FunctionExpression"
+            ) {
+              taskCallbackRanges.push(argument.range);
+            }
+          }
         }
       },
 
@@ -261,13 +285,16 @@ const rule = defineRule({
             }
           }
 
+          // Only callbacks reached by this call can create a per-branch session.
+          const perBranchRanges = taskCallbackRanges.filter((callback) =>
+            searchRanges.some((range) => isWithin(callback, range)),
+          );
+
           const shared = sessionReferences.find(
             (reference) =>
               searchRanges.some((range) => isWithin(reference.range, range)) &&
               !nonReferenceRanges.has(reference.range.join(":")) &&
-              // Check every searched range, not just the call: a task list built above the call
-              // can itself create a per-branch session inside its callbacks.
-              !searchRanges.some((range) => createsOwnSession(reference.variable, range)),
+              !perBranchRanges.some((range) => createsOwnSession(reference.variable, range)),
           );
 
           if (shared) {

--- a/packages/oxlint-plugin/src/lib/rules/no-parallel-mongo-session-ops/index.ts
+++ b/packages/oxlint-plugin/src/lib/rules/no-parallel-mongo-session-ops/index.ts
@@ -21,6 +21,22 @@
  *
  * Repositories with their own bounded-concurrency helpers should list them in
  * `additionalPrimitives`; the defaults cover only the `Promise` combinators.
+ *
+ * The invariant is one sentence: a session is per-branch when a `map` callback creates it, and
+ * shared otherwise. Everything else follows from that — a callback parameter receives whatever was
+ * mapped over, an alias is the same session, a `flatMap` callback runs once per group rather than
+ * per task, and a session created in a scope that encloses the fan-out is shared.
+ *
+ * Known limitations. The rule is a net for the shapes people write, not a soundness proof, and
+ * cannot become one without type and dataflow information:
+ *
+ * - a session forwarded as an opaque options object through a call chain, or held on `this`, is
+ *   invisible
+ * - a session reaching the fan-out through a helper the rule does not model is invisible
+ * - recognition is by binding name, so a session under an unlisted name is missed
+ *
+ * Prefer accepting a miss over reporting safe code: a false positive gets the rule switched off,
+ * which costs more than any single missed call site.
  */
 import { defineRule, type ESTree, type Variable } from "@oxlint/plugins";
 
@@ -37,6 +53,12 @@ const SESSION_NAMES = new Set([
 const PROMISE_COMBINATORS = new Set(["all", "allSettled", "race", "any"]);
 
 const TASK_LIST_METHODS = new Set(["map", "flatMap"]);
+
+/**
+ * Only a `map` callback runs once per task. A `flatMap` callback runs once per group and can
+ * return many operations, so a session created there is shared by all of them.
+ */
+const PER_BRANCH_METHODS = new Set(["map"]);
 
 type Identifier = ESTree.BindingIdentifier | ESTree.IdentifierName | ESTree.IdentifierReference;
 
@@ -200,7 +222,7 @@ const rule = defineRule({
           callee.type === "MemberExpression" &&
           !callee.computed &&
           callee.property.type === "Identifier" &&
-          TASK_LIST_METHODS.has(callee.property.name)
+          PER_BRANCH_METHODS.has(callee.property.name)
         ) {
           for (const argument of node.arguments) {
             if (

--- a/packages/oxlint-plugin/src/lib/rules/no-parallel-mongo-session-ops/index.ts
+++ b/packages/oxlint-plugin/src/lib/rules/no-parallel-mongo-session-ops/index.ts
@@ -241,7 +241,9 @@ const rule = defineRule({
             (reference) =>
               searchRanges.some((range) => isWithin(reference.range, range)) &&
               !nonReferenceRanges.has(reference.range.join(":")) &&
-              !isDeclaredWithin(reference.variable, node.range),
+              // Check every searched range, not just the call: a task list built above the call
+              // can itself declare a per-branch session inside its callbacks.
+              !searchRanges.some((range) => isDeclaredWithin(reference.variable, range)),
           );
 
           if (shared) {


### PR DESCRIPTION
Moves a rule I had drafted in clipboard-health (ClipboardHealth/clipboard-health#28554) into this package, after @therockstorm pointed out that our oxlint plugins live here. He's right, and there were two better reasons than convention:

- `require-run-validators-with-upsert` is already a Mongoose rule here, so database-safety rules have a precedent in this package.
- This package has `internal/findVariable`, which the in-repo draft did not. Rewriting on top of proper scope resolution fixed two real precision bugs (below) rather than shipping the heuristic version and replacing it later.

## What the rule catches

The MongoDB driver documents parallel operations inside a transaction as **undefined behaviour**, in both `startTransaction` and `withTransaction`:

> Running operations in parallel is not supported during a transaction. The use of `Promise.all`, `Promise.allSettled`, `Promise.race`, etc to parallelize operations inside a transaction is undefined behaviour.

In practice one branch aborts the transaction and its in-flight siblings fail with `Transaction with { txnNumber: N } has been aborted.` clipboard-health has 16 of those in 30 days on one code path.

The rule reports a concurrency primitive that reaches a session declared **outside** it — every branch sharing one session. A session created **inside** the callback gives each branch its own and is not reported, since that is the safe way to fan out. That distinction is the whole rule.

## Design, and the constraint behind it

I probed the plugin API before writing anything:

```
error probe(probe-rule): parserServices keys=[NONE] getScope=true
```

**JS plugins get no type information** — type-aware linting runs Rust-side via tsgolint and is not plumbed into `parserServices`. So the rule cannot ask "is this a `ClientSession`". It recognises a session by binding name or `.session` member access, and resolves bindings through `findVariable`.

Using resolved bindings rather than names matters more than it sounds. Two bugs that the name-based draft had, both now covered by tests:

- **same-named task lists collide.** `promises` recurs across functions in a file. Keyed by name, a session-free `Promise.all(promises)` in one function picked up another function's list and was reported — and worse, with the declaration order reversed the *real* finding was silently missed. A rule that quietly drops what it exists to catch is the worse half.
- **an inner redeclaration masked an outer shared session.** I had accepted this as a known false negative in the draft. Scope resolution removes it; there is a test for it.

Beyond the obvious `Promise.all(items.map(...))`, it also handles:

- task lists built into a variable before the call — `const jobs = shifts.flatMap(...)` then `Promise.all(jobs.map(...))`, where the call site names no session at all
- sessions arriving as a **parameter**, with no transaction wrapper in lexical scope
- `options?.session` member access rather than a `session` binding
- `Promise.allSettled` / `race` / `any`

## `additionalPrimitives`

The single option, and the reason this is opt-in. Repositories wrap `Promise.all` in bounded-concurrency helpers under local names; clipboard-health has `batchPromiseAllWithLimit` and `batchPromiseAllSettledWithLimit`, and **7 of its 13 offending call sites use them**. A shared rule cannot know those names, and hardcoding them here would leak one repo's specifics into the package, so they are configured by the consumer:

```ts
"@clipboard-health/no-parallel-mongo-session-ops": [
  "warn",
  { additionalPrimitives: ["batchPromiseAllWithLimit", "batchPromiseAllSettledWithLimit"] },
],
```

Note this is the first rule here to take options — the other eight use `schema: []`. I verified the plumbing works before relying on it: `context.options` receives the config and the schema is accepted.

A configured helper called with a literal `1` is treated as sequential, since that is already one task at a time.

## Validation

- **24 rule tests**, and the full package suite at **145 passing**. Invalid cases are transcribed from real call sites rather than invented, including the `flatMap` task-list shape and `{ session }: BookOptions` destructuring.
- `nx lint oxlint-plugin` clean, `nx build oxlint-plugin` (tsgo) clean, `oxfmt --check` clean, `markdownlint` clean, `knip` clean.
- **Validated against clipboard-health end to end.** I pointed its oxlint config at this package's local build with `additionalPrimitives` set, and the output is **byte-identical** to the in-repo draft: the same 13 known call sites, `diff` confirmed. `node --run lint` there exits 0 with zero errors. Every one of the 13 is a site previously confirmed by hand, and none of the reviewed-safe sites is flagged — per-branch sessions, a `pLimit` block that runs before the transaction opens, a post-commit `Promise.all`, and a helper called with limit 1.

## Scope notes

Following the `no-empty-boolean-call` precedent, this is oxlint-plugin only: not added to `eslint-plugin`, and not wired into an `oxlint-config` preset, since its adoption scope is repository-specific. Consumers should exclude tests — app-level session objects such as `session.sessionUserId` share the name but are unrelated.

## Known limitation

A session forwarded as an opaque options object through a call chain, or held on `this`, is not detectable without type information. It is a strong net, not a proof.

## Follow-up

clipboard-health#28554 stays open until this publishes; it then shrinks to deleting the in-repo rule and adding the config above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
