### PR TITLE
fix: enforce frontend inner boolean casts

### DIFF
--- a/packages/oxlint-config/README.md
+++ b/packages/oxlint-config/README.md
@@ -91,32 +91,18 @@ Merge behavior:
 - `rules`, `settings`, `options`, `categories`, `env`, and `globals` merge left-to-right
 - `localConfig` always wins over preset values when keys conflict
 
-For React applications, compose `frontend` with the shared base and the repository's test runner:
+For React applications, compose the standalone `frontend` policy with the repository's test runner:
 
 ```ts
-import {
-  base,
-  createOxlintConfig,
-  frontend,
-  typeAware,
-  vitest,
-} from "@clipboard-health/oxlint-config";
+import { createOxlintConfig, frontend, typeAware, vitest } from "@clipboard-health/oxlint-config";
 import { defineConfig } from "oxlint";
 
 export default defineConfig(
   createOxlintConfig({
     localConfig: {
       ignorePatterns: ["coverage/"],
-      overrides: [
-        {
-          files: ["src/**"],
-          rules: {
-            "no-console": "error",
-          },
-        },
-      ],
     },
-    presets: [base, frontend, typeAware, vitest],
+    presets: [frontend, typeAware, vitest],
   }),
 );
 ```
@@ -124,10 +110,12 @@ export default defineConfig(
 Keep repository architecture rules, import restrictions, and additional JavaScript plugins in
 `localConfig`.
 
-`base` is the organization-wide JavaScript and TypeScript policy. `frontend` adds the common
-frontend application baseline, including React, accessibility, and browser-facing JavaScript
-rules. `typeAware` contains rules that require Oxlint's `--type-aware` mode, and `vitest` adds the
-complete Vitest policy. Keep repository-specific exceptions in `localConfig`.
+`base` is the organization-wide general JavaScript and TypeScript policy. `frontend` is the
+standalone frontend application policy, including React, accessibility, and browser-facing
+JavaScript rules. It permits console output in Playwright, scripts, stories, and Storybook, and
+disables the React hooks rule in Playwright. `typeAware` contains rules that require Oxlint's
+`--type-aware` mode, and `vitest` adds the complete Vitest policy. Keep repository-specific
+exceptions in `localConfig`.
 
 ### JSON config
 

--- a/packages/oxlint-config/README.md
+++ b/packages/oxlint-config/README.md
@@ -112,10 +112,8 @@ Keep repository architecture rules, import restrictions, and additional JavaScri
 
 `base` is the organization-wide general JavaScript and TypeScript policy. `frontend` is the
 standalone frontend application policy, including React, accessibility, and browser-facing
-JavaScript rules. It permits console output in Playwright, scripts, stories, and Storybook, and
-disables the React hooks rule in Playwright. `typeAware` contains rules that require Oxlint's
-`--type-aware` mode, and `vitest` adds the complete Vitest policy. Keep repository-specific
-exceptions in `localConfig`.
+JavaScript rules. `typeAware` contains rules that require Oxlint's `--type-aware` mode, and `vitest`
+adds the complete Vitest policy. Keep repository-specific exceptions in `localConfig`.
 
 ### JSON config
 

--- a/packages/oxlint-config/src/index.test.ts
+++ b/packages/oxlint-config/src/index.test.ts
@@ -142,6 +142,21 @@ describe("oxlint-config", () => {
           },
         ],
         plugins: ["react", "jsx-a11y", "import"],
+        overrides: [
+          {
+            files: ["playwright/**"],
+            rules: {
+              "no-console": "off",
+              "react-hooks/rules-of-hooks": "off",
+            },
+          },
+          {
+            files: ["scripts/**", "**/*.stories.*", ".storybook/**"],
+            rules: {
+              "no-console": "off",
+            },
+          },
+        ],
         rules: expect.objectContaining({
           "array-callback-return": "error",
           curly: ["error", "all"],
@@ -193,7 +208,7 @@ describe("oxlint-config", () => {
           "no-ex-assign": "error",
           "no-extend-native": "error",
           "no-extra-bind": "error",
-          "no-extra-boolean-cast": "error",
+          "no-extra-boolean-cast": ["error", { enforceForLogicalOperands: true }],
           "no-extra-label": "error",
           "no-fallthrough": "error",
           "no-func-assign": "error",

--- a/packages/oxlint-config/src/index.test.ts
+++ b/packages/oxlint-config/src/index.test.ts
@@ -142,21 +142,6 @@ describe("oxlint-config", () => {
           },
         ],
         plugins: ["react", "jsx-a11y", "import"],
-        overrides: [
-          {
-            files: ["playwright/**"],
-            rules: {
-              "no-console": "off",
-              "react-hooks/rules-of-hooks": "off",
-            },
-          },
-          {
-            files: ["scripts/**", "**/*.stories.*", ".storybook/**"],
-            rules: {
-              "no-console": "off",
-            },
-          },
-        ],
         rules: expect.objectContaining({
           "array-callback-return": "error",
           curly: ["error", "all"],

--- a/packages/oxlint-config/src/index.test.ts
+++ b/packages/oxlint-config/src/index.test.ts
@@ -208,7 +208,7 @@ describe("oxlint-config", () => {
           "no-ex-assign": "error",
           "no-extend-native": "error",
           "no-extra-bind": "error",
-          "no-extra-boolean-cast": ["error", { enforceForLogicalOperands: true }],
+          "no-extra-boolean-cast": ["error", { enforceForInnerExpressions: true }],
           "no-extra-label": "error",
           "no-fallthrough": "error",
           "no-func-assign": "error",

--- a/packages/oxlint-config/src/internal/presets.ts
+++ b/packages/oxlint-config/src/internal/presets.ts
@@ -220,7 +220,7 @@ const FRONTEND_RULES: DummyRuleMap = {
   "no-ex-assign": "error",
   "no-extend-native": "error",
   "no-extra-bind": "error",
-  "no-extra-boolean-cast": ["error", { enforceForLogicalOperands: true }],
+  "no-extra-boolean-cast": ["error", { enforceForInnerExpressions: true }],
   "no-extra-label": "error",
   "no-fallthrough": "error",
   "no-func-assign": "error",

--- a/packages/oxlint-config/src/internal/presets.ts
+++ b/packages/oxlint-config/src/internal/presets.ts
@@ -449,21 +449,6 @@ export const frontend: OxlintPreset = {
       specifier: "oxlint-plugin-react-doctor",
     },
   ],
-  overrides: [
-    {
-      files: ["playwright/**"],
-      rules: {
-        "no-console": "off",
-        "react-hooks/rules-of-hooks": "off",
-      },
-    },
-    {
-      files: ["scripts/**", "**/*.stories.*", ".storybook/**"],
-      rules: {
-        "no-console": "off",
-      },
-    },
-  ],
   plugins: ["react", "jsx-a11y", "import"],
   rules: { ...FRONTEND_RULES, ...REACT_DOCTOR_RULES },
 };

--- a/packages/oxlint-config/src/internal/presets.ts
+++ b/packages/oxlint-config/src/internal/presets.ts
@@ -220,7 +220,7 @@ const FRONTEND_RULES: DummyRuleMap = {
   "no-ex-assign": "error",
   "no-extend-native": "error",
   "no-extra-bind": "error",
-  "no-extra-boolean-cast": "error",
+  "no-extra-boolean-cast": ["error", { enforceForLogicalOperands: true }],
   "no-extra-label": "error",
   "no-fallthrough": "error",
   "no-func-assign": "error",
@@ -447,6 +447,21 @@ export const frontend: OxlintPreset = {
     {
       name: "react-doctor",
       specifier: "oxlint-plugin-react-doctor",
+    },
+  ],
+  overrides: [
+    {
+      files: ["playwright/**"],
+      rules: {
+        "no-console": "off",
+        "react-hooks/rules-of-hooks": "off",
+      },
+    },
+    {
+      files: ["scripts/**", "**/*.stories.*", ".storybook/**"],
+      rules: {
+        "no-console": "off",
+      },
     },
   ],
   plugins: ["react", "jsx-a11y", "import"],


### PR DESCRIPTION
## Why

The mobile and admin frontends both intend to reject redundant boolean casts inside larger boolean expressions, but their local option uses an ESLint name that Oxlint does not support. Moving the supported Oxlint option into the universal `frontend` preset prevents silent policy drift. There is no direct customer impact; this improves static-analysis correctness and maintainability.

## Summary

- configure `no-extra-boolean-cast` with Oxlint's supported `enforceForInnerExpressions` option
- document that `frontend` is a standalone application preset and should not be composed with `base`
- keep Playwright, Storybook, script, and repository architecture exceptions local to consumers

## Validation

- `vitest run --config packages/oxlint-config/vitest.config.ts` (17 tests passed using borrowed workspace dependencies)
- `oxfmt --check packages/oxlint-config/src packages/oxlint-config/README.md`
- `markdownlint-cli2 packages/oxlint-config/README.md`
- `git diff --check`

## Notes

Consumer follow-ups will remove only the obsolete local boolean-cast option after this package version is published. Admin will separately converge its application `no-console` severity on the shared warning policy.

<sub>🤖 <code>cb-ship:created v1 skill@1.0.3</code></sub>