### PR TITLE
fix: diagnose Mailpit extraction misses (STAFF-2526)

### DIFF
--- a/packages/playwright-toolkit/README.md
+++ b/packages/playwright-toolkit/README.md
@@ -279,6 +279,18 @@ await page.getByLabel("Verification Code").fill(code.value);
 
 The pollers search newest-first, tolerate incomplete dates in search results, fetch at most three candidates per probe, and retry Mailpit network errors, `404`, `408`, `429`, and `5xx`. They return both the extracted value and source message ID.
 
+Timeout errors and successful results include polling diagnostics. These distinguish transient
+search errors from message-fetch errors and count skips of cached extraction misses. The first
+three extraction misses across the entire wait carry only a SHA-256 message-ID hash, content
+channel, combined Text/HTML character-count bucket, candidate age at fetch, and OTP shape.
+Shape classification observes the documented four-plus-four OTP format; it does not select a
+value or change the parser. `other` means the built-in OTP parser recognized a value that the
+caller’s extractor did not select. Samples contain no raw message fields or extracted secrets.
+The error retains this evidence for Playwright reports without a separate logging hook.
+
+Misses remain cached by message ID, and the default wait remains 60 seconds. These diagnostics
+help classify a future failure; they do not establish why a historical message failed extraction.
+
 ## Cognito OTP and login diagnostics
 
 `fillOtpAndWaitForCognitoRedirect` monitors `RespondToAuthChallenge` requests for `SMS_OTP` and `EMAIL_OTP` while it waits for the expected redirect.

