### PR TITLE
feat: include Knock request ID in notifications logs (DEVOP-5046)

### DIFF
--- a/packages/notifications/README.md
+++ b/packages/notifications/README.md
@@ -233,9 +233,9 @@ Send notifications through third-party providers.
 
 Log entries for Knock's responses and errors include `knockRequestId`, Knock's ID for that request.
 Filter by **Request ID** under **Observability** > **Logs** in
-[Knock's dashboard](https://dashboard.knock.app) to see Knock's own view of the request, including
-the full request and response bodies. Knock keeps 30 days of
-[API logs](https://docs.knock.app/developer-tools/api-logs).
+[Knock's dashboard](https://dashboard.knock.app) to see Knock's own view of the request and response
+bodies. Knock truncates long values in them, marking what it dropped with `__knock_truncated__` or
+`[TRUNCATED]`, and keeps 30 days of [API logs](https://docs.knock.app/developer-tools/api-logs).
 
 ## Local development commands
 

--- a/packages/notifications/README.md
+++ b/packages/notifications/README.md
@@ -6,6 +6,7 @@ Send notifications through third-party providers.
 
 - [Usage](#usage)
   - [`triggerChunked`](#triggerchunked)
+- [Debugging](#debugging)
 - [Local development commands](#local-development-commands)
 
 ## Usage
@@ -227,6 +228,14 @@ Send notifications through third-party providers.
    ```
 
 </embedex>
+
+## Debugging
+
+Log entries for Knock's responses and errors include `knockRequestId`, Knock's ID for that request.
+Filter by **Request ID** under **Observability** > **Logs** in
+[Knock's dashboard](https://dashboard.knock.app) to see Knock's own view of the request, including
+the full request and response bodies. Knock keeps 30 days of
+[API logs](https://docs.knock.app/developer-tools/api-logs).
 
 ## Local development commands
 

--- a/packages/notifications/src/lib/internal/knockRequestId.ts
+++ b/packages/notifications/src/lib/internal/knockRequestId.ts
@@ -1,3 +1,5 @@
+import type { APIPromise } from "@knocklabs/node";
+
 /**
  * Knock returns a unique ID for every API request in this response header. Include it in logs so
  * that, given one of our log entries, you can find the matching Knock API log entry, along with
@@ -7,9 +9,8 @@
  */
 const REQUEST_ID_HEADER = "x-request-id";
 
-interface RawResponse {
-  asResponse: () => Promise<Response>;
-}
+/** Derived from Knock's SDK so an upgrade that drops `asResponse` fails the build. */
+type RawResponse = Pick<APIPromise<unknown>, "asResponse">;
 
 /**
  * Awaits a call to Knock, returning its parsed response alongside Knock's request ID.

--- a/packages/notifications/src/lib/internal/knockRequestId.ts
+++ b/packages/notifications/src/lib/internal/knockRequestId.ts
@@ -1,0 +1,50 @@
+/**
+ * Knock returns a unique ID for every API request in this response header. Include it in logs so
+ * that, given one of our log entries, you can find the matching Knock API log entry, along with
+ * Knock's view of the request and response bodies, in Knock's dashboard under Observability > Logs.
+ *
+ * @see {@link https://docs.knock.app/developer-tools/api-logs}
+ */
+const REQUEST_ID_HEADER = "x-request-id";
+
+interface RawResponse {
+  asResponse: () => Promise<Response>;
+}
+
+/**
+ * Awaits a call to Knock, returning its parsed response alongside Knock's request ID.
+ *
+ * Pass the provider's promise directly instead of wrapping it in an `async` function; the raw HTTP
+ * response, and therefore the request ID, is only reachable through the promise Knock's SDK
+ * returns. `knockRequestId` is `undefined` for promises that don't expose the raw HTTP response,
+ * which is the case when tests mock the provider.
+ */
+export async function withKnockRequestId<T>(promise: Promise<T>): Promise<{
+  knockRequestId: string | undefined;
+  response: T;
+}> {
+  if (!hasRawResponse(promise)) {
+    return { knockRequestId: undefined, response: await promise };
+  }
+
+  const [response, rawResponse] = await Promise.all([promise, promise.asResponse()]);
+
+  return { knockRequestId: toRequestId(rawResponse.headers), response };
+}
+
+/**
+ * Reads Knock's request ID from the response headers Knock's SDK attaches to the errors it throws.
+ */
+export function toKnockRequestId(error: Error): string | undefined {
+  return "headers" in error && error.headers instanceof Headers
+    ? toRequestId(error.headers)
+    : undefined;
+}
+
+function hasRawResponse<T>(promise: Promise<T>): promise is Promise<T> & RawResponse {
+  return "asResponse" in promise && typeof promise.asResponse === "function";
+}
+
+function toRequestId(headers: Headers): string | undefined {
+  return headers.get(REQUEST_ID_HEADER) ?? undefined;
+}

--- a/packages/notifications/src/lib/internal/knockRequestId.ts
+++ b/packages/notifications/src/lib/internal/knockRequestId.ts
@@ -9,26 +9,21 @@ import type { APIPromise } from "@knocklabs/node";
  */
 const REQUEST_ID_HEADER = "x-request-id";
 
-/** Derived from Knock's SDK so an upgrade that drops `asResponse` fails the build. */
-type RawResponse = Pick<APIPromise<unknown>, "asResponse">;
-
 /**
  * Awaits a call to Knock, returning its parsed response alongside Knock's request ID.
  *
- * Pass the provider's promise directly instead of wrapping it in an `async` function; the raw HTTP
- * response, and therefore the request ID, is only reachable through the promise Knock's SDK
- * returns. `knockRequestId` is `undefined` for promises that don't expose the raw HTTP response,
- * which is the case when tests mock the provider.
+ * Pass the SDK's promise directly instead of wrapping it in an `async` function, which would
+ * discard the raw HTTP response the request ID comes from. Knock sends the header on every
+ * response, so `knockRequestId` is only `undefined` if Knock stops doing so.
  */
-export async function withKnockRequestId<T>(promise: Promise<T>): Promise<{
+export async function withKnockRequestId<T>(promise: APIPromise<T>): Promise<{
   knockRequestId: string | undefined;
   response: T;
 }> {
-  if (!hasRawResponse(promise)) {
-    return { knockRequestId: undefined, response: await promise };
-  }
-
-  const [response, rawResponse] = await Promise.all([promise, promise.asResponse()]);
+  // Await the body first so a failed request throws here rather than from `asResponse`. Both read
+  // the same settled request, so this costs no extra round trip.
+  const response = await promise;
+  const rawResponse = await promise.asResponse();
 
   return { knockRequestId: toRequestId(rawResponse.headers), response };
 }
@@ -40,10 +35,6 @@ export function toKnockRequestId(error: Error): string | undefined {
   return "headers" in error && error.headers instanceof Headers
     ? toRequestId(error.headers)
     : undefined;
-}
-
-function hasRawResponse<T>(promise: Promise<T>): promise is Promise<T> & RawResponse {
-  return "asResponse" in promise && typeof promise.asResponse === "function";
 }
 
 function toRequestId(headers: Headers): string | undefined {

--- a/packages/notifications/src/lib/internal/toNotificationError.test.ts
+++ b/packages/notifications/src/lib/internal/toNotificationError.test.ts
@@ -54,6 +54,21 @@ describe(toNotificationError, () => {
     expect(actual.error).toBeInstanceOf(Error);
   });
 
+  it("extracts Knock's request ID from the response headers", () => {
+    const input = createErrorWithStatus("invalid params", 422) as Error & { headers: Headers };
+    input.headers = new Headers({ "x-request-id": "2fVhPwXrQnUxQ9krVnP5a6Z4qXe" });
+
+    const actual = toNotificationError(input);
+
+    expect(actual.knockRequestId).toBe("2fVhPwXrQnUxQ9krVnP5a6Z4qXe");
+  });
+
+  it("returns an undefined request ID when the error has no response headers", () => {
+    const actual = toNotificationError(new Error("boom"));
+
+    expect(actual.knockRequestId).toBeUndefined();
+  });
+
   it("ignores non-numeric status values", () => {
     const input = createErrorWithStatus("weird", "429");
 

--- a/packages/notifications/src/lib/internal/toNotificationError.ts
+++ b/packages/notifications/src/lib/internal/toNotificationError.ts
@@ -1,6 +1,7 @@
 import { toError } from "@clipboard-health/util-ts";
 
 import { ERROR_CODES, type ErrorCode } from "../errorCodes";
+import { toKnockRequestId } from "./knockRequestId";
 
 const RATE_LIMITED_STATUS = 429;
 const MINIMUM_CLIENT_ERROR_STATUS = 400;
@@ -11,17 +12,21 @@ const MAXIMUM_CLIENT_ERROR_STATUS = 499;
  * decide whether retrying makes sense. A 429 is surfaced as {@link ERROR_CODES.rateLimited}
  * (retry with backoff), other 4xx responses as {@link ERROR_CODES.clientError} (not
  * retryable), and everything else as {@link ERROR_CODES.unknown}.
+ *
+ * `knockRequestId` is Knock's request ID for the failed call, when Knock returned one.
  */
 export function toNotificationError(maybeError: unknown): {
   code: ErrorCode;
   error: Error;
+  knockRequestId: string | undefined;
   message: string;
 } {
   const error = toError(maybeError);
+  const knockRequestId = toKnockRequestId(error);
   const status = "status" in error && typeof error.status === "number" ? error.status : undefined;
 
   if (status === RATE_LIMITED_STATUS) {
-    return { code: ERROR_CODES.rateLimited, error, message: error.message };
+    return { code: ERROR_CODES.rateLimited, error, knockRequestId, message: error.message };
   }
 
   if (
@@ -29,8 +34,8 @@ export function toNotificationError(maybeError: unknown): {
     status >= MINIMUM_CLIENT_ERROR_STATUS &&
     status <= MAXIMUM_CLIENT_ERROR_STATUS
   ) {
-    return { code: ERROR_CODES.clientError, error, message: error.message };
+    return { code: ERROR_CODES.clientError, error, knockRequestId, message: error.message };
   }
 
-  return { code: ERROR_CODES.unknown, error, message: error.message };
+  return { code: ERROR_CODES.unknown, error, knockRequestId, message: error.message };
 }

--- a/packages/notifications/src/lib/notificationClient.test.ts
+++ b/packages/notifications/src/lib/notificationClient.test.ts
@@ -1,7 +1,7 @@
 import { expectToBeFailure, expectToBeSuccess } from "@clipboard-health/testing-core";
-import { type LogFunction, type Logger, ServiceError } from "@clipboard-health/util-ts";
+import { isDefined, type LogFunction, type Logger, ServiceError } from "@clipboard-health/util-ts";
 import type { APIPromise, Knock } from "@knocklabs/node";
-import type { Mocked } from "vitest";
+import type { Mocked, MockInstance } from "vitest";
 
 import { ERROR_CODES } from "./errorCodes";
 import { MAXIMUM_RECIPIENTS_COUNT } from "./internal/chunkRecipients";
@@ -27,6 +27,8 @@ import type {
 const mockKnockRequestId = "2fVhPwXrQnUxQ9krVnP5a6Z4qXe";
 
 type SetChannelDataResponse = Awaited<ReturnType<Knock["users"]["setChannelData"]>>;
+type WorkflowTriggerResponse = Awaited<ReturnType<Knock["workflows"]["trigger"]>>;
+type TriggerSpy = MockInstance<Knock["workflows"]["trigger"]>;
 type GetChannelDataResponse = Awaited<ReturnType<Knock["users"]["getChannelData"]>>;
 
 describe(NotificationClient, () => {
@@ -61,6 +63,13 @@ describe(NotificationClient, () => {
   afterEach(() => {
     vi.clearAllMocks();
   });
+
+  /** Spies on Knock's trigger, resolving `response` with the raw HTTP response the SDK exposes. */
+  function mockTrigger(response: WorkflowTriggerResponse, knockRequestId?: string): TriggerSpy {
+    return vi
+      .spyOn(provider.workflows, "trigger")
+      .mockReturnValue(mockKnockCall(response, knockRequestId));
+  }
 
   describe("constructor", () => {
     it("creates Knock instance with correct configuration", () => {
@@ -101,7 +110,7 @@ describe(NotificationClient, () => {
         data: { message: "Hello world" },
       };
       const mockResponse = { workflow_run_id: mockWorkflowRunId };
-      const triggerSpy = vi.spyOn(provider.workflows, "trigger").mockResolvedValue(mockResponse);
+      const triggerSpy = mockTrigger(mockResponse);
 
       const input: TriggerRequest = {
         workflowKey: mockWorkflowKey,
@@ -190,12 +199,7 @@ describe(NotificationClient, () => {
     });
 
     it("logs Knock's request ID from the response", async () => {
-      vi.spyOn(provider.workflows, "trigger").mockReturnValue(
-        mockApiPromise({
-          data: { workflow_run_id: mockWorkflowRunId },
-          knockRequestId: mockKnockRequestId,
-        }),
-      );
+      mockTrigger({ workflow_run_id: mockWorkflowRunId }, mockKnockRequestId);
 
       const input: TriggerRequest = {
         workflowKey: mockWorkflowKey,
@@ -293,7 +297,7 @@ describe(NotificationClient, () => {
         },
       };
       const mockResponse = { workflow_run_id: mockWorkflowRunId };
-      vi.spyOn(provider.workflows, "trigger").mockResolvedValue(mockResponse);
+      mockTrigger(mockResponse);
 
       const input: TriggerRequest = {
         workflowKey: mockWorkflowKey,
@@ -328,7 +332,7 @@ describe(NotificationClient, () => {
     it("handles undefined data in body", async () => {
       const mockBody = { recipients: [{ userId: "user-1" }] };
       const mockResponse = { workflow_run_id: mockWorkflowRunId };
-      vi.spyOn(provider.workflows, "trigger").mockResolvedValue(mockResponse);
+      mockTrigger(mockResponse);
 
       const input: TriggerRequest = {
         workflowKey: mockWorkflowKey,
@@ -356,7 +360,7 @@ describe(NotificationClient, () => {
     it("traces workflow execution with correct tags", async () => {
       const mockBody = { recipients: [{ userId: "user-1" }] };
       const mockResponse = { workflow_run_id: mockWorkflowRunId };
-      vi.spyOn(provider.workflows, "trigger").mockResolvedValue(mockResponse);
+      mockTrigger(mockResponse);
       const mockSpan = { addTags: vi.fn<Span["addTags"]>() };
       mockTracer.trace.mockImplementation((_name, _options, fun) => fun(mockSpan));
 
@@ -401,7 +405,7 @@ describe(NotificationClient, () => {
         ],
       };
       const mockResponse = { workflow_run_id: mockWorkflowRunId };
-      const triggerSpy = vi.spyOn(provider.workflows, "trigger").mockResolvedValue(mockResponse);
+      const triggerSpy = mockTrigger(mockResponse);
 
       const input: TriggerRequest = {
         workflowKey: mockWorkflowKey,
@@ -432,7 +436,7 @@ describe(NotificationClient, () => {
     it("handles string recipients in trigger body", async () => {
       const mockBody = { recipients: ["user-1", "user-2"] };
       const mockResponse = { workflow_run_id: mockWorkflowRunId };
-      vi.spyOn(provider.workflows, "trigger").mockResolvedValue(mockResponse);
+      mockTrigger(mockResponse);
 
       const input: TriggerRequest = {
         workflowKey: mockWorkflowKey,
@@ -452,7 +456,7 @@ describe(NotificationClient, () => {
     it("handles body with no actor or cancellation key", async () => {
       const mockBody = { recipients: [{ userId: "user-1" }] };
       const mockResponse = { workflow_run_id: mockWorkflowRunId };
-      vi.spyOn(provider.workflows, "trigger").mockResolvedValue(mockResponse);
+      mockTrigger(mockResponse);
 
       const input: TriggerRequest = {
         workflowKey: mockWorkflowKey,
@@ -472,7 +476,7 @@ describe(NotificationClient, () => {
     it("handles recipient with minimal fields", async () => {
       const mockBody = { recipients: [{ userId: "user-1" }] };
       const mockResponse = { workflow_run_id: mockWorkflowRunId };
-      vi.spyOn(provider.workflows, "trigger").mockResolvedValue(mockResponse);
+      mockTrigger(mockResponse);
 
       const input: TriggerRequest = {
         workflowKey: mockWorkflowKey,
@@ -506,7 +510,7 @@ describe(NotificationClient, () => {
         cancellationKey: "cancel-key",
       };
       const mockResponse = { workflow_run_id: mockWorkflowRunId };
-      vi.spyOn(provider.workflows, "trigger").mockResolvedValue(mockResponse);
+      mockTrigger(mockResponse);
 
       const input: TriggerRequest = {
         workflowKey: mockWorkflowKey,
@@ -617,7 +621,7 @@ describe(NotificationClient, () => {
     it("handles trigger request without keysToRedact", async () => {
       const mockBody = { recipients: [{ userId: "user-1" }] };
       const mockResponse = { workflow_run_id: mockWorkflowRunId };
-      vi.spyOn(provider.workflows, "trigger").mockResolvedValue(mockResponse);
+      mockTrigger(mockResponse);
 
       const input: Omit<TriggerRequest, "keysToRedact"> = {
         workflowKey: mockWorkflowKey,
@@ -725,7 +729,7 @@ describe(NotificationClient, () => {
 
     it("defaults dryRun to false and calls provider", async () => {
       const mockResponse = { workflow_run_id: mockWorkflowRunId };
-      const triggerSpy = vi.spyOn(provider.workflows, "trigger").mockResolvedValue(mockResponse);
+      const triggerSpy = mockTrigger(mockResponse);
 
       const input: TriggerRequest = {
         workflowKey: mockWorkflowKey,
@@ -756,7 +760,7 @@ describe(NotificationClient, () => {
     const mockCancellationKey = "cancel-key-123";
 
     it("cancels workflow with recipients", async () => {
-      const cancelSpy = vi.spyOn(provider.workflows, "cancel").mockResolvedValue();
+      const cancelSpy = vi.spyOn(provider.workflows, "cancel").mockReturnValue(mockKnockCall());
 
       const input: CancelRequest = {
         workflowKey: mockWorkflowKey,
@@ -773,7 +777,7 @@ describe(NotificationClient, () => {
     });
 
     it("cancels workflow without recipients", async () => {
-      const cancelSpy = vi.spyOn(provider.workflows, "cancel").mockResolvedValue();
+      const cancelSpy = vi.spyOn(provider.workflows, "cancel").mockReturnValue(mockKnockCall());
 
       const input: CancelRequest = {
         workflowKey: mockWorkflowKey,
@@ -789,7 +793,7 @@ describe(NotificationClient, () => {
 
     it("logs Knock's request ID from the response", async () => {
       vi.spyOn(provider.workflows, "cancel").mockReturnValue(
-        mockApiPromise({ data: undefined, knockRequestId: mockKnockRequestId }),
+        mockKnockCall(undefined, mockKnockRequestId),
       );
 
       const input: CancelRequest = {
@@ -878,7 +882,7 @@ describe(NotificationClient, () => {
         data: { message: "Hello world" },
       };
       const mockResponse = { workflow_run_id: mockWorkflowRunId };
-      const triggerSpy = vi.spyOn(provider.workflows, "trigger").mockResolvedValue(mockResponse);
+      const triggerSpy = mockTrigger(mockResponse);
 
       const input: TriggerChunkedRequest = {
         workflowKey: mockWorkflowKey,
@@ -907,12 +911,7 @@ describe(NotificationClient, () => {
     });
 
     it("logs Knock's request ID for each chunk", async () => {
-      vi.spyOn(provider.workflows, "trigger").mockReturnValue(
-        mockApiPromise({
-          data: { workflow_run_id: mockWorkflowRunId },
-          knockRequestId: mockKnockRequestId,
-        }),
-      );
+      mockTrigger({ workflow_run_id: mockWorkflowRunId }, mockKnockRequestId);
 
       const input: TriggerChunkedRequest = {
         workflowKey: mockWorkflowKey,
@@ -944,8 +943,8 @@ describe(NotificationClient, () => {
       const mockResponse2 = { workflow_run_id: "run-2" };
       const triggerSpy = vi
         .spyOn(provider.workflows, "trigger")
-        .mockResolvedValueOnce(mockResponse1)
-        .mockResolvedValueOnce(mockResponse2);
+        .mockReturnValueOnce(mockKnockCall(mockResponse1))
+        .mockReturnValueOnce(mockKnockCall(mockResponse2));
 
       const input: TriggerChunkedRequest = {
         workflowKey: mockWorkflowKey,
@@ -1117,7 +1116,7 @@ describe(NotificationClient, () => {
     it("handles string recipients", async () => {
       const mockBody = { recipients: ["user-1", "user-2"] };
       const mockResponse = { workflow_run_id: mockWorkflowRunId };
-      const triggerSpy = vi.spyOn(provider.workflows, "trigger").mockResolvedValue(mockResponse);
+      const triggerSpy = mockTrigger(mockResponse);
 
       const input: TriggerChunkedRequest = {
         workflowKey: mockWorkflowKey,
@@ -1141,7 +1140,7 @@ describe(NotificationClient, () => {
     it("logs request and chunk responses", async () => {
       const mockBody = { recipients: [{ userId: "user-1" }] };
       const mockResponse = { workflow_run_id: mockWorkflowRunId };
-      vi.spyOn(provider.workflows, "trigger").mockResolvedValue(mockResponse);
+      mockTrigger(mockResponse);
 
       const input: TriggerChunkedRequest = {
         workflowKey: mockWorkflowKey,
@@ -1175,7 +1174,7 @@ describe(NotificationClient, () => {
         workplaceId: "workplace-123",
       };
       const mockResponse = { workflow_run_id: mockWorkflowRunId };
-      const triggerSpy = vi.spyOn(provider.workflows, "trigger").mockResolvedValue(mockResponse);
+      const triggerSpy = mockTrigger(mockResponse);
 
       const input: TriggerChunkedRequest = {
         workflowKey: mockWorkflowKey,
@@ -1212,7 +1211,7 @@ describe(NotificationClient, () => {
         ],
       };
       const mockResponse = { workflow_run_id: mockWorkflowRunId };
-      const triggerSpy = vi.spyOn(provider.workflows, "trigger").mockResolvedValue(mockResponse);
+      const triggerSpy = mockTrigger(mockResponse);
 
       const input: TriggerChunkedRequest = {
         workflowKey: mockWorkflowKey,
@@ -1249,7 +1248,7 @@ describe(NotificationClient, () => {
         },
       };
       const mockResponse = { workflow_run_id: mockWorkflowRunId };
-      vi.spyOn(provider.workflows, "trigger").mockResolvedValue(mockResponse);
+      mockTrigger(mockResponse);
 
       const input: TriggerChunkedRequest = {
         workflowKey: mockWorkflowKey,
@@ -1289,7 +1288,7 @@ describe(NotificationClient, () => {
         ],
       };
       const mockResponse = { workflow_run_id: mockWorkflowRunId };
-      const triggerSpy = vi.spyOn(provider.workflows, "trigger").mockResolvedValue(mockResponse);
+      const triggerSpy = mockTrigger(mockResponse);
 
       const input: TriggerChunkedRequest = {
         workflowKey: mockWorkflowKey,
@@ -1333,7 +1332,7 @@ describe(NotificationClient, () => {
         ],
       };
       const mockResponse = { workflow_run_id: mockWorkflowRunId };
-      vi.spyOn(provider.workflows, "trigger").mockResolvedValue(mockResponse);
+      mockTrigger(mockResponse);
 
       const input: TriggerChunkedRequest = {
         workflowKey: mockWorkflowKey,
@@ -1371,9 +1370,11 @@ describe(NotificationClient, () => {
       const getChannelDataSpy = vi
         .spyOn(provider.users, "getChannelData")
         .mockRejectedValue(createNotFoundError());
-      const setChannelDataSpy = vi.spyOn(provider.users, "setChannelData").mockResolvedValue({
-        data: { tokens: [mockToken] },
-      } as SetChannelDataResponse);
+      const setChannelDataSpy = vi.spyOn(provider.users, "setChannelData").mockReturnValue(
+        mockKnockCall({
+          data: { tokens: [mockToken] },
+        } as SetChannelDataResponse),
+      );
 
       const result = await client.appendPushToken({
         channelId: mockChannelId,
@@ -1410,9 +1411,11 @@ describe(NotificationClient, () => {
       vi.spyOn(provider.users, "getChannelData").mockResolvedValue({
         data: { tokens: existingTokens },
       } as GetChannelDataResponse);
-      const setChannelDataSpy = vi.spyOn(provider.users, "setChannelData").mockResolvedValue({
-        data: { tokens: [...existingTokens, mockToken] },
-      } as SetChannelDataResponse);
+      const setChannelDataSpy = vi.spyOn(provider.users, "setChannelData").mockReturnValue(
+        mockKnockCall({
+          data: { tokens: [...existingTokens, mockToken] },
+        } as SetChannelDataResponse),
+      );
 
       const result = await client.appendPushToken({
         channelId: mockChannelId,
@@ -1439,9 +1442,11 @@ describe(NotificationClient, () => {
       vi.spyOn(provider.users, "getChannelData").mockResolvedValue({
         data: { tokens: existingTokens },
       } as GetChannelDataResponse);
-      const setChannelDataSpy = vi.spyOn(provider.users, "setChannelData").mockResolvedValue({
-        data: { tokens: ["existing-token-1", mockToken] },
-      } as SetChannelDataResponse);
+      const setChannelDataSpy = vi.spyOn(provider.users, "setChannelData").mockReturnValue(
+        mockKnockCall({
+          data: { tokens: ["existing-token-1", mockToken] },
+        } as SetChannelDataResponse),
+      );
 
       const result = await client.appendPushToken({
         channelId: mockChannelId,
@@ -1467,9 +1472,11 @@ describe(NotificationClient, () => {
       vi.spyOn(provider.users, "getChannelData").mockResolvedValue({
         data: {},
       } as GetChannelDataResponse);
-      const setChannelDataSpy = vi.spyOn(provider.users, "setChannelData").mockResolvedValue({
-        data: { tokens: [mockToken] },
-      } as SetChannelDataResponse);
+      const setChannelDataSpy = vi.spyOn(provider.users, "setChannelData").mockReturnValue(
+        mockKnockCall({
+          data: { tokens: [mockToken] },
+        } as SetChannelDataResponse),
+      );
 
       const result = await client.appendPushToken({
         channelId: mockChannelId,
@@ -1485,9 +1492,11 @@ describe(NotificationClient, () => {
 
     it("logs info when no existing channel data found", async () => {
       vi.spyOn(provider.users, "getChannelData").mockRejectedValue(createNotFoundError());
-      vi.spyOn(provider.users, "setChannelData").mockResolvedValue({
-        data: { tokens: [mockToken] },
-      } as SetChannelDataResponse);
+      vi.spyOn(provider.users, "setChannelData").mockReturnValue(
+        mockKnockCall({
+          data: { tokens: [mockToken] },
+        } as SetChannelDataResponse),
+      );
 
       await client.appendPushToken({
         channelId: mockChannelId,
@@ -1552,9 +1561,11 @@ describe(NotificationClient, () => {
 
     it("does not log sensitive push token in request or response", async () => {
       vi.spyOn(provider.users, "getChannelData").mockRejectedValue(createNotFoundError());
-      vi.spyOn(provider.users, "setChannelData").mockResolvedValue({
-        data: { tokens: [mockToken] },
-      } as SetChannelDataResponse);
+      vi.spyOn(provider.users, "setChannelData").mockReturnValue(
+        mockKnockCall({
+          data: { tokens: [mockToken] },
+        } as SetChannelDataResponse),
+      );
 
       await client.appendPushToken({
         channelId: mockChannelId,
@@ -1576,9 +1587,11 @@ describe(NotificationClient, () => {
 
     it("handles response with no tokens field", async () => {
       vi.spyOn(provider.users, "getChannelData").mockRejectedValue(createNotFoundError());
-      vi.spyOn(provider.users, "setChannelData").mockResolvedValue({
-        data: {},
-      } as SetChannelDataResponse);
+      vi.spyOn(provider.users, "setChannelData").mockReturnValue(
+        mockKnockCall({
+          data: {},
+        } as SetChannelDataResponse),
+      );
 
       const result = await client.appendPushToken({
         channelId: mockChannelId,
@@ -1631,7 +1644,9 @@ describe(NotificationClient, () => {
         name: mockWorkplaceName,
         __typename: "Tenant",
       };
-      const tenantSetSpy = vi.spyOn(provider.tenants, "set").mockResolvedValue(mockResponse);
+      const tenantSetSpy = vi
+        .spyOn(provider.tenants, "set")
+        .mockReturnValue(mockKnockCall(mockResponse));
 
       const input: UpsertWorkplaceRequest = {
         workplaceId: mockWorkplaceId,
@@ -1662,7 +1677,9 @@ describe(NotificationClient, () => {
         name: mockWorkplaceName,
         __typename: "Tenant",
       };
-      const tenantSetSpy = vi.spyOn(provider.tenants, "set").mockResolvedValue(mockResponse);
+      const tenantSetSpy = vi
+        .spyOn(provider.tenants, "set")
+        .mockReturnValue(mockKnockCall(mockResponse));
 
       const input: UpsertWorkplaceRequest = {
         workplaceId: mockWorkplaceId,
@@ -1897,7 +1914,7 @@ fQ4QecZi2079UtRo1Amb8+wqaQ==
 
       const setPreferencesSpy = vi
         .spyOn(provider.users, "setPreferences")
-        .mockResolvedValue(mockPreferenceSet);
+        .mockReturnValue(mockKnockCall(mockPreferenceSet));
 
       const input: UpsertUserPreferencesRequest = {
         userId: mockUserId,
@@ -1967,15 +1984,16 @@ function createErrorWithRequestId(message: string, status: number): Error & { st
 }
 
 /**
- * Knock's SDK returns promises that expose the raw HTTP response; `vi.fn`'s promises don't.
+ * Stands in for the {@link APIPromise} Knock's SDK returns, which settles the parsed body and
+ * exposes the raw HTTP response the body was parsed from.
  */
 // eslint-disable-next-line @typescript-eslint/promise-function-async -- must return the promise itself, not an async wrapper around it.
-function mockApiPromise<T>(params: { data: T; knockRequestId: string }): APIPromise<T> {
-  const { data, knockRequestId } = params;
+function mockKnockCall<T>(data?: T, knockRequestId?: string): APIPromise<T> {
   const promise = Promise.resolve(data) as unknown as APIPromise<T>;
-
   promise.asResponse = async () =>
-    new Response(undefined, { headers: { "x-request-id": knockRequestId } });
+    new Response(undefined, {
+      headers: isDefined(knockRequestId) ? { "x-request-id": knockRequestId } : {},
+    });
 
   return promise;
 }

--- a/packages/notifications/src/lib/notificationClient.test.ts
+++ b/packages/notifications/src/lib/notificationClient.test.ts
@@ -1,6 +1,6 @@
 import { expectToBeFailure, expectToBeSuccess } from "@clipboard-health/testing-core";
 import { type LogFunction, type Logger, ServiceError } from "@clipboard-health/util-ts";
-import type { Knock } from "@knocklabs/node";
+import type { APIPromise, Knock } from "@knocklabs/node";
 import type { Mocked } from "vitest";
 
 import { ERROR_CODES } from "./errorCodes";
@@ -23,6 +23,8 @@ import type {
   UpsertUserPreferencesRequest,
   UpsertWorkplaceRequest,
 } from "./types";
+
+const mockKnockRequestId = "2fVhPwXrQnUxQ9krVnP5a6Z4qXe";
 
 type SetChannelDataResponse = Awaited<ReturnType<Knock["users"]["setChannelData"]>>;
 type GetChannelDataResponse = Awaited<ReturnType<Knock["users"]["getChannelData"]>>;
@@ -184,6 +186,56 @@ describe(NotificationClient, () => {
       expect(mockLogger.error).toHaveBeenCalledWith(
         "notifications.trigger [unknown] Knock API error",
         expect.any(Object),
+      );
+    });
+
+    it("logs Knock's request ID from the response", async () => {
+      vi.spyOn(provider.workflows, "trigger").mockReturnValue(
+        mockApiPromise({
+          data: { workflow_run_id: mockWorkflowRunId },
+          knockRequestId: mockKnockRequestId,
+        }),
+      );
+
+      const input: TriggerRequest = {
+        workflowKey: mockWorkflowKey,
+        body: { recipients: [{ userId: "user-1" }] },
+        idempotencyKey: mockIdempotencyKey,
+        expiresAt: mockExpiresAt,
+        attempt: mockAttempt,
+      };
+
+      const actual = await client.trigger(input);
+
+      expectToBeSuccess(actual);
+      expect(actual.value.knockRequestId).toBe(mockKnockRequestId);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        "notifications.trigger response",
+        expect.objectContaining({ knockRequestId: mockKnockRequestId }),
+      );
+    });
+
+    it("logs Knock's request ID from a failed response", async () => {
+      const mockError = createErrorWithRequestId(
+        "One or more parameters supplied were invalid",
+        422,
+      );
+      vi.spyOn(provider.workflows, "trigger").mockRejectedValue(mockError);
+
+      const input: TriggerRequest = {
+        workflowKey: mockWorkflowKey,
+        body: { recipients: [{ userId: "user-1" }] },
+        idempotencyKey: mockIdempotencyKey,
+        expiresAt: mockExpiresAt,
+        attempt: mockAttempt,
+      };
+
+      const actual = await client.trigger(input);
+
+      expectToBeFailure(actual);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "notifications.trigger [clientError] One or more parameters supplied were invalid",
+        expect.objectContaining({ knockRequestId: mockKnockRequestId }),
       );
     });
 
@@ -735,6 +787,24 @@ describe(NotificationClient, () => {
       });
     });
 
+    it("logs Knock's request ID from the response", async () => {
+      vi.spyOn(provider.workflows, "cancel").mockReturnValue(
+        mockApiPromise({ data: undefined, knockRequestId: mockKnockRequestId }),
+      );
+
+      const input: CancelRequest = {
+        workflowKey: mockWorkflowKey,
+        cancellationKey: mockCancellationKey,
+      };
+
+      await client.cancel(input);
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        "notifications.cancel response",
+        expect.objectContaining({ knockRequestId: mockKnockRequestId }),
+      );
+    });
+
     it("skips provider call when dryRun is true", async () => {
       const cancelSpy = vi.spyOn(provider.workflows, "cancel");
 
@@ -833,6 +903,34 @@ describe(NotificationClient, () => {
         {
           idempotencyKey: `${mockIdempotencyKey}-1`,
         },
+      );
+    });
+
+    it("logs Knock's request ID for each chunk", async () => {
+      vi.spyOn(provider.workflows, "trigger").mockReturnValue(
+        mockApiPromise({
+          data: { workflow_run_id: mockWorkflowRunId },
+          knockRequestId: mockKnockRequestId,
+        }),
+      );
+
+      const input: TriggerChunkedRequest = {
+        workflowKey: mockWorkflowKey,
+        body: { recipients: [{ userId: "user-1" }] },
+        idempotencyKey: mockIdempotencyKey,
+        expiresAt: mockExpiresAt,
+        attempt: mockAttempt,
+      };
+
+      const actual = await client.triggerChunked(input);
+
+      expectToBeSuccess(actual);
+      expect(actual.value.responses).toStrictEqual([
+        { chunkNumber: 1, id: mockWorkflowRunId, knockRequestId: mockKnockRequestId },
+      ]);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        "notifications.triggerChunked chunk response",
+        expect.objectContaining({ knockRequestId: mockKnockRequestId }),
       );
     });
 
@@ -1857,4 +1955,27 @@ function createErrorWithStatus(message: string, status: number): Error & { statu
   const error = new Error(message) as Error & { status: number };
   error.status = status;
   return error;
+}
+
+function createErrorWithRequestId(message: string, status: number): Error & { status: number } {
+  const error = createErrorWithStatus(message, status) as Error & {
+    status: number;
+    headers: Headers;
+  };
+  error.headers = new Headers({ "x-request-id": mockKnockRequestId });
+  return error;
+}
+
+/**
+ * Knock's SDK returns promises that expose the raw HTTP response; `vi.fn`'s promises don't.
+ */
+// eslint-disable-next-line @typescript-eslint/promise-function-async -- must return the promise itself, not an async wrapper around it.
+function mockApiPromise<T>(params: { data: T; knockRequestId: string }): APIPromise<T> {
+  const { data, knockRequestId } = params;
+  const promise = Promise.resolve(data) as unknown as APIPromise<T>;
+
+  promise.asResponse = async () =>
+    new Response(undefined, { headers: { "x-request-id": knockRequestId } });
+
+  return promise;
 }

--- a/packages/notifications/src/lib/notificationClient.ts
+++ b/packages/notifications/src/lib/notificationClient.ts
@@ -1,6 +1,7 @@
 import {
   failure,
   type FailureResult,
+  isDefined,
   isFailure,
   type LogFunction,
   ServiceError,
@@ -15,6 +16,7 @@ import { chunkRecipients, MAXIMUM_RECIPIENTS_COUNT } from "./internal/chunkRecip
 import { createTriggerLogParams } from "./internal/createTriggerLogParams";
 import { createTriggerTraceOptions } from "./internal/createTriggerTraceOptions";
 import { IdempotentKnock } from "./internal/idempotentKnock";
+import { withKnockRequestId } from "./internal/knockRequestId";
 import { parseTriggerIdempotencyKey } from "./internal/parseTriggerIdempotencyKey";
 import { redact } from "./internal/redact";
 import { toKnockUserPreferences } from "./internal/toKnockUserPreferences";
@@ -140,25 +142,27 @@ export class NotificationClient {
             return success({ id: "dry-run" });
           }
 
-          const response = await this.provider.workflows.trigger(workflowKey, triggerBody, {
-            idempotencyKey: triggerIdempotencyKeyParamsToHash({
-              ...idempotencyKeyParams,
-              workplaceId,
+          const { knockRequestId, response } = await withKnockRequestId(
+            this.provider.workflows.trigger(workflowKey, triggerBody, {
+              idempotencyKey: triggerIdempotencyKeyParamsToHash({
+                ...idempotencyKeyParams,
+                workplaceId,
+              }),
             }),
-          });
+          );
 
           const id = response.workflow_run_id;
-          this.logTriggerResponse({ span, response, id, logParams });
+          this.logTriggerResponse({ span, response, id, knockRequestId, logParams });
 
-          return success({ id });
+          return success({ id, ...(isDefined(knockRequestId) && { knockRequestId }) });
         } catch (maybeError) {
-          const { code, error, message } = toNotificationError(maybeError);
+          const { code, error, knockRequestId, message } = toNotificationError(maybeError);
           return this.createAndLogError({
             notificationError: { code, message },
             span,
             logFunction: this.logger.error,
             logParams,
-            metadata: { error },
+            metadata: { error, knockRequestId },
           });
         }
       },
@@ -324,7 +328,7 @@ export class NotificationClient {
         }
 
         const chunks = chunkRecipients({ recipients: body.recipients });
-        const responses: Array<{ chunkNumber: number; id: string }> = [];
+        const responses: TriggerChunkedResponse["responses"] = [];
 
         // Sequential execution is intentional - we want to fail fast on error and track progress
         for (const recipientChunk of chunks) {
@@ -337,9 +341,11 @@ export class NotificationClient {
             const triggerBody = toTriggerBody(chunkBody);
 
             // eslint-disable-next-line no-await-in-loop
-            const response = await this.provider.workflows.trigger(workflowKey, triggerBody, {
-              idempotencyKey: chunkIdempotencyKey,
-            });
+            const { knockRequestId, response } = await withKnockRequestId(
+              this.provider.workflows.trigger(workflowKey, triggerBody, {
+                idempotencyKey: chunkIdempotencyKey,
+              }),
+            );
 
             const id = response.workflow_run_id;
             this.logger.info(`${logParams.traceName} chunk response`, {
@@ -347,11 +353,16 @@ export class NotificationClient {
               chunkNumber: recipientChunk.number,
               totalChunks: chunks.length,
               id,
+              knockRequestId,
             });
 
-            responses.push({ chunkNumber: recipientChunk.number, id });
+            responses.push({
+              chunkNumber: recipientChunk.number,
+              id,
+              ...(isDefined(knockRequestId) && { knockRequestId }),
+            });
           } catch (maybeError) {
-            const { code, error, message } = toNotificationError(maybeError);
+            const { code, error, knockRequestId, message } = toNotificationError(maybeError);
             return this.createAndLogError({
               notificationError: {
                 code,
@@ -362,6 +373,7 @@ export class NotificationClient {
               logParams,
               metadata: {
                 error,
+                knockRequestId,
                 chunkNumber: recipientChunk.number,
                 totalChunks: chunks.length,
                 completedChunks: responses.length,
@@ -422,20 +434,22 @@ export class NotificationClient {
       }
 
       try {
-        await this.provider.workflows.cancel(workflowKey, {
-          cancellation_key: cancellationKey,
-          ...(recipients ? { recipients } : {}),
-        });
+        const { knockRequestId } = await withKnockRequestId(
+          this.provider.workflows.cancel(workflowKey, {
+            cancellation_key: cancellationKey,
+            ...(recipients ? { recipients } : {}),
+          }),
+        );
 
-        this.logger.info(`${logParams.traceName} response`, logParams);
+        this.logger.info(`${logParams.traceName} response`, { ...logParams, knockRequestId });
       } catch (maybeError) {
-        const { code, error, message } = toNotificationError(maybeError);
+        const { code, error, knockRequestId, message } = toNotificationError(maybeError);
         const result = this.createAndLogError({
           notificationError: { code, message },
           span,
           logFunction: this.logger.error,
           logParams,
-          metadata: { error },
+          metadata: { error, knockRequestId },
         });
         throw result.error;
       }
@@ -462,24 +476,27 @@ export class NotificationClient {
         existingTokenCount: existingTokens.length,
       });
 
-      const response = await this.provider.users.setChannelData(userId, channelId, {
-        data: { tokens: [...new Set([...existingTokens, token])] },
-      });
+      const { knockRequestId, response } = await withKnockRequestId(
+        this.provider.users.setChannelData(userId, channelId, {
+          data: { tokens: [...new Set([...existingTokens, token])] },
+        }),
+      );
 
       this.logger.info(`${logParams.traceName} response`, {
         ...logParams,
+        knockRequestId,
         // Don't log the actual response; push tokens are sensitive.
         response: { tokenCount: "tokens" in response.data ? response.data.tokens.length : 0 },
       });
 
       return success({ success: true });
     } catch (maybeError) {
-      const { code, error, message } = toNotificationError(maybeError);
+      const { code, error, knockRequestId, message } = toNotificationError(maybeError);
       return this.createAndLogError({
         notificationError: { code, message },
         logFunction: this.logger.error,
         logParams,
-        metadata: { error },
+        metadata: { error, knockRequestId },
       });
     }
   }
@@ -546,10 +563,13 @@ export class NotificationClient {
     try {
       this.logger.info(`${logParams.traceName} request`, logParams);
 
-      const response = await this.provider.tenants.set(workplaceId, toTenantSetRequest(body));
+      const { knockRequestId, response } = await withKnockRequestId(
+        this.provider.tenants.set(workplaceId, toTenantSetRequest(body)),
+      );
 
       this.logger.info(`${logParams.traceName} response`, {
         ...logParams,
+        knockRequestId,
         response: { workplaceId: response.id, name: response.name },
       });
 
@@ -557,12 +577,12 @@ export class NotificationClient {
         workplaceId: response.id,
       });
     } catch (maybeError) {
-      const { code, error, message } = toNotificationError(maybeError);
+      const { code, error, knockRequestId, message } = toNotificationError(maybeError);
       return this.createAndLogError({
         notificationError: { code, message },
         logFunction: this.logger.error,
         logParams,
-        metadata: { error },
+        metadata: { error, knockRequestId },
       });
     }
   }
@@ -582,21 +602,24 @@ export class NotificationClient {
       this.logger.info(`${logParams.traceName} request`, logParams);
 
       const userPreferences = toKnockUserPreferences(params);
-      const response = await this.provider.users.setPreferences(userId, "default", userPreferences);
+      const { knockRequestId, response } = await withKnockRequestId(
+        this.provider.users.setPreferences(userId, "default", userPreferences),
+      );
 
       this.logger.info(`${logParams.traceName} response`, {
         ...logParams,
+        knockRequestId,
         response: { userId, preferenceSet: response },
       });
 
       return success({ userId });
     } catch (maybeError) {
-      const { code, error, message } = toNotificationError(maybeError);
+      const { code, error, knockRequestId, message } = toNotificationError(maybeError);
       return this.createAndLogError({
         notificationError: { code, message },
         logFunction: this.logger.error,
         logParams,
-        metadata: { error },
+        metadata: { error, knockRequestId },
       });
     }
   }
@@ -780,16 +803,22 @@ export class NotificationClient {
     span?: Span | undefined;
     response: unknown;
     id: string;
+    knockRequestId?: string | undefined;
     logParams: LogParams;
   }): string {
-    const { span, response, id, logParams } = params;
+    const { span, response, id, knockRequestId, logParams } = params;
 
     span?.addTags({
       "response.id": id,
       success: true,
     });
 
-    this.logger.info(`${logParams.traceName} response`, { ...logParams, id, response });
+    this.logger.info(`${logParams.traceName} response`, {
+      ...logParams,
+      id,
+      knockRequestId,
+      response,
+    });
 
     return id;
   }

--- a/packages/notifications/src/lib/types.ts
+++ b/packages/notifications/src/lib/types.ts
@@ -221,6 +221,14 @@ export interface TriggerRequest {
 export interface TriggerResponse {
   /** Third-party provider's unique identifier. */
   id: string;
+
+  /**
+   * Knock's request ID, when Knock returned one. Use it to find the matching entry in Knock's
+   * dashboard under Observability > Logs.
+   *
+   * @see {@link https://docs.knock.app/developer-tools/api-logs}
+   */
+  knockRequestId?: string | undefined;
 }
 
 /**


### PR DESCRIPTION
## Why

Debugging a Knock failure currently means hand-searching Knock's dashboard. On [TEM-2494](https://linear.app/clipboardhealth/issue/TEM-2494) the SDK error only said `422 One or more parameters supplied were invalid`; the actionable detail — `recipients.id can't be blank` — lived in Knock's API log, and finding the matching entry took manual guesswork. No direct customer impact; this shortens time-to-diagnosis for on-call and anyone debugging a notification.

## Summary

Knock returns a unique `X-Request-ID` header on every API call and lets you filter its API logs by it. We now capture it and put it in our logs:

- Success paths read it from the raw HTTP response the SDK's `APIPromise` exposes (`trigger`, `triggerChunked` per chunk, `cancel`, `appendPushToken`, `upsertWorkplace`, `upsertUserPreferences`).
- Failure paths read it from the response headers the SDK attaches to the errors it throws, so `toNotificationError` returns it and every error log carries it.
- `TriggerResponse` exposes `knockRequestId`, so callers that log `result.value` — including `TriggerNotificationJob` — get it in their own log entries too.
- The README documents how to pivot from `knockRequestId` to Knock's dashboard.

`withKnockRequestId` takes the SDK's promise directly and awaits the parsed body before the raw response, so a failed request throws before `asResponse` is touched — which is why the suite's rejection mocks needed no changes. The resolved mocks now return an `APIPromise`-shaped double, matching what production actually flows through. Extracting `mockTrigger` collapsed 21 repeats of the same spy incantation and keeps the test file under the repo's 2000-line cap.

## Validation

- `nx run-many -t build lint test -p notifications` — passing (176 tests, 5 new)
- `node --run verify` — all 8 checks passing
- New tests assert the request ID reaches the logs on success, on a 422 failure, and per chunk, and cover `cancel`'s empty (204) response body
- Mutation-checked: breaking the header name, and forcing the extraction to return `undefined`, each fail exactly the 5 new tests

## Notes

- [DEVOP-5046](https://linear.app/clipboardhealth/issue/DEVOP-5046/include-knock-request-id-in-logs)
- `knockRequestId` names the provider inside otherwise provider-agnostic types. Deliberate: the package already names Knock throughout its log and trace values (`knock.workflows.trigger`, `IdempotentKnock`), and a searchable field name matching the ticket's wording is worth more than hiding the provider.
- Not added as a span tag — request IDs are high cardinality and `createTriggerTraceOptions` deliberately keeps those out of Datadog.
- `signUserToken` has no request ID; it signs locally and never calls Knock's API. `users.getChannelData` is also unwrapped — it is an internal read whose failures already surface the ID through `appendPushToken`'s catch.

Agent session: `claude --resume c431211b-f698-48af-8635-bd0b660d53ea`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.3</code></sub>
