### PR TITLE
feat(ai-rules): add design-system and Code Connect guidance (FE-625)

### DIFF
--- a/packages/ai-rules/README.md
+++ b/packages/ai-rules/README.md
@@ -161,6 +161,7 @@ Each rule's "When to Read" text comes from the `description` field in the rule f
 | `frontend/architecture`    | Frontend architecture: feature-based file organization, where business logic lives                                             |
 | `frontend/customHooks`     | Creating React custom hooks: naming, shared state with constate                                                                |
 | `frontend/dataFetching`    | Implementing data fetching, API response fixtures, and error handling: React Query, MSW, Playwright, caching, parsedApi        |
+| `frontend/designSystem`    | Implementing UI from the design system or Figma: prefer shared components, theme lookup, optional Code Connect                 |
 | `frontend/e2eTesting`      | Choosing and writing Playwright E2E tests for registered critical flows                                                        |
 | `frontend/reactComponents` | Building UI components: structure, composition, modals, bottom sheets, interactive elements, a11y, Storybook                   |
 | `frontend/renderScope`     | Adding or restructuring React state, context, hook returns, wall-clock values, hidden queries/subscriptions, or list filtering |

--- a/packages/ai-rules/rules/frontend/designSystem.md
+++ b/packages/ai-rules/rules/frontend/designSystem.md
@@ -1,0 +1,31 @@
+---
+description: "Implementing UI from the design system or Figma: prefer shared components, theme lookup, optional Code Connect"
+---
+
+# Design System
+
+There is no shared design-system package across Clipboard frontend apps. Each repo owns its own
+theme and components. Prefer those over hand-rolled UI.
+
+## Resolve from the repo's code
+
+1. Look up tokens and components in this repo's theme / design-system source (paths in `OVERLAY.md`).
+2. Theme and component code are authoritative. If a `.rules` doc disagrees, trust the code and flag
+   the rule as stale — do not invent or restate token hex/values from memory or docs.
+
+Repo-specific import paths, mapped components, and Code Connect status live in that repo's
+`OVERLAY.md`. Do not assume Workplace and Worker share the same tree or APIs.
+
+## Figma / Code Connect (when present)
+
+Some repos publish Figma Code Connect mappings (`*.figma.ts`); others have none. Do **not** assume
+mappings exist, and do not open `.figma.ts` files unconditionally.
+
+When implementing from a Figma frame:
+
+1. If this repo has Code Connect mappings, check whether the frame (or its library component) is
+   already mapped before inventing an implementation.
+2. When Figma MCP returns a `CodeConnectSnippet`, use its import path and props **verbatim** —
+   do not re-infer variants, sizes, or import paths from the visual design.
+3. If there is no mapping (or the repo has zero Code Connect), implement from the repo's existing
+   design-system components and theme code instead.

--- a/packages/ai-rules/rules/frontend/designSystem.md
+++ b/packages/ai-rules/rules/frontend/designSystem.md
@@ -5,16 +5,14 @@ description: "Implementing UI from the design system or Figma: prefer shared com
 # Design System
 
 There is no shared design-system package across Clipboard frontend apps. Each repo owns its own
-theme and components. Prefer those over hand-rolled UI.
+theme and components. Prefer this repo's existing theme and components over hand-rolled UI; do not
+invent import paths from another app (Workplace and Worker do not share one tree).
 
 ## Resolve from the repo's code
 
-1. Look up tokens and components in this repo's theme / design-system source (paths in `OVERLAY.md`).
+1. Look up tokens and components in this repo's theme / design-system source.
 2. Theme and component code are authoritative. If a `.rules` doc disagrees, trust the code and flag
    the rule as stale — do not invent or restate token hex/values from memory or docs.
-
-Repo-specific import paths, mapped components, and Code Connect status live in that repo's
-`OVERLAY.md`. Do not assume Workplace and Worker share the same tree or APIs.
 
 ## Figma / Code Connect (when present)
 

--- a/packages/ai-rules/rules/frontend/styling.md
+++ b/packages/ai-rules/rules/frontend/styling.md
@@ -11,6 +11,11 @@ description: "Styling components with MUI sx prop: theme tokens, spacing, no CSS
 3. **Type-safe theme access**—use `sx={(theme) => ({...})}`
 4. **Use semantic token names**—`theme.palette.text.primary`, not `common.white`
 
+## Design system
+
+Prefer the repo's design-system components and theme code over hand-rolled UI or remembered token
+values. See `frontend/designSystem` (and this repo's `OVERLAY.md` for paths / Code Connect).
+
 ## Patterns
 
 ```typescript


### PR DESCRIPTION
## Summary

- Adds `frontend/designSystem` shared AI rule so Workplace and Worker both get design-system + optional Figma Code Connect guidance via `@clipboard-health/ai-rules` sync.
- Cross-references the new rule from `frontend/styling.md`.
- Regenerates the README Available Rules table (folder auto-discovery; no registration).

Closes [FE-625](https://linear.app/clipboardhealth/issue/FE-625/add-code-connect-and-design-system-guidance-to-shared-ai-rules).

## Behavior

The rule is written to be true in **both** frontend apps and degrade gracefully:

- Prefer the repo’s existing design-system components over hand-rolling.
- Resolve tokens/components from the repo’s own theme/component code (authoritative); never restate hex/token values in the shared rule.
- **If** the repo has Code Connect mappings, check for a mapping before implementing from a Figma frame — do not unconditionally open `.figma.ts`.
- When Figma MCP returns a `CodeConnectSnippet`, use import + props verbatim.
- Point to each repo’s `OVERLAY.md` for paths and Code Connect status (Worker has zero `.figma.ts`).

## Version / publish

No manual version bump. This monorepo versions `@clipboard-health/ai-rules` via conventional commits on merge to `main` (`scripts/release.ts` + `nx release publish`). A `feat:` commit will bump a new published version automatically after merge (currently `2.49.6` → next minor/patch per nx conventional-commits).

## Follow-up (out of scope)

Do **not** edit `OVERLAY.md` in `cbh-admin-frontend` or `cbh-mobile-app` in this PR. Follow-up: add repo-specific paths / mapped components / “Code Connect does not apply yet” notes in each `OVERLAY.md`, then bump `@clipboard-health/ai-rules` and re-sync.

## Test plan

- [ ] Confirm `packages/ai-rules/rules/frontend/designSystem.md` frontmatter `description` parses.
- [ ] Confirm README frontend table lists `frontend/designSystem`.
- [ ] CI: ai-rules tests / format / lint on the PR.
- [ ] After merge + publish: sync in both frontend apps and verify `AGENTS.md` index includes the new rule; Worker still has no Code Connect instructions that require `.figma.ts`.