### PR TITLE
fix: recover from Playwright response body loss (STAFF-2501)

### DIFF
--- a/packages/playwright-toolkit/README.md
+++ b/packages/playwright-toolkit/README.md
@@ -94,6 +94,8 @@ Playwright response bodies can become unreadable after a document navigation. Us
 `waitForParsedJsonResponse` when a page action both waits for a JSON response and crosses a
 navigation boundary. The helper parses each candidate inside the `waitForResponse` predicate and
 returns only the parsed value, so callers cannot accidentally retain a lazy `Response` handle.
+Predicate-local parsing narrows the response-lifetime window but cannot eliminate it: Chromium can
+discard the underlying CDP resource while `response.json()` is still pending.
 
 ```typescript
 const workerResponsePromise = waitForParsedJsonResponse({
@@ -110,8 +112,14 @@ const workerResponse = await workerResponsePromise;
 ```
 
 Return `undefined` from `parseCandidate` when the URL-level candidate is valid but its body is not
-the response the test needs. Parsing errors propagate immediately. Keep repository-specific URL,
-method, resource-type, and schema matching in the consumer.
+the response the test needs. If a candidate body read fails with the exact Chromium
+`Network.getResponseBody` / `No resource with given identifier found` signature, the helper rejects
+only that candidate and continues inside the original finite waiter. It does not issue another
+request or navigation, add a retry or sleep, or widen the timeout. Invalid JSON, parsing and schema
+errors, near-match protocol errors, page or target closure, and cancellation propagate immediately.
+If the outer waiter times out after classified losses, the error preserves the original timeout as
+its cause and adds only bounded diagnostics with the loss count, method, status, and a redacted path
+template. Keep repository-specific URL, method, resource-type, and schema matching in the consumer.
 
 ## Per-test traceparent fixture
 

--- a/packages/playwright-toolkit/src/lib/jsonResponse.test.ts
+++ b/packages/playwright-toolkit/src/lib/jsonResponse.test.ts
@@ -1,15 +1,25 @@
-import type { Page, Response } from "@playwright/test";
+import { isNil } from "@clipboard-health/util-ts";
+import { errors, type Page, type Response } from "@playwright/test";
 
 import { waitForParsedJsonResponse } from "../index";
 
 interface MockResponseParams {
   body: unknown;
+  bodyError?: Error;
+  method?: string;
+  status?: number;
   url?: string;
 }
 
 interface MockResponse {
   response: Response;
   setReadable(isReadable: boolean): void;
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  reject(error: unknown): void;
+  resolve(value: T): void;
 }
 
 interface VersionResponse {
@@ -33,9 +43,14 @@ function createMockResponse(params: MockResponseParams): MockResponse {
       if (!isReadable) {
         throw new Error("Response body is no longer readable");
       }
+      if (params.bodyError) {
+        throw params.bodyError;
+      }
 
       return await Promise.resolve(params.body);
     }),
+    request: vi.fn(() => ({ method: vi.fn(() => params.method ?? "GET") })),
+    status: vi.fn(() => params.status ?? 200),
     url: vi.fn(() => params.url ?? "https://api.example.test/workers"),
   } as unknown as Response;
 
@@ -47,7 +62,11 @@ function createMockResponse(params: MockResponseParams): MockResponse {
   };
 }
 