--- a/packages/playwright-toolkit/src/lib/mailpit.test.ts
+++ b/packages/playwright-toolkit/src/lib/mailpit.test.ts
@@ -4,6 +4,7 @@ import {
   extractMagicLinkFromMailpitMessage,
   fetchEmailOtpCodeFromMailpit,
   fetchMagicLinkFromMailpit,
+  fetchMailpitValue,
   type MailpitClient,
   type MailpitMessage,
   type MailpitMessageSummary,
@@ -11,6 +12,54 @@ import {
 } from "../index";
 
 describe("Mailpit polling", () => {
+  it("diagnoses a cached extraction miss without refetching or extending the default deadline", async () => {
+    let currentTimeMs = Date.parse("2026-07-16T12:00:01.000Z");
+    const messageId = "private-mailpit-id";
+    const mockClient: MailpitClient = {
+      searchMessages: vi.fn<MailpitClient["searchMessages"]>(async () => [
+        createSearchSummary({ id: messageId }),
+      ]),
+      getMessage: vi.fn<MailpitClient["getMessage"]>(async () =>
+        createMessage({ id: messageId, text: "private-body 8102-7033" }),
+      ),
+    };
+
+    const actualError = await captureError({
+      promise: fetchEmailOtpCodeFromMailpit({
+        client: mockClient,
+        email: "private-user@example.test",
+        nowImplementation: () => currentTimeMs,
+        sleepImplementation: async ({ durationMs }) => {
+          currentTimeMs += durationMs;
+        },
+      }),
+    });
+    const actualErrorChain = getErrorChainMessage({ error: actualError });
+
+    expect(actualError).toMatchObject({ attempts: 60, elapsedMs: 60_000, reason: "timeout" });
+    expect(mockClient.searchMessages).toHaveBeenCalledTimes(60);
+    expect(mockClient.getMessage).toHaveBeenCalledTimes(1);
+    expect(actualError.message).toContain("cachedExtractionMissCount=59");
+    expect(actualError.message).toContain(
+      '"otpMissShape":"eight-digits-with-unsupported-separator"',
+    );
+    expect(actualError.message).toContain('"contentChannel":"text"');
+    expect(actualError.message).toContain('"contentSizeBucket":"1-256"');
+    expect(actualError.message).toContain('"candidateAgeAtFetchBucket":"under-5s"');
+    expect(actualError.message).toMatch(/"messageIdHash":"[a-f0-9]{64}"/);
+    for (const secret of [
+      messageId,
+      "private-user@example.test",
+      "private-body",
+      "8102-7033",
+      "81027033",
+      "noreply@example.test",
+      "Sign in",
+    ]) {
+      expect(actualErrorChain).not.toContain(secret);
+    }
+  });
+
   it("returns the newest non-excluded magic link", async () => {
     const messages = [
       createSearchSummary({ id: "new", created: "2026-07-16T12:00:00.000Z" }),
@@ -48,6 +97,10 @@ describe("Mailpit polling", () => {
         transientRequestErrorCount: 0,
         transientRequestErrorStatuses: [],
         newestCandidateTimestamp: "2026-07-16T12:00:00.000Z",
+        cachedExtractionMissCount: 0,
+        transientSearchErrorCount: 0,
+        transientMessageFetchErrorCount: 0,
+        extractionMissSamples: [],
       },
     });
   });
@@ -86,8 +139,240 @@ describe("Mailpit polling", () => {
         transientRequestErrorCount: 0,
         transientRequestErrorStatuses: [],
         newestCandidateTimestamp: "2026-07-16T12:00:00.000Z",
+        cachedExtractionMissCount: 0,
+        transientSearchErrorCount: 0,
+        transientMessageFetchErrorCount: 0,
+        extractionMissSamples: [],
       },
     });
+  });
+
+  it.each([
+    {
+      text: "",
+      html: "",
+      channel: "none",
+      size: "empty",
+      shape: "empty-content",
+      created: undefined,
+      age: "unavailable",
+    },
+    {
+      text: "No code",
+      html: "<p>Private content</p>",
+      channel: "both",
+      size: "1-256",
+      shape: "no-eight-digit-sequence",
+      created: "2026-07-16T12:00:02.000Z",
+      age: "future",
+    },
+    {
+      text: "x".repeat(257),
+      html: "",
+      channel: "text",
+      size: "257-4096",
+      shape: "no-eight-digit-sequence",
+      created: "2026-07-16T11:59:50.000Z",
+      age: "5-30s",
+    },
+    {
+      text: "",
+      html: `<p>${"x".repeat(4097)}8102-7033</p>`,
+      channel: "html",
+      size: "4097+",
+      shape: "eight-digits-with-unsupported-separator",
+      created: "2026-07-16T11:59:00.000Z",
+      age: "30s+",
+    },
+    {
+      text: "",
+      html: "<script>8102-7033</script><style>8102-7033</style><p>No code</p>",
+      channel: "html",
+      size: "1-256",
+      shape: "no-eight-digit-sequence",
+      created: "2026-07-16T12:00:00.000Z",
+      age: "under-5s",
+    },
+  ])(
+    "reports bounded miss shape $shape for $channel content",
+    async ({ text, html, channel, size, shape, created, age }) => {
+      const mockClient: MailpitClient = {
+        searchMessages: vi.fn<MailpitClient["searchMessages"]>(async () => [
+          { ...createSearchSummary({ id: "private-id" }), Created: created },
+        ]),
+        getMessage: vi.fn<MailpitClient["getMessage"]>(async () =>
+          createMessage({ id: "private-id", text, html }),
+        ),
+      };
+
+      const actualError = await captureError({
+        promise: fetchEmailOtpCodeFromMailpit({
+          client: mockClient,
+          email: "user@example.test",
+          ...createImmediateTimeout(),
+        }),
+      });
+
+      expect(actualError.message).toContain(`"contentChannel":"${channel}"`);
+      expect(actualError.message).toContain(`"contentSizeBucket":"${size}"`);
+      expect(actualError.message).toContain(`"otpMissShape":"${shape}"`);
+      expect(actualError.message).toContain(`"candidateAgeAtFetchBucket":"${age}"`);
+      expect(actualError.message).not.toContain("private-id");
+      expect(actualError.message).not.toContain("Private content");
+      expect(actualError.message).not.toContain("8102");
+      expect(actualError.message.length).toBeLessThan(1300);
+    },
+  );
+
+  it.each([
+    { text: "Code 81027033", html: "" },
+    { text: "Code 8102 7033", html: "" },
+    { text: "Code 8102\n\t7033", html: "" },
+    { text: "", html: "<div>8102<span>7033</span></div>" },
+  ])("preserves the supported OTP parser for $text $html", async ({ text, html }) => {
+    const mockClient: MailpitClient = {
+      searchMessages: vi.fn<MailpitClient["searchMessages"]>(async () => [
+        createSearchSummary({ id: "otp" }),
+      ]),
+      getMessage: vi.fn<MailpitClient["getMessage"]>(async () =>
+        createMessage({ id: "otp", text, html }),
+      ),
+    };
+
+    const actual = await fetchEmailOtpCodeFromMailpit({
+      client: mockClient,
+      email: "user@example.test",
+    });
+
+    expect(actual.value).toBe("81027033");
+    expect(actual.pollingDiagnostics.extractionMissSamples).toEqual([]);
+    expect(mockClient.getMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports other when a custom extractor misses a supported OTP", async () => {
+    const mockExtractValue = vi.fn<() => undefined>();
+    const mockClient: MailpitClient = {
+      searchMessages: vi.fn<MailpitClient["searchMessages"]>(async () => [
+        createSearchSummary({ id: "otp" }),
+      ]),
+      getMessage: vi.fn<MailpitClient["getMessage"]>(async () =>
+        createMessage({ id: "otp", text: "81027033" }),
+      ),
+    };
+
+    const actualError = await captureError({
+      promise: fetchMailpitValue({
+        client: mockClient,
+        email: "user@example.test",
+        extractValue: mockExtractValue,
+        valueLabel: "custom OTP",
+        ...createImmediateTimeout(),
+      }),
+    });
+
+    expect(actualError.message).toContain('"otpMissShape":"other"');
+    expect(actualError.message).not.toContain("81027033");
+    expect(mockExtractValue).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    {
+      phase: "search",
+      responseSequence: [{ body: "private response body", status: 404 }],
+      searchErrors: 3,
+      fetchErrors: 0,
+    },
+    {
+      phase: "message-fetch",
+      responseSequence: [
+        {
+          body: JSON.stringify({ messages: [createSearchSummary({ id: "private-id" })] }),
+          status: 200,
+        },
+        { body: "private response body", status: 404 },
+      ],
+      searchErrors: 0,
+      fetchErrors: 3,
+    },
+  ])(
+    "preserves 404 retries and identifies the $phase phase",
+    async ({ responseSequence, searchErrors, fetchErrors }) => {
+      let currentTimeMs = 0;
+      const mockFetch = vi.fn<typeof fetch>();
+      for (const { body, status } of Array.from({ length: 3 }, () => responseSequence).flat()) {
+        mockFetch.mockResolvedValueOnce(new Response(body, { status }));
+      }
+      const client = createMailpitClient({
+        password: "private-password",
+        fetchImplementation: mockFetch,
+      });
+
+      const actualError = await captureError({
+        promise: fetchEmailOtpCodeFromMailpit({
+          client,
+          email: "private-user@example.test",
+          timeoutMs: 300,
+          pollIntervalMs: 100,
+          nowImplementation: () => currentTimeMs,
+          sleepImplementation: async ({ durationMs }) => {
+            currentTimeMs += durationMs;
+          },
+        }),
+      });
+
+      expect(actualError).toMatchObject({ attempts: 3, elapsedMs: 300, reason: "timeout" });
+      expect(mockFetch).toHaveBeenCalledTimes(responseSequence.length * 3);
+      expect(actualError.message).toContain(
+        "transientRequestErrorCount=3, transientRequestErrorStatuses=[404]",
+      );
+      expect(actualError.message).toContain(`transientSearchErrorCount=${searchErrors}`);
+      expect(actualError.message).toContain(`transientMessageFetchErrorCount=${fetchErrors}`);
+      expect(actualError.message).toContain("extractionMissSamples=[]");
+      expect(getErrorChainMessage({ error: actualError })).not.toMatch(
+        /private-|private response body/,
+      );
+    },
+  );
+
+  it("caps miss samples across polls while preserving three candidates per probe", async () => {
+    let currentTimeMs = 0;
+    const mockClient: MailpitClient = {
+      searchMessages: vi
+        .fn<MailpitClient["searchMessages"]>()
+        .mockResolvedValueOnce(
+          ["one", "two", "three", "never-fetched"].map((id) => createSearchSummary({ id })),
+        )
+        .mockResolvedValueOnce(["four", "five", "ready"].map((id) => createSearchSummary({ id }))),
+      getMessage: vi
+        .fn<MailpitClient["getMessage"]>()
+        .mockResolvedValueOnce(createMessage({ id: "one", text: "private-body" }))
+        .mockResolvedValueOnce(createMessage({ id: "two", text: "private-body" }))
+        .mockResolvedValueOnce(createMessage({ id: "three", text: "private-body" }))
+        .mockResolvedValueOnce(createMessage({ id: "four", text: "private-body" }))
+        .mockResolvedValueOnce(createMessage({ id: "five", text: "private-body" }))
+        .mockResolvedValueOnce(createMessage({ id: "ready", text: "81027033" })),
+    };
+
+    const actual = await fetchEmailOtpCodeFromMailpit({
+      client: mockClient,
+      email: "user@example.test",
+      nowImplementation: () => currentTimeMs,
+      sleepImplementation: async ({ durationMs }) => {
+        currentTimeMs += durationMs;
+      },
+    });
+
+    expect(actual.value).toBe("81027033");
+    expect(actual.pollingDiagnostics.extractionMissCount).toBe(5);
+    expect(actual.pollingDiagnostics.extractionMissSamples).toHaveLength(3);
+    expect(
+      new Set(
+        actual.pollingDiagnostics.extractionMissSamples.map(({ messageIdHash }) => messageIdHash),
+      ).size,
+    ).toBe(3);
+    expect(JSON.stringify(actual.pollingDiagnostics)).not.toMatch(/private-body|81027033/);
+    expect(mockClient.getMessage).toHaveBeenCalledTimes(6);
+    expect(mockClient.getMessage).not.toHaveBeenCalledWith({ messageId: "never-fetched" });
   });
 
   it("uses authenticated Mailpit HTTP search and message endpoints", async () => {
@@ -528,6 +813,38 @@ describe("Mailpit polling", () => {
     );
     expect(actualErrorChain).not.toContain(email);
     expect(actualErrorChain).not.toContain(secret);
+  });
+
+  it("keeps excluded values cached without counting them as extraction misses", async () => {
+    let currentTimeMs = 0;
+    const mockClient: MailpitClient = {
+      searchMessages: vi.fn<MailpitClient["searchMessages"]>(async () => [
+        createSearchSummary({ id: "excluded" }),
+      ]),
+      getMessage: vi.fn<MailpitClient["getMessage"]>(async () =>
+        createMessage({ id: "excluded", text: "81027033" }),
+      ),
+    };
+
+    const actualError = await captureError({
+      promise: fetchEmailOtpCodeFromMailpit({
+        client: mockClient,
+        email: "user@example.test",
+        excludeCodes: ["81027033"],
+        timeoutMs: 300,
+        pollIntervalMs: 100,
+        nowImplementation: () => currentTimeMs,
+        sleepImplementation: async ({ durationMs }) => {
+          currentTimeMs += durationMs;
+        },
+      }),
+    });
+
+    expect(mockClient.searchMessages).toHaveBeenCalledTimes(3);
+    expect(mockClient.getMessage).toHaveBeenCalledTimes(1);
+    expect(actualError.message).toContain("excludedValueCount=1");
+    expect(actualError.message).toContain("cachedExtractionMissCount=0");
+    expect(actualError.message).toContain("extractionMissSamples=[]");
   });
 });
 

