### PR TITLE
test: prove Pullfrog private-skill loading

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -61,7 +61,7 @@ jobs:
           gh api \
             --header 'Accept: application/vnd.github.raw+json' \
             --header 'X-GitHub-Api-Version: 2022-11-28' \
-            'repos/ClipboardHealth/skills-private/contents/skills/pullfrog-private-skill-poc/SKILL.md?ref=460a534170c135f164e92e8bb212823bbc3a5385' \
+            'repos/ClipboardHealth/skills-private/contents/skills/pullfrog-private-skill-poc/SKILL.md?ref=56106f858cdf10ea4857d42a0252ac09c92e4c18' \
             > "$skill_dir/SKILL.md"
       - name: Set up Node for the skills installer
         if: ${{ inputs.private_skill_poc }}
@@ -92,8 +92,7 @@ jobs:
           prompt: |
             Use the native skill tool to load `pullfrog-private-skill-poc`.
             Read no SKILL.md file directly. Follow the loaded skill and keep the repository unchanged.
-            Call `set_output` exactly once with the three fields required by the output schema,
-            taking every value from the loaded skill's frontmatter. Then stop.
+            Call `set_output` exactly once with the exact object supplied by the loaded skill. Then stop.
           timeout: 10m
           model: openai/gpt-sol
           effort: low
@@ -129,19 +128,9 @@ jobs:
             ".agents/skills/pullfrog-private-skill-poc/SKILL.md",
             "utf8",
           );
-          const capture = (pattern, label) => {
-            const match = skill.match(pattern);
-            assert(match, `Missing ${label} in installed skill frontmatter`);
-            return match[1];
-          };
-          const expected = {
-            skill_name: capture(/^name:\s*"?([^"\r\n]+?)"?\s*$/m, "name"),
-            source_repository: capture(
-              /^  source_repository:\s*"([^"]+)"\s*$/m,
-              "metadata.source_repository",
-            ),
-            canary: capture(/^  canary:\s*"([^"]+)"\s*$/m, "metadata.canary"),
-          };
+          const proofBlock = skill.match(/```json\s*([\s\S]*?)\s*```/);
+          assert(proofBlock, "Missing JSON proof object in installed skill");
+          const expected = JSON.parse(proofBlock[1]);
           assert.deepEqual(JSON.parse(process.env.PULLFROG_RESULT), expected);
           console.log(`Verified ${expected.skill_name} from ${expected.source_repository}.`);
           NODE

--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+          persist-credentials: false
       - name: Exclude private-skill POC files
         if: ${{ inputs.private_skill_poc }}
         shell: bash

--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -10,6 +10,10 @@ on:
       name:
         type: string
         description: Run name
+      private_skill_poc:
+        type: boolean
+        description: Run the private-skill canary instead of the managed prompt
+        default: false
 
 permissions:
   contents: read