-function createMockPage(params: { afterMatch?: () => void; responses: Response[] }): Page {
+function createMockPage(params: {
+  afterMatch?: () => void;
+  exhaustionError?: Error;
+  responses: Response[];
+}): Page {
   return {
     waitForResponse: vi.fn(async (predicate: Parameters<Page["waitForResponse"]>[0]) => {
       if (typeof predicate !== "function") {
@@ -62,9 +81,62 @@ function createMockPage(params: { afterMatch?: () => void; responses: Response[]
         }
       }
 
-      throw new Error("Timeout waiting for response");
+      throw params.exhaustionError ?? new Error("Timeout waiting for response");
     }),
   } as unknown as Page;
+}
+
+function createOutOfOrderMockPage(params: {
+  fastBody: Deferred<unknown>;
+  fastResponse: Response;
+  fastValue: unknown;
+  slowBody: Deferred<unknown>;
+  slowResponse: Response;
+  slowValue: unknown;
+}): Page {
+  return {
+    waitForResponse: vi.fn(async (predicate: Parameters<Page["waitForResponse"]>[0]) => {
+      if (typeof predicate !== "function") {
+        throw new TypeError("Expected a response predicate");
+      }
+
+      const slowMatchPromise = predicate(params.slowResponse);
+      const fastMatchPromise = predicate(params.fastResponse);
+      params.fastBody.resolve(params.fastValue);
+      await fastMatchPromise;
+      params.slowBody.resolve(params.slowValue);
+      await slowMatchPromise;
+
+      return params.fastResponse;
+    }),
+  } as unknown as Page;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let rejectPromise: ((error: unknown) => void) | undefined;
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve, reject) => {
+    rejectPromise = reject;
+    resolvePromise = resolve;
+  });
+
+  return {
+    promise,
+    reject(error) {
+      if (isNil(rejectPromise)) {
+        throw new Error("Deferred promise was not initialized");
+      }
+
+      rejectPromise(error);
+    },
+    resolve(value) {
+      if (isNil(resolvePromise)) {
+        throw new Error("Deferred promise was not initialized");
+      }
+
+      resolvePromise(value);
+    },
+  };
 }
 
 describe("waitForParsedJsonResponse", () => {
@@ -87,6 +159,158 @@ describe("waitForParsedJsonResponse", () => {
     expect(actual).toEqual({ version: "V3" });
     expect(mockResponse.response.json).toHaveBeenCalledTimes(1);
     expect(page.waitForResponse).toHaveBeenCalledWith(expect.any(Function), { timeout: 1000 });
+  });
+
+  it("continues after an exact response body loss and returns a later candidate", async () => {
+    const firstBody = createDeferred<unknown>();
+    const lostResponse = createMockResponse({ body: firstBody.promise });
+    const freshResponse = createMockResponse({ body: VERSION_THREE_RESPONSE });
+    const waitPromise = waitForParsedJsonResponse<{ version: string }>({
+      isCandidate: () => true,
+      page: createMockPage({ responses: [lostResponse.response, freshResponse.response] }),
+      parseCandidate: parseVersionThreeCandidate,
+      timeoutMs: 1000,
+    });
+    await vi.waitFor(() => {
+      expect(lostResponse.response.json).toHaveBeenCalledTimes(1);
+    });
+
+    firstBody.reject(
+      new Error(
+        "response.json: Protocol error (Network.getResponseBody): No resource with given identifier found",
+      ),
+    );
+
+    await expect(waitPromise).resolves.toEqual({ version: "V3" });
+    expect(freshResponse.response.json).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates a response body loss from a different protocol method", async () => {
+    const body = createDeferred<unknown>();
+    const mockResponse = createMockResponse({ body: body.promise });
+    const waitPromise = waitForParsedJsonResponse({
+      isCandidate: () => true,
+      page: createMockPage({ responses: [mockResponse.response] }),
+      parseCandidate: parseVersionThreeCandidate,
+      timeoutMs: 1000,
+    });
+    await vi.waitFor(() => {
+      expect(mockResponse.response.json).toHaveBeenCalledTimes(1);
+    });
+    const error = new Error(
+      "response.json: Protocol error (Network.getResponseBodyForInterception): No resource with given identifier found",
+    );
+
+    body.reject(error);
+
+    await expect(waitPromise).rejects.toBe(error);
+  });
+
+  it("preserves the timeout cause with bounded redacted loss diagnostics", async () => {
+    const bodyLossError = new Error(
+      "response.json: Protocol error (Network.getResponseBody): No resource with given identifier found",
+    );
+    const sensitivePath =
+      "/api/workplaces/workplace-secret/shift-invites/invite-secret/workers/worker-secret";
+    const methods = ["GET", "POST", "PUT", "PATCH", "DELETE"];
+    const responses = methods.map((method, index) =>
+      createMockResponse({
+        body: undefined,
+        bodyError: bodyLossError,
+        method,
+        status: 200 + index,
+        url: `https://api.example.test${sensitivePath}?token=secret-token`,
+      }),
+    );
+    const timeoutError = new errors.TimeoutError("Timeout 1000ms exceeded.");
+    let actualError: unknown;
+
+    try {
+      await waitForParsedJsonResponse({
+        isCandidate: () => true,
+        page: createMockPage({
+          exhaustionError: timeoutError,
+          responses: responses.map(({ response }) => response),
+        }),
+        parseCandidate: parseVersionThreeCandidate,
+        timeoutMs: 1000,
+      });
+    } catch (error: unknown) {
+      actualError = error;
+    }
+
+    expect(actualError).toMatchObject({
+      cause: timeoutError,
+      message: expect.stringContaining("count=5"),
+    });
+    expect(String(actualError)).toContain("method=GET status=200 path=/[redacted-path]");
+    expect(String(actualError).match(/method=/g)).toHaveLength(3);
+    expect(String(actualError)).not.toContain("workplace-secret");
+    expect(String(actualError)).not.toContain("invite-secret");
+    expect(String(actualError)).not.toContain("worker-secret");
+    expect(String(actualError)).not.toContain("secret-token");
+    expect(String(actualError).length).toBeLessThan(500);
+  });
+
+  it.each([
+    ["invalid JSON", new SyntaxError("Unexpected token in JSON")],
+    [
+      "the CDP method without the loss message",
+      new Error("response.json: Protocol error (Network.getResponseBody): Request failed"),
+    ],
+    [
+      "the loss message without the CDP method",
+      new Error("response.json: No resource with given identifier found"),
+    ],
+    ["an arbitrary protocol error", new Error("Protocol error (Runtime.callFunctionOn): Failed")],
+    ["page closure", new Error("Target page, context or browser has been closed")],
+    ["cancellation", new DOMException("This operation was aborted", "AbortError")],
+  ])("propagates %s from the candidate body read", async (_name, bodyError) => {
+    const mockResponse = createMockResponse({ body: undefined, bodyError });
+
+    const actualPromise = waitForParsedJsonResponse({
+      isCandidate: () => true,
+      page: createMockPage({ responses: [mockResponse.response] }),
+      parseCandidate: parseVersionThreeCandidate,
+      timeoutMs: 1000,
+    });
+
+    await expect(actualPromise).rejects.toBe(bodyError);
+  });
+
+  it("propagates a page closure after a classified body loss", async () => {
+    const pageClosedError = new Error("Target page, context or browser has been closed");
+    const lostResponse = createMockResponse({
+      body: undefined,
+      bodyError: new Error(
+        "response.json: Protocol error (Network.getResponseBody): No resource with given identifier found",
+      ),
+    });
+
+    const actualPromise = waitForParsedJsonResponse({
+      isCandidate: () => true,
+      page: createMockPage({
+        exhaustionError: pageClosedError,
+        responses: [lostResponse.response],
+      }),
+      parseCandidate: parseVersionThreeCandidate,
+      timeoutMs: 1000,
+    });
+
+    await expect(actualPromise).rejects.toBe(pageClosedError);
+  });
+
+  it("propagates the original timeout when no response body was lost", async () => {
+    const timeoutError = new errors.TimeoutError("Timeout 1000ms exceeded.");
+
+    const actualPromise = waitForParsedJsonResponse({
+      isCandidate: () => false,
+      page: createMockPage({ exhaustionError: timeoutError, responses: [] }),
+      parseCandidate: parseVersionThreeCandidate,
+      timeoutMs: 1000,
+    });
+
+    await expect(actualPromise).rejects.toBe(timeoutError);
   });
 
   it("accepts null as a parsed JSON response", async () => {
@@ -123,6 +347,36 @@ describe("waitForParsedJsonResponse", () => {
     expect(unrelatedResponse.response.json).not.toHaveBeenCalled();
     expect(staleResponse.response.json).toHaveBeenCalledTimes(1);
     expect(freshResponse.response.json).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the value associated with the response selected during concurrent parsing", async () => {
+    const slowBody = createDeferred<unknown>();
+    const fastBody = createDeferred<unknown>();
+    const slowValue = { version: "slow" };
+    const fastValue = { version: "fast" };
+    const slowResponse = createMockResponse({ body: slowBody.promise });
+    const fastResponse = createMockResponse({ body: fastBody.promise });
+    const parsedResponses = new Map<unknown, VersionResponse>([
+      [slowValue, slowValue],
+      [fastValue, fastValue],
+    ]);
+    const page = createOutOfOrderMockPage({
+      fastBody,
+      fastResponse: fastResponse.response,
+      fastValue,
+      slowBody,
+      slowResponse: slowResponse.response,
+      slowValue,
+    });
+
+    const actual = await waitForParsedJsonResponse({
+      isCandidate: () => true,
+      page,
+      parseCandidate: ({ body }) => parsedResponses.get(body),
+      timeoutMs: 1000,
+    });
+
+    expect(actual).toBe(fastValue);
   });
 
   it("surfaces parser failures", async () => {

--- a/packages/playwright-toolkit/src/lib/jsonResponse.test.ts
+++ b/packages/playwright-toolkit/src/lib/jsonResponse.test.ts
@@ -300,6 +300,28 @@ describe("waitForParsedJsonResponse", () => {
     await expect(actualPromise).rejects.toBe(pageClosedError);
   });
 
+  it("propagates a candidate parser timeout after a classified body loss", async () => {
+    const candidateTimeoutError = new errors.TimeoutError("Candidate parser timed out");
+    const lostResponse = createMockResponse({
+      body: undefined,
+      bodyError: new Error(
+        "response.json: Protocol error (Network.getResponseBody): No resource with given identifier found",
+      ),
+    });
+    const freshResponse = createMockResponse({ body: VERSION_THREE_RESPONSE });
+
+    const actualPromise = waitForParsedJsonResponse({
+      isCandidate: () => true,
+      page: createMockPage({ responses: [lostResponse.response, freshResponse.response] }),
+      parseCandidate: () => {
+        throw candidateTimeoutError;
+      },
+      timeoutMs: 1000,
+    });
+
+    await expect(actualPromise).rejects.toBe(candidateTimeoutError);
+  });
+
   it("propagates the original timeout when no response body was lost", async () => {
     const timeoutError = new errors.TimeoutError("Timeout 1000ms exceeded.");
 

--- a/packages/playwright-toolkit/src/lib/jsonResponse.ts
+++ b/packages/playwright-toolkit/src/lib/jsonResponse.ts
@@ -1,5 +1,9 @@
-import { isDefined } from "@clipboard-health/util-ts";
-import type { Page, Response } from "@playwright/test";
+import { isDefined, toError } from "@clipboard-health/util-ts";
+import { errors, type Page, type Response } from "@playwright/test";
+
+const MAX_RESPONSE_BODY_LOSS_DIAGNOSTICS = 3;
+const RESPONSE_BODY_METHOD_SIGNATURE = "Protocol error (Network.getResponseBody):";
+const RESPONSE_BODY_LOSS_MESSAGE = "No resource with given identifier found";
 
 export interface WaitForParsedJsonResponseParams<T> {
   isCandidate: (params: { response: Response }) => boolean;
@@ -14,35 +18,69 @@ interface ParsedCandidate<T> {
 
 /**
  * Waits for a matching JSON response and parses its body while Playwright's
- * document-scoped response resource is still readable. Return `undefined`
- * from `parseCandidate` to keep waiting for another candidate response.
+ * document-scoped response resource is still readable. If Chromium discards
+ * only that candidate's response body during the read, the unchanged waiter
+ * continues. Return `undefined` from `parseCandidate` to keep waiting for
+ * another candidate response.
  */
 export async function waitForParsedJsonResponse<T>(
   params: WaitForParsedJsonResponseParams<T>,
 ): Promise<T> {
   const { isCandidate, page, parseCandidate, timeoutMs } = params;
   const parsedCandidates = new WeakMap<Response, ParsedCandidate<T>>();
+  const responseBodyLossDiagnostics = new Set<string>();
+  let responseBodyLossCount = 0;
 
-  const response = await page.waitForResponse(
-    async (candidateResponse) => {
-      if (!isCandidate({ response: candidateResponse })) {
-        return false;
-      }
+  let response: Response;
+  try {
+    response = await page.waitForResponse(
+      async (candidateResponse) => {
+        if (!isCandidate({ response: candidateResponse })) {
+          return false;
+        }
 
-      const parsedCandidate = parseCandidate({
-        body: await candidateResponse.json(),
-        response: candidateResponse,
-      });
-      // JSON null is a valid parsed value; only undefined means "keep waiting".
-      if (parsedCandidate === undefined) {
-        return false;
-      }
+        let body: unknown;
+        try {
+          body = await candidateResponse.json();
+        } catch (error) {
+          if (!isResponseBodyLoss({ error })) {
+            throw error;
+          }
 
-      parsedCandidates.set(candidateResponse, { value: parsedCandidate });
-      return true;
-    },
-    { timeout: timeoutMs },
-  );
+          responseBodyLossCount += 1;
+          if (responseBodyLossDiagnostics.size < MAX_RESPONSE_BODY_LOSS_DIAGNOSTICS) {
+            responseBodyLossDiagnostics.add(
+              formatResponseBodyLossDiagnostic({ response: candidateResponse }),
+            );
+          }
+          return false;
+        }
+
+        const parsedCandidate = parseCandidate({
+          body,
+          response: candidateResponse,
+        });
+        // JSON null is a valid parsed value; only undefined means "keep waiting".
+        if (parsedCandidate === undefined) {
+          return false;
+        }
+
+        parsedCandidates.set(candidateResponse, { value: parsedCandidate });
+        return true;
+      },
+      { timeout: timeoutMs },
+    );
+  } catch (error) {
+    if (!(error instanceof errors.TimeoutError) || responseBodyLossCount === 0) {
+      throw error;
+    }
+
+    throw createResponseBodyLossTimeoutError({
+      diagnostics: [...responseBodyLossDiagnostics],
+      responseBodyLossCount,
+      timeoutError: error,
+    });
+  }
   const parsedResponse = parsedCandidates.get(response);
 
   if (!isDefined(parsedResponse)) {
@@ -52,4 +90,65 @@ export async function waitForParsedJsonResponse<T>(
   }
 
   return parsedResponse.value;
+}
+
+function createResponseBodyLossTimeoutError(params: {
+  diagnostics: string[];
+  responseBodyLossCount: number;
+  timeoutError: Error;
+}): Error {
+  const { diagnostics, responseBodyLossCount, timeoutError } = params;
+  return new Error(
+    `${timeoutError.message}\nResponse body loss diagnostics: count=${responseBodyLossCount}; candidates=${diagnostics.join(
+      ", ",
+    )}`,
+    { cause: timeoutError },
+  );
+}
+
+function formatResponseBodyLossDiagnostic(params: { response: Response }): string {
+  const { response } = params;
+
+  return [
+    `method=${getResponseMethod({ response })}`,
+    `status=${getResponseStatus({ response })}`,
+    `path=${getResponsePathTemplate({ response })}`,
+  ].join(" ");
+}
+
+function getResponseMethod(params: { response: Response }): string {
+  try {
+    const method = params.response.request().method();
+    return /^[A-Za-z]{1,16}$/.test(method) ? method.toUpperCase() : "[redacted]";
+  } catch {
+    return "[unavailable]";
+  }
+}
+
+function getResponsePathTemplate(params: { response: Response }): string {
+  try {
+    return new URL(params.response.url()).pathname === "/" ? "/" : "/[redacted-path]";
+  } catch {
+    return "/[redacted-path]";
+  }
+}
+
+function getResponseStatus(params: { response: Response }): string {
+  try {
+    const status = params.response.status();
+    return Number.isInteger(status) && status >= 100 && status <= 599
+      ? String(status)
+      : "[unavailable]";
+  } catch {
+    return "[unavailable]";
+  }
+}
+
+function isResponseBodyLoss(params: { error: unknown }): boolean {
+  const { error } = params;
+  const message = toError(error).message;
+
+  return (
+    message.includes(RESPONSE_BODY_METHOD_SIGNATURE) && message.includes(RESPONSE_BODY_LOSS_MESSAGE)
+  );
 }

--- a/packages/playwright-toolkit/src/lib/jsonResponse.ts
+++ b/packages/playwright-toolkit/src/lib/jsonResponse.ts
@@ -27,6 +27,7 @@ export async function waitForParsedJsonResponse<T>(
   params: WaitForParsedJsonResponseParams<T>,
 ): Promise<T> {
   const { isCandidate, page, parseCandidate, timeoutMs } = params;
+  const candidateTimeoutErrors = new WeakSet<Error>();
   const parsedCandidates = new WeakMap<Response, ParsedCandidate<T>>();
   const responseBodyLossDiagnostics = new Set<string>();
   let responseBodyLossCount = 0;
@@ -35,43 +36,55 @@ export async function waitForParsedJsonResponse<T>(
   try {
     response = await page.waitForResponse(
       async (candidateResponse) => {
-        if (!isCandidate({ response: candidateResponse })) {
-          return false;
-        }
-
-        let body: unknown;
         try {
-          body = await candidateResponse.json();
+          if (!isCandidate({ response: candidateResponse })) {
+            return false;
+          }
+
+          let body: unknown;
+          try {
+            body = await candidateResponse.json();
+          } catch (error) {
+            if (!isResponseBodyLoss({ error })) {
+              throw error;
+            }
+
+            responseBodyLossCount += 1;
+            if (responseBodyLossDiagnostics.size < MAX_RESPONSE_BODY_LOSS_DIAGNOSTICS) {
+              responseBodyLossDiagnostics.add(
+                formatResponseBodyLossDiagnostic({ response: candidateResponse }),
+              );
+            }
+            return false;
+          }
+
+          const parsedCandidate = parseCandidate({
+            body,
+            response: candidateResponse,
+          });
+          // JSON null is a valid parsed value; only undefined means "keep waiting".
+          if (parsedCandidate === undefined) {
+            return false;
+          }
+
+          parsedCandidates.set(candidateResponse, { value: parsedCandidate });
+          return true;
         } catch (error) {
-          if (!isResponseBodyLoss({ error })) {
-            throw error;
+          if (error instanceof errors.TimeoutError) {
+            candidateTimeoutErrors.add(error);
           }
 
-          responseBodyLossCount += 1;
-          if (responseBodyLossDiagnostics.size < MAX_RESPONSE_BODY_LOSS_DIAGNOSTICS) {
-            responseBodyLossDiagnostics.add(
-              formatResponseBodyLossDiagnostic({ response: candidateResponse }),
-            );
-          }
-          return false;
+          throw error;
         }
-
-        const parsedCandidate = parseCandidate({
-          body,
-          response: candidateResponse,
-        });
-        // JSON null is a valid parsed value; only undefined means "keep waiting".
-        if (parsedCandidate === undefined) {
-          return false;
-        }
-
-        parsedCandidates.set(candidateResponse, { value: parsedCandidate });
-        return true;
       },
       { timeout: timeoutMs },
     );
   } catch (error) {
-    if (!(error instanceof errors.TimeoutError) || responseBodyLossCount === 0) {
+    if (
+      !(error instanceof errors.TimeoutError) ||
+      candidateTimeoutErrors.has(error) ||
+      responseBodyLossCount === 0
+    ) {
       throw error;
     }
 


### PR DESCRIPTION
## Why

Playwright can discard a response body during navigation while a candidate's `response.json()` read is still pending. That candidate-local Chromium failure currently terminates the finite waiter, causing avoidable end-to-end test flakes even when a later equivalent response succeeds. This has no direct customer impact; it improves test reliability and reduces false CI failures.

## Summary

- Classify only the exact `Network.getResponseBody` / `No resource with given identifier found` candidate-body failure and continue within the unchanged waiter.
- Preserve invalid JSON, consumer/parser errors, near matches, closure, cancellation, and candidate-originated timeout errors unchanged.
- Add bounded, redacted loss diagnostics when the outer waiter times out, while retaining the original timeout as `cause`.
- Document the remaining response-lifetime window and add deterministic retry-disabled regressions for recovery, exhaustion, concurrency, fail-closed handling, and redaction.

## Validation

- `npm exec nx test playwright-toolkit -- --testFiles=src/lib/jsonResponse.test.ts --retry=0`
- `npm exec nx test playwright-toolkit`
- `npm exec nx lint playwright-toolkit`
- `npm exec nx build playwright-toolkit`
- `node --run format:check`
- `node --run architecture:check`
- `node --run verify`

## Notes

- Linear: https://linear.app/clipboardhealth/issue/STAFF-2501/89fb76a33eef-classify-candidate-local-playwright-response-body-loss
- The package remains at `1.4.2` in this PR. Main-branch release automation will select and publish the next exact patch version after merge; that published version must then be linked to dependency-blocked STAFF-2502 and STAFF-2503.

Agent session: `codex resume 01a05d6f-30f9-7503-821a-5bd7fe3e8000` · Model: `gpt-5-6-sol`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.5</code></sub>