--- a/packages/playwright-toolkit/src/lib/mailpit.ts
+++ b/packages/playwright-toolkit/src/lib/mailpit.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { isNil, isRecord, toErrorMessage as getErrorMessage } from "@clipboard-health/util-ts";
 
 import { RetryError, type RetrySuccess, runWithRetry, type RunWithRetryParams } from "./retry";
@@ -55,6 +57,20 @@ export interface MailpitPollingDiagnostics {
   transientRequestErrorCount: number;
   transientRequestErrorStatuses: string[];
   newestCandidateTimestamp: string | undefined;
+  cachedExtractionMissCount: number;
+  transientSearchErrorCount: number;
+  transientMessageFetchErrorCount: number;
+  extractionMissSamples: Array<{
+    messageIdHash: string;
+    contentChannel: "text" | "html" | "both" | "none";
+    contentSizeBucket: "empty" | "1-256" | "257-4096" | "4097+";
+    otpMissShape:
+      | "empty-content"
+      | "no-eight-digit-sequence"
+      | "eight-digits-with-unsupported-separator"
+      | "other";
+    candidateAgeAtFetchBucket: "unavailable" | "future" | "under-5s" | "5-30s" | "30s+";
+  }>;
 }
 
 export interface FetchMailpitValueResult {
@@ -108,6 +124,10 @@ interface MailpitPollingSnapshot {
   transientRequestErrorCount: number;
   transientRequestErrorStatuses: Set<string>;
   newestCandidateTimestampMs: number | undefined;
+  cachedExtractionMissCount: number;
+  transientSearchErrorCount: number;
+  transientMessageFetchErrorCount: number;
+  extractionMissSamples: MailpitPollingDiagnostics["extractionMissSamples"];
 }
 
 export class MailpitRequestError extends Error {
@@ -199,7 +219,7 @@ export async function fetchMailpitValue(
           throw error;
         }
 
-        recordTransientRequestError({ error, pollingSnapshot });
+        recordTransientRequestError({ error, pollingSnapshot, phase: "search" });
         throw createMailpitValueNotFoundError({
           nowMs: nowImplementation(),
           pollingSnapshot,
@@ -228,6 +248,9 @@ export async function fetchMailpitValue(
       for (const message of candidates) {
         if (valuesByMessageId.has(message.ID)) {
           const cachedValue = valuesByMessageId.get(message.ID);
+          if (cachedValue === undefined) {
+            pollingSnapshot.cachedExtractionMissCount += 1;
+          }
 
           if (cachedValue !== undefined && !excludedValues.has(cachedValue)) {
             return createFetchMailpitValueResult({
@@ -251,6 +274,12 @@ export async function fetchMailpitValue(
 
           if (value === undefined) {
             pollingSnapshot.extractionMissCount += 1;
+            recordExtractionMiss({
+              message: fullMessage,
+              messageSummary: message,
+              pollingSnapshot,
+              nowMs: nowImplementation(),
+            });
           } else if (excludedValues.has(value)) {
             pollingSnapshot.excludedValueCount += 1;
           } else {
@@ -261,7 +290,7 @@ export async function fetchMailpitValue(
             throw error;
           }
 
-          recordTransientRequestError({ error, pollingSnapshot });
+          recordTransientRequestError({ error, pollingSnapshot, phase: "message-fetch" });
         }
       }
 
@@ -516,6 +545,10 @@ function createMailpitPollingSnapshot(): MailpitPollingSnapshot {
     transientRequestErrorCount: 0,
     transientRequestErrorStatuses: new Set(),
     newestCandidateTimestampMs: undefined,
+    cachedExtractionMissCount: 0,
+    transientSearchErrorCount: 0,
+    transientMessageFetchErrorCount: 0,
+    extractionMissSamples: [],
   };
 }
 
@@ -546,6 +579,10 @@ function createFetchMailpitValueResult(params: {
         newestCandidateTimestampMs === undefined
           ? undefined
           : new Date(newestCandidateTimestampMs).toISOString(),
+      cachedExtractionMissCount: params.pollingSnapshot.cachedExtractionMissCount,
+      transientSearchErrorCount: params.pollingSnapshot.transientSearchErrorCount,
+      transientMessageFetchErrorCount: params.pollingSnapshot.transientMessageFetchErrorCount,
+      extractionMissSamples: params.pollingSnapshot.extractionMissSamples,
     },
   };
 }
@@ -588,7 +625,11 @@ function formatMailpitPollingSnapshot(params: {
     `excludedValueCount=${params.pollingSnapshot.excludedValueCount}, ` +
     `transientRequestErrorCount=${params.pollingSnapshot.transientRequestErrorCount}, ` +
     `transientRequestErrorStatuses=[${transientRequestErrorStatuses}], ` +
-    `newestCandidateAgeMs=${newestCandidateAgeMs}`
+    `newestCandidateAgeMs=${newestCandidateAgeMs}, ` +
+    `cachedExtractionMissCount=${params.pollingSnapshot.cachedExtractionMissCount}, ` +
+    `transientSearchErrorCount=${params.pollingSnapshot.transientSearchErrorCount}, ` +
+    `transientMessageFetchErrorCount=${params.pollingSnapshot.transientMessageFetchErrorCount}, ` +
+    `extractionMissSamples=${JSON.stringify(params.pollingSnapshot.extractionMissSamples)}`
   );
 }
 
@@ -624,12 +665,87 @@ function recordNewestCandidateTimestamp(params: {
 function recordTransientRequestError(params: {
   error: unknown;
   pollingSnapshot: MailpitPollingSnapshot;
+  phase: "search" | "message-fetch";
 }): void {
   params.pollingSnapshot.transientRequestErrorCount += 1;
+  if (params.phase === "search") {
+    params.pollingSnapshot.transientSearchErrorCount += 1;
+  } else {
+    params.pollingSnapshot.transientMessageFetchErrorCount += 1;
+  }
 
   if (params.error instanceof MailpitRequestError) {
     params.pollingSnapshot.transientRequestErrorStatuses.add(
       params.error.status?.toString() ?? "unavailable",
     );
   }
+}
+
+function recordExtractionMiss(params: {
+  message: MailpitMessage;
+  messageSummary: MailpitMessageSummary;
+  pollingSnapshot: MailpitPollingSnapshot;
+  nowMs: number;
+}): void {
+  // Keep only the first three misses for the whole wait, even if later probes find new IDs.
+  if (params.pollingSnapshot.extractionMissSamples.length >= MAX_MESSAGES_TO_FETCH) {
+    return;
+  }
+
+  const { message } = params;
+  const contentSize = message.Text.length + message.HTML.length;
+  const timestampMs = getMailpitMessageTimestampMs({ message: params.messageSummary });
+  const ageMs = timestampMs === undefined ? undefined : params.nowMs - timestampMs;
+  params.pollingSnapshot.extractionMissSamples.push({
+    messageIdHash: createHash("sha256").update(params.messageSummary.ID).digest("hex"),
+    contentChannel:
+      message.Text.length > 0
+        ? message.HTML.length > 0
+          ? "both"
+          : "text"
+        : message.HTML.length > 0
+          ? "html"
+          : "none",
+    contentSizeBucket:
+      contentSize === 0
+        ? "empty"
+        : contentSize <= 256
+          ? "1-256"
+          : contentSize <= 4096
+            ? "257-4096"
+            : "4097+",
+    otpMissShape: getOtpMissShape({ message }),
+    candidateAgeAtFetchBucket:
+      ageMs === undefined
+        ? "unavailable"
+        : ageMs < 0
+          ? "future"
+          : ageMs < 5000
+            ? "under-5s"
+            : ageMs < 30_000
+              ? "5-30s"
+              : "30s+",
+  });
+}
+
+function getOtpMissShape(params: {
+  message: MailpitMessage;
+}): MailpitPollingDiagnostics["extractionMissSamples"][number]["otpMissShape"] {
+  const { message } = params;
+  if (message.Text.length + message.HTML.length === 0) {
+    return "empty-content";
+  }
+  // A custom extractor can miss even when the built-in OTP parser recognizes the content.
+  if (extractEmailOtpCodeFromMailpitMessage({ message }) !== undefined) {
+    return "other";
+  }
+  const visibleHtml = message.HTML.replaceAll(
+    /<(style|script)[^>]*>[\s\S]*?<\/\1>/gi,
+    "",
+  ).replaceAll(/<[^>]+>/g, " ");
+  // This observes the documented four-plus-four form; it never feeds the extractor.
+  const unsupportedSeparator = /(?<!\d)\d{4}[^\d\s]+\d{4}(?!\d)/;
+  return unsupportedSeparator.test(message.Text) || unsupportedSeparator.test(visibleHtml)
+    ? "eight-digits-with-unsupported-separator"
+    : "no-eight-digit-sequence";
 }


### PR DESCRIPTION
## Why

The [September 10 admin login failure](https://github.com/ClipboardHealth/cbh-admin-frontend/actions/runs/34425968820/attempts/1) reached Mailpit after a successful Cognito email-OTP challenge. One fetched message produced no OTP, its miss stayed cached, and polling expired after 60 seconds. Existing counters cannot show whether that message was empty or formatted outside the parser contract, or whether the transient 404s came from search or message fetch. This delays CI diagnosis; no direct customer impact was demonstrated.

## Summary

Add separate search/fetch error counts, cached-miss skips, and the first three extraction-miss samples to the existing polling diagnostics. Samples contain only a SHA-256 message-ID hash and fixed content/size/age/OTP-shape classifications. Parser, cache, candidate selection, retry, and timeout behavior remain unchanged. No new logging hook, dependency, or package-version edit.

This is A8 diagnostic instrumentation for [STAFF-2526](https://linear.app/clipboardhealth/issue/STAFF-2526). Historical terminal-cause confidence remains **2/5**; the change does not claim to prevent the flake. The critic approved the bounded plan before implementation.

## Validation

- `npm exec nx -- run-many --projects playwright-toolkit --targets test,lint,build --configuration ci --parallel 3` passed, including coverage thresholds.
- `node --run verify` passed all eight repository checks.
- The cache characterization failed against pre-change code for the missing diagnostic, then passed with the same 60 polls, one message fetch, 59 cached-miss skips, and 60-second deadline.
- Deterministic tests cover both HTTP 404 phases, existing contiguous/whitespace/HTML OTP forms, empty content, unsupported separators, excluded-value caching, privacy, and the sample cap across polls.
- A controlled fake Mailpit HTTP sequence captured this sanitized terminal evidence in the existing error path:

```text
60 attempts (60000ms, reason: timeout)
searchAttempts=60, fetchedMessageCount=1, extractionMissCount=1
cachedExtractionMissCount=57, transientSearchErrorCount=1, transientMessageFetchErrorCount=1
extractionMissSamples=[{"messageIdHash":"4cc20d3746f852072051a8ce3105cb533a08837680f1d7e76512002023b922a5","contentChannel":"text","contentSizeBucket":"1-256","otpMissShape":"eight-digits-with-unsupported-separator","candidateAgeAtFetchBucket":"under-5s"}]
```

The fixture used private message fields and a synthetic OTP; none appeared in the error. This demonstrates the new signal, not the historical cause. Datadog identity was verified for the exact admin test/suite; the fixing commit contains `DD_5MSS1Y`.

## Release and dependent adoption

1. Merge through the normal core-utils workflow. Its main-branch `scripts/release.ts` and `nx release publish` steps assign and publish the actual toolkit version; this PR does not publish or invent one. Current main starts at toolkit 1.4.5.
2. After that release succeeds, update admin to the released version. Run its Mailpit helper tests, lint/typecheck, and `playwright/e2e/cognito/redesignedLogin.spec.ts` in staging CI. Confirm the exact wrapper carries the bounded error into the Playwright report and Datadog test error, joined by the test/run identity. This consumer validation is release-dependent and remains pending.
3. Recheck mobile main's toolkit version and generic Mailpit consumers after release; create a linked adoption ticket only if it has not inherited the change. No duplicate consumer implementation is being dispatched now.
4. Use the next recurrence's bounded evidence to select any behavioral follow-up under a fresh plan. Do not refetch cached misses, widen the parser, resend, or extend the timeout based on the historical evidence alone.

Agent session: `codex resume 01a08cf7-1027-73a1-b5bc-d327f5d45484` · Model: `gpt-6-astra` · Reasoning: `ultra`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.8</code></sub>