@@ -25,7 +29,125 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+      - name: Exclude private-skill POC files
+        if: ${{ inputs.private_skill_poc }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          exclude_file="$(git rev-parse --git-path info/exclude)"
+          printf '%s\n' \
+            '/.agents/skills/pullfrog-private-skill-poc/' \
+            '/skills-lock.json' >> "$exclude_file"
+      - name: Create private-skills read token
+        if: ${{ inputs.private_skill_poc }}
+        id: private_skills_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: skills-private
+          permission-contents: read
+      - name: Fetch private skill
+        if: ${{ inputs.private_skill_poc }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.private_skills_token.outputs.token }}
+        run: |
+          set -euo pipefail
+          private_skill_source="${RUNNER_TEMP:?}/pullfrog-private-skill-poc"
+          skill_dir="${private_skill_source}/skills/pullfrog-private-skill-poc"
+          mkdir -p "$skill_dir"
+          gh api \
+            --header 'Accept: application/vnd.github.raw+json' \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            'repos/ClipboardHealth/skills-private/contents/skills/pullfrog-private-skill-poc/SKILL.md?ref=460a534170c135f164e92e8bb212823bbc3a5385' \
+            > "$skill_dir/SKILL.md"
+      - name: Set up Node for the skills installer
+        if: ${{ inputs.private_skill_poc }}
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version-file: .nvmrc
+          check-latest: true
+          package-manager-cache: false
+      - name: Install private skill
+        if: ${{ inputs.private_skill_poc }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          private_skill_source="${RUNNER_TEMP:?}/pullfrog-private-skill-poc"
+          npx --yes skills@1.5.23 add "$private_skill_source" \
+            --skill pullfrog-private-skill-poc \
+            --agent opencode \
+            --copy \
+            --yes
+          test -f .agents/skills/pullfrog-private-skill-poc/SKILL.md
+          test -z "$(git status --porcelain)"
+          rm -rf -- "$private_skill_source"
+      - name: Run private-skill POC
+        if: ${{ inputs.private_skill_poc }}
+        id: private_skill_poc
+        uses: pullfrog/pullfrog@0212dedb0f92b8ba4020c17dc30d3eced32415d7 # v0.1.68
+        with:
+          prompt: |
+            Use the native skill tool to load `pullfrog-private-skill-poc`.
+            Read no SKILL.md file directly. Follow the loaded skill and keep the repository unchanged.
+            Call `set_output` exactly once with the three fields required by the output schema,
+            taking every value from the loaded skill's frontmatter. Then stop.
+          timeout: 10m
+          model: openai/gpt-sol
+          effort: low
+          push: disabled
+          shell: disabled
+          output_schema: |
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["skill_name", "source_repository", "canary"],
+              "properties": {
+                "skill_name": { "type": "string" },
+                "source_repository": { "type": "string" },
+                "canary": { "type": "string" }
+              }
+            }
+        env:
+          PULLFROG_AGENT: opencode
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+      - name: Verify private-skill POC
+        if: ${{ inputs.private_skill_poc }}
+        shell: bash
+        env:
+          PULLFROG_RESULT: ${{ steps.private_skill_poc.outputs.result }}
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const assert = require("node:assert/strict");
+          const fs = require("node:fs");
+
+          const skill = fs.readFileSync(
+            ".agents/skills/pullfrog-private-skill-poc/SKILL.md",
+            "utf8",
+          );
+          const capture = (pattern, label) => {
+            const match = skill.match(pattern);
+            assert(match, `Missing ${label} in installed skill frontmatter`);
+            return match[1];
+          };
+          const expected = {
+            skill_name: capture(/^name:\s*"?([^"\r\n]+?)"?\s*$/m, "name"),
+            source_repository: capture(
+              /^  source_repository:\s*"([^"]+)"\s*$/m,
+              "metadata.source_repository",
+            ),
+            canary: capture(/^  canary:\s*"([^"]+)"\s*$/m, "metadata.canary"),
+          };
+          assert.deepEqual(JSON.parse(process.env.PULLFROG_RESULT), expected);
+          console.log(`Verified ${expected.skill_name} from ${expected.source_repository}.`);
+          NODE
+          test -z "$(git status --porcelain)"
       - name: Run agent
+        if: ${{ inputs.private_skill_poc != true }}
         uses: pullfrog/pullfrog@v0
         with:
           prompt: ${{ inputs.prompt }}


### PR DESCRIPTION
## Why

We need to know whether Pullfrog can load a project-scoped skill from `ClipboardHealth/skills-private` through Vercel's `skills` CLI before adopting private review guidance. This is an opt-in CI proof of concept with no direct customer impact; it reduces integration uncertainty and demonstrates a least-privilege credential path without publishing a production skill in this public repository.

## Summary

- Add a `private_skill_poc` manual-dispatch mode while preserving the existing managed Pullfrog route.
- Mint a short-lived GitHub App token scoped to read only `skills-private`, fetch one canary `SKILL.md` at immutable commit `56106f858cdf10ea4857d42a0252ac09c92e4c18`, and install it project-locally with `skills@1.5.23` for OpenCode.
- Ask Pullfrog to invoke the skill through its native skill tool, compare the structured result with the installed skill's proof object, and assert that the checkout remains clean.
- Avoid persisting the primary checkout token while the third-party installer runs.

## Validation

- `node --run verify`
- `actionlint .github/workflows/pullfrog.yml`
- Local pinned Vercel Skills install; source and installed `SKILL.md` SHA-256 matched.
- [Live hardened POC run](https://github.com/ClipboardHealth/core-utils/actions/runs/33979364827): skill selected and installed, native `skill` invocation observed, exact private canary output verified, clean checkout preserved.
- `cb-review` report: ship gate passed, review queue clear at `4ddab798de97912ea04c95d233deaa821846c848`.

## Notes

- Companion private canary PR: https://github.com/ClipboardHealth/skills-private/pull/143
- This intentionally uses a non-sensitive canary because `core-utils` and its Actions logs are public. Production private skills must be treated as instructions, not secret storage.
- Pullfrog's automatic `npm ci` still warns with `EBADENGINE`: its action runtime puts Node 24.19.0/npm 11.17.0 ahead of this repo's Node 24.15.0/npm ~11.12.0. Pullfrog treats that install as non-fatal; the durable fix belongs upstream.
- `actions/create-github-app-token@v3` accepts the existing `GH_APP_ID` secret but warns that `app-id` is deprecated. Moving to `client-id` requires a verified organization client-ID secret.
- Commits are unsigned because the configured 1Password signing program was unavailable in this execution environment.

<sub>🤖 <code>cb-ship:created v1 skill@1.0.7</code></sub>
