### PR TITLE
feat: raise Renovate minimum release age to 7 days and boost coverage (SEC-2569)

### DIFF
--- a/default.json
+++ b/default.json
@@ -20,6 +20,13 @@
       "token": "{{ secrets.COM_GITHUB_TOKEN }}"
     }
   ],
+  "logLevelRemap": [
+    {
+      "description": "Demote the timestamp-optional notice from WARN to INFO. Mend renders every WARN in a red 'Repository problems' banner on the dependency dashboard, and this one fires on every run for any repo using a registry that does not publish release timestamps (public.ecr.aws, private ECR, GHCR, Quay) -- which is most of ours. It reports expected behaviour, not a failure: the update was raised rather than frozen. Left at WARN it is a permanent false alarm that trains engineers to ignore the banner.",
+      "matchMessage": "/Some .+ did not have a releaseTimestamp, but as we're running with minimumReleaseAgeBehaviour=timestamp-optional, proceeding/",
+      "newLogLevel": "info"
+    }
+  ],
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,

--- a/default.json
+++ b/default.json
@@ -25,6 +25,11 @@
       "description": "Demote the timestamp-optional notice from WARN to INFO. Mend renders every WARN in a red 'Repository problems' banner on the dependency dashboard, and this one fires on every run for any repo using a registry that does not publish release timestamps (public.ecr.aws, private ECR, GHCR, Quay) -- which is most of ours. It reports expected behaviour, not a failure: the update was raised rather than frozen. Left at WARN it is a permanent false alarm that trains engineers to ignore the banner.",
       "matchMessage": "/Some .+ did not have a releaseTimestamp, but as we're running with minimumReleaseAgeBehaviour=timestamp-optional, proceeding/",
       "newLogLevel": "info"
+    },
+    {
+      "description": "Demote the npm --before fallback notice from WARN to INFO, for the same banner reason. Setting minimumReleaseAge makes Renovate pass --before to npm during lock file generation; every lockfile we already have contains packages published inside the last 7 days, so npm returns ETARGET and Renovate retries without the flag. That is handled and non-fatal -- the lockfile is still written -- and it self-heals once lockFileMaintenance regenerates the file. Without this, every npm repo shows a red banner for the first week. The same text is also pushed to artifactNotices, so it still appears in the PR body where it is actually actionable.",
+      "matchMessage": "/npm `--before` could not be enforced because existing locked packages were published after the/",
+      "newLogLevel": "info"
     }
   ],
   "lockFileMaintenance": {

--- a/default.json
+++ b/default.json
@@ -85,14 +85,6 @@
       "commitMessageTopic": "{{depName}}"
     },
     {
-      "description": "Do not require Minimum Release Age for container images. Only Docker Hub returns release timestamps; public.ecr.aws (our default registry per .rules/common/containerRegistry.md), private *.dkr.ecr.*.amazonaws.com, GHCR and Quay return none. minimumReleaseAgeBehaviour=timestamp-optional already prevents these from freezing, but stating it here keeps the gap explicit rather than implicit, and stops image updates being silently held if that behaviour is ever changed back.",
-      "matchDatasources": ["docker"],
-      "minimumReleaseAge": null,
-      "prBodyNotes": [
-        "⚠️ Container registries other than Docker Hub do not publish release timestamps, so this image update was raised without the usual 7-day check. Validate the release age manually before merging."
-      ]
-    },
-    {
       "description": "Re-assert 7 days for npm. config:best-practices pulls in security:minimumReleaseAgeNpm, whose packageRule pins npm to 3 days; preset rules resolve before ours and override the top-level minimumReleaseAge, so npm needs this to reach 7 days.",
       "matchDatasources": ["npm"],
       "minimumReleaseAge": "7 days"

--- a/default.json
+++ b/default.json
@@ -25,6 +25,8 @@
     "automerge": true,
     "automergeType": "branch"
   },
+  "minimumReleaseAge": "7 days",
+  "minimumReleaseAgeBehaviour": "timestamp-optional",
   "npmToken": "{{ secrets.NPM_TOKEN }}",
   "packageRules": [
     {
@@ -81,6 +83,42 @@
       "matchUpdateTypes": ["security"],
       "commitMessagePrefix": "fix(deps): ",
       "commitMessageTopic": "{{depName}}"
+    },
+    {
+      "description": "Do not require Minimum Release Age for container images. Only Docker Hub returns release timestamps; public.ecr.aws (our default registry per .rules/common/containerRegistry.md), private *.dkr.ecr.*.amazonaws.com, GHCR and Quay return none. minimumReleaseAgeBehaviour=timestamp-optional already prevents these from freezing, but stating it here keeps the gap explicit rather than implicit, and stops image updates being silently held if that behaviour is ever changed back.",
+      "matchDatasources": ["docker"],
+      "minimumReleaseAge": null,
+      "prBodyNotes": [
+        "⚠️ Container registries other than Docker Hub do not publish release timestamps, so this image update was raised without the usual 7-day check. Validate the release age manually before merging."
+      ]
+    },
+    {
+      "description": "Re-assert 7 days for npm. config:best-practices pulls in security:minimumReleaseAgeNpm, whose packageRule pins npm to 3 days; preset rules resolve before ours and override the top-level minimumReleaseAge, so npm needs this to reach 7 days.",
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "Do not require Minimum Release Age for update types Renovate cannot age. Renovate does not wire a release timestamp into these, so under the default minimumReleaseAgeBehaviour=timestamp-required they would otherwise be held back indefinitely.",
+      "matchUpdateTypes": [
+        "bump",
+        "lockFileMaintenance",
+        "lockfileUpdate",
+        "pin",
+        "replacement",
+        "rollback"
+      ],
+      "minimumReleaseAge": null,
+      "prBodyNotes": [
+        "⚠️ Renovate cannot enforce Minimum Release Age for this update type, so this PR was raised without the usual 7-day check. Validate the release age manually before merging."
+      ]
+    },
+    {
+      "description": "Do not require Minimum Release Age for digest updates. Renovate ages a digest against its matched version's timestamp, which is unavailable for registries that publish none (GHCR, Quay, ECR) and for unversioned refs such as `latest` or a branch-pinned GitHub Action, where no version exists to match. Left gated, those updates are held indefinitely. Deliberately not scoped to a datasource: the unversioned-ref case applies to github-tags too, and config:best-practices pins GitHub Action digests via helpers:pinGitHubActionDigests.",
+      "matchUpdateTypes": ["digest", "pinDigest"],
+      "minimumReleaseAge": null,
+      "prBodyNotes": [
+        "⚠️ Digest updates are not age-checked, so this PR was raised without the usual 7-day check. Validate the release age manually before merging."
+      ]
     }
   ],
   "prBodyTemplate": "{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{controls}}}",


### PR DESCRIPTION
## Why

Our only supply-chain cooldown today is 3 days, npm only and it was never configured here. It comes from `config:best-practices` → `security:minimumReleaseAgeNpm`, which upstream scopes to npm. 

Go, PyPI, Docker, and Terraform have no cooldown at all, including `terraform-provider-jamfpro`, the Go repo that prompted this.

Upstream calls that npm-only scope incremental rollout, not a deliberate exclusion ([#37967](https://github.com/renovatebot/renovate/pull/37967), [#42610](https://github.com/renovatebot/renovate/discussions/42610)), so there is no reason to inherit it.

No customer impact. Reduces supply-chain risk across the 28 repos extending this preset.

## What changed

- Top-level `minimumReleaseAge: "7 days"`
  - Covers all 52 datasources that report release timestamps, not the three upstream has presets for.
- `minimumReleaseAgeBehaviour: "timestamp-optional"`
  - Since Renovate 42 the default is `timestamp-required`, under which a missing timestamp holds the update indefinitely. 
  - With `internalChecksFilter: strict` that means no branch, no PR, just a dashboard entry. 
  - Failing open with a warning is safer: an image that silently stops updating keeps its known CVEs.

Four supporting rules:

| Rule | Why |
| --- | --- |
| npm re-asserted to 7 days | Preset rules resolve **before** ours and override the top-level value. Without this npm stays at 3 days. |
| 6 un-ageable update types exempted | `bump`, `lockFileMaintenance`, `lockfileUpdate`, `pin`, `replacement`, `rollback` — Renovate wires no timestamp into these. Declared datasource-agnostically; upstream's are npm/crate/pypi-scoped. |
| `pinDigest` exempted (**not** `digest`) | A `pinDigest` ages against the newest matching version, so a fast-releasing ref may never clear the gate and stays perpetually unpinned — less safe than pinning slightly stale. Plain `digest` keeps the 7-day gate: Docker Hub ages it against `tag_last_pushed`, so a tag re-push restarts the delay. Timestamp-less digests proceed via `timestamp-optional`. Narrowed after CodeRabbit and pullfrog both flagged the original `digest` exemption. |
| `logLevelRemap` → INFO (×2) | Mend renders every WARN in a red "Repository problems" banner. The `timestamp-optional` notice fires every run for ECR/GHCR/Quay repos; the npm `--before` fallback notice fires whenever a lockfile regeneration meets an unlocked fresh pin. Both report expected behaviour. Left at WARN they are permanent false alarms that teach people to ignore the banner. |

Each carve-out carries a `prBodyNotes` warning, since these rules automerge and an un-aged PR would otherwise look identical to an aged one.

## Coverage

**Enabled** = Renovate raises PRs at all. **Gated** = the 7-day cooldown applies. This change only touches gating.

| Datasource | Enabled old | Enabled new | Gated old | Gated new | Timestamps | Upstream default | Carve-out |
| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
| npm | ✅ | ✅ | ✅ 3d | ✅ 7d | ✅ | ✅ | ✅ |
| docker — Docker Hub (version) | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ |
| docker — Docker Hub (digest re-push) | ✅ | ✅ | ❌ | ✅ ³ | ✅ | ❌ | ❌ |
| go | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ |
| terraform-provider | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ |
| terraform-module | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ |
| github-tags (versioned) | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ |
| github-releases | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ |
| maven | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ |
| rubygems | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ |
| nuget | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ |
| crate | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ ¹ | ❌ |
| pypi | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ ¹ | ❌ |
| docker — ECR/GHCR/Quay | ✅ | ✅ | ❌ | ❌ ² | ❌ | ❌ | ❌ ² |
| digest — no timestamp / unversioned | ✅ | ✅ | ❌ | ❌ ² | ❌ ³ | ❌ | ❌ ² |
| pinDigest | ✅ | ✅ | ❌ | ❌ | ❌ ³ | ❌ | ✅ |
| 6 un-ageable update types | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
| 30 datasources w/o timestamps ⁴ | ✅ | ✅ | ❌ | ❌ ² | ❌ | ❌ | ❌ ² |
| Disabled by pre-existing rules ⁵ | ❌ | ❌ | — | — | — | ❌ | — |

**The Enabled columns are identical.** This sets a cooldown; it enables nothing. `minimumReleaseAge` is a string option (`default: null`) with no enable semantics, and `enabledManagers` is unset. Go/Docker/Terraform PRs were already being raised — they just arrived instantly and will now arrive 7 days later.

¹ `best-practices` extends only `security:minimumReleaseAgeNpm`, so we have no crate/pypi cooldown today either.
² Configured at 7 days but no timestamp is returned, so `timestamp-optional` raises with a warning rather than freezing. One setting covers every such case.
³ A digest ages against the matched version's timestamp — on Docker Hub, `tag_last_pushed`, so re-pushes are gated. Unversioned refs have no version to match. `pinDigest` is exempt so fast-releasing refs don't stay perpetually unpinned.
⁴ 30 of 82 datasources declare no `releaseTimestampSupport` (`git-refs`, `git-tags`, `github-runners`, …). None in our repos.
⁵ Pre-existing, unchanged: `nx`/`@nx/*`, `node`/`npm`, `eslint*`/`@typescript-eslint/*`. Note `["node","npm"]` also matches the **Docker** `node` image.

## Validation

Live Renovate runs (44.71.0, Mend app) on [cb-sec-dummy](https://github.com/ClipboardHealth/cb-sec-dummy) extending this preset from the PR branch — no merge needed. [Dashboard](https://github.com/ClipboardHealth/cb-sec-dummy/issues/3). **13/13 confirmed.**

| Check | Result |
| --- | --- |
| npm inside 7d | `@types/node` v26.5.1 (2d), `vitest` v5 (6d) → **held** |
| npm outside 7d | `@types/node` v26.4.1 (7d), `vitest` 4.1.11 (22d), `axios` (14d) → raised |
| Pending clears with time | `vitest` v5 held at 6d, released at 12d |
| Docker Hub | `redis` 8.4.6 / 8.10.1 → gated |
| ECR (no timestamps) | Node v22.23.2 / v24 → raised, not frozen |
| go | `testify` v1.12.1 → gated then raised |
| terraform-provider | `null` v3.2.4 / v3.3.1 → gated |
| Pinned action digest | `actions/checkout` v4.1.7 / v4.4.0 / v7 → raised |
| Unversioned `@main` | detected, no pending entry |
| `prBodyNotes` on carve-outs | present on pinDigest PR (#12), absent on normal updates (#17) |
| Branch automerge, zero CI checks | `renovate/stability-days` alone resolves **success** — no stall |
| `--before` fallback | fired on [cb-sec-dummy#22](https://github.com/ClipboardHealth/cb-sec-dummy/pull/22) via an unlocked fresh pin: `artifactNotices` PR comment present, retry resolved the dep, **no dashboard banner** — second remap confirmed |
| Banner after both `logLevelRemap`s | none; gate unaffected. First remap also observed at log level in a local `platform=local` run (message emitted as INFO) |

Two npm packages independently bracket the boundary, which is what proves the npm rule — without it both would have been raised at 3 days.

Also: `renovate-config-validator` @44.73.0, `node --run verify` (8/8). Both `logLevelRemap` regexes were checked against the real emitted strings — the source emits "upgrade(s)", the dashboard renders "release(s)"; the pattern spans both.

Claims were read from Renovate source at v44.71.0/44.73.0 (`security.preset.ts`, `config.preset.ts`, `package-rules/index.ts`, `minimum-release-age.ts`, `datasource/docker/index.ts`, `npm/post-update/npm.ts`, `options/index.ts`, `logger/bunyan.ts`) and the registry table in `docs/usage/key-concepts/minimum-release-age.md`.

## Notes

- [SEC-2569](https://linear.app/clipboardhealth/issue/SEC-2569) · [Slack thread](https://clipboardhealth.slack.com/archives/C0BTSS3SFC7/p1788964094446019?thread_ts=1788957444.002719&cid=C0BTSS3SFC7)
- **Blast radius:** 28 repos. None override `minimumReleaseAge`, so all inherit on merge.
- **Side effect:** minor/patch/digest and devDependency automerges delayed 4 extra days. Intended per the thread; per-package exceptions are possible, as `schema-packages.json` already does with `"0 days"`.
- **Reviewer focus:** the npm `packageRule` is load-bearing. Deleting it silently reverts npm to 3 days while the rest of the config still says 7.
- **Known gap (pre-existing, same as upstream):** lock file maintenance runs with `minimumReleaseAge: null`, so it regenerates without `--before` and will pull transitive deps regardless of age — observed on [cb-sec-dummy#20](https://github.com/ClipboardHealth/cb-sec-dummy/pull/20), which pulled a 5-day-old `vite`. npm's own `.npmrc` `min-release-age=7` closes this per repo; worth a follow-up ticket.
- **Coverage gap (out of scope):** `cbh-mobile-app` and `cbh-admin-frontend` extend `:schema-packages` (`"0 days"`), not this preset, so they get no cooldown from this change. Follow-up ticket.
- Security fixes unaffected — `vulnerabilityAlerts` defaults to `minimumReleaseAge: null`.
- Watch upstream [#42610](https://github.com/renovatebot/renovate/discussions/42610); if `best-practices` broadens coverage, parts of this become redundant.

Agent session: `claude --resume 028c8513-dd9a-4b77-91ad-ed3b7ed0b94b`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.1</code></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)